### PR TITLE
feat: auto-create ~/.movie-narrator/.env on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ pip install "movie-narrator[web]"
 pip install "movie-narrator[full]"
 ```
 
+> **Python 3.13+ note**: `[ml]` extras (whisperx, sentence-transformers) depend on PyTorch wheels that may lag behind new Python releases. On Python 3.14 these packages are automatically skipped — `align_audio` and `match_clips` will soft-degrade to heuristic fallbacks. Use Python 3.12 for full ML features.
+
 For development:
 
 ```bash
@@ -234,7 +236,7 @@ All settings use the `MN_` prefix to avoid conflicts with other tools.
 
 ### Via `.env` file (recommended)
 
-Create `.env` in your project directory (or `~/.movie-narrator/.env` for global config — this file lives outside the package, so `pip install/upgrade/uninstall` never touches it):
+`~/.movie-narrator/.env` is auto-created with default values on first run — edit it to configure LLM, TTS, and other settings. This file lives outside the package, so `pip install/upgrade/uninstall` never touches it. You can also create a project-level `.env` in your working directory for per-project overrides.
 
 ```bash
 MN_LLM_BASE_URL=http://localhost:11434/v1

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -7,7 +7,75 @@ from functools import lru_cache
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-_USER_ENV = Path.home() / ".movie-narrator" / ".env"
+_USER_DIR = Path.home() / ".movie-narrator"
+_USER_ENV = _USER_DIR / ".env"
+
+# Template written to ~/.movie-narrator/.env on first run.
+# Mirrors .env.example — kept inline so it works regardless of install method.
+_DEFAULT_ENV_TEMPLATE = """\
+# ============================================================
+# Movie Narrator — global configuration
+# ============================================================
+# This file was auto-created on first run.  Edit values as needed.
+# Project-level .env (current directory) and MN_* environment
+# variables override entries here.
+# ============================================================
+
+# ── LLM ──
+MN_LLM_BASE_URL=http://localhost:11434/v1
+MN_LLM_API_KEY=ollama
+MN_LLM_MODEL=qwen2.5:7b
+
+# ── TTS voice (unified, interpreted per-provider) ──
+MN_DEFAULT_VOICE=zh-CN-YunxiNeural
+
+# ── Video output ──
+MN_DEFAULT_FORMAT=16:9
+
+# ── TTS provider: edge | openai | mimo ──
+# MN_TTS_PROVIDER=edge
+
+# ── OpenAI TTS (active when MN_TTS_PROVIDER=openai) ──
+# MN_OPENAI_TTS_MODEL=tts-1
+# MN_OPENAI_TTS_API_KEY=           # falls back to MN_LLM_API_KEY
+# MN_OPENAI_TTS_BASE_URL=          # falls back to MN_LLM_BASE_URL
+
+# ── MiMo TTS (active when MN_TTS_PROVIDER=mimo) ──
+# MN_MIMO_TTS_MODEL=mimo-v2.5-tts
+# MN_MIMO_API_KEY=                 # falls back to MN_LLM_API_KEY
+# MN_MIMO_BASE_URL=https://api.xiaomimimo.com/v1
+# MN_MIMO_STYLE_PROMPT=            # style description, mimo-v2.5-tts only
+
+# ── v0.2 optional ──
+# MN_LIBRARY_DIR=
+# MN_DEFAULT_BGM=
+# MN_RESEARCH_ENABLED=false
+# MN_RESEARCH_PROVIDER=llm
+# MN_SCENE_THRESHOLD=27.0
+# MN_SCENE_FRAME_SKIP=10
+# MN_MATCH_MIN_SCORE=0.25
+# MN_EXPORT_CLIPS_DEFAULT=true
+
+# ── v0.3 multi-language subtitles ──
+# MN_SUBTITLE_LANG=                # empty = feature off
+# MN_SUBTITLE_MODE=original
+# MN_TRANSLATE_PROVIDER=llm
+# MN_TRANSLATE_RETRIES=3
+# MN_TRANSLATE_CHUNK_CHARS=4000
+# MN_TRANSLATE_CHUNK_SIZE=20
+"""
+
+
+def ensure_user_config() -> Path:
+    """Create ``~/.movie-narrator/.env`` from defaults if it does not exist.
+
+    Returns the path to the user-level .env (existing or newly created).
+    Safe to call multiple times — never overwrites an existing file.
+    """
+    if not _USER_ENV.exists():
+        _USER_DIR.mkdir(parents=True, exist_ok=True)
+        _USER_ENV.write_text(_DEFAULT_ENV_TEMPLATE, encoding="utf-8")
+    return _USER_ENV
 
 
 class TTSProviderType(str, Enum):
@@ -61,4 +129,5 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings() -> Settings:
+    ensure_user_config()
     return Settings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,7 @@
-from movie_narrator.config import Settings
+from pathlib import Path
+from unittest.mock import patch
+
+from movie_narrator.config import Settings, ensure_user_config, _DEFAULT_ENV_TEMPLATE
 from movie_narrator.utils.environment import collect_environment
 
 
@@ -18,3 +21,31 @@ def test_collect_environment_keys():
     assert "python" in env
     assert "platform" in env
     assert "ffmpeg" in env
+
+
+def test_ensure_user_config_creates_file(tmp_path):
+    """ensure_user_config creates ~/.movie-narrator/.env when missing."""
+    fake_home = tmp_path / "fakehome"
+    fake_env = fake_home / ".movie-narrator" / ".env"
+    with patch("movie_narrator.config._USER_DIR", fake_home / ".movie-narrator"), \
+         patch("movie_narrator.config._USER_ENV", fake_env):
+        result = ensure_user_config()
+    assert result == fake_env
+    assert fake_env.exists()
+    content = fake_env.read_text(encoding="utf-8")
+    assert "MN_LLM_BASE_URL" in content
+    assert "MN_DEFAULT_VOICE" in content
+
+
+def test_ensure_user_config_no_overwrite(tmp_path):
+    """ensure_user_config never overwrites an existing file."""
+    fake_home = tmp_path / "fakehome"
+    fake_dir = fake_home / ".movie-narrator"
+    fake_dir.mkdir(parents=True)
+    fake_env = fake_dir / ".env"
+    original = "MN_LLM_MODEL=my-custom-model\n"
+    fake_env.write_text(original, encoding="utf-8")
+    with patch("movie_narrator.config._USER_DIR", fake_dir), \
+         patch("movie_narrator.config._USER_ENV", fake_env):
+        ensure_user_config()
+    assert fake_env.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary

Auto-create `~/.movie-narrator/.env` with default values on first run, so users get a discoverable config template without manual setup. Also document the Python 3.13+ limitation for `[ml]` extras.

## Changes

### Auto-init user config (`cc551ad`)
- **config.py**: Add `ensure_user_config()` — creates `~/.movie-narrator/` directory and `.env` file from an inline template if missing. Never overwrites existing files.
- **config.py**: Call `ensure_user_config()` in `get_settings()` before `Settings()` instantiation, so pydantic-settings can read the file on first run.
- **README.md**: Document auto-creation behavior in Configuration section.
- **README.md**: Add Python 3.13+ note about `[ml]` extras (whisperx/sentence-transformers automatically skipped; align/match soft-degrade to heuristics).
- **test_settings.py**: Add `test_ensure_user_config_creates_file` and `test_ensure_user_config_no_overwrite`.

## Behavior

| Scenario | Action |
|----------|--------|
| First run (no ~/.movie-narrator/.env) | Create dir + .env with default template |
| Existing ~/.movie-narrator/.env | No change — never overwrite |
| Project .env exists | Both files read; project .env takes priority |

## Test Results
- 240 passed, 11 skipped, 2 failed (pre-existing local .env pollution)
- New tests: 2/2 pass
