### PR TITLE
feat: preflight LLM/TTS validation before pipeline execution

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -137,6 +137,11 @@ def create(
     try:
         ctx = run_pipeline(ctx)
     except Exception as e:
+        # PreflightError gets a targeted remediation hint.
+        from .pipeline.preflight import PreflightError
+        if isinstance(e, PreflightError):
+            typer.echo(str(e), err=True)
+            raise typer.Exit(code=1)
         # step_err already printed the single-line summary and wrote the
         # full traceback to the log file.  Suppress Typer's Rich
         # traceback to keep the console output clean.

--- a/src/movie_narrator/pipeline/preflight.py
+++ b/src/movie_narrator/pipeline/preflight.py
@@ -1,0 +1,115 @@
+"""Pre-run validation of LLM and TTS availability.
+
+Called by ``run_pipeline`` before any step executes.  Fails fast with a
+``PreflightError`` (extends ``ConfigError``) so the user sees a clear
+remediation hint instead of a pipeline that silently degrades to mock
+content.
+
+Design:
+- LLM check: minimal ``chat.completions.create`` with ``max_tokens=1``.
+  Verifies endpoint reachable, credentials valid, model exists.
+- TTS check: provider-dependent.
+  - edge: no network probe needed (free, no credentials).
+  - openai / mimo: verify ``ConfigError`` is not raised during provider
+    construction (credentials present).  A real network probe is skipped
+    to avoid cost/latency — the provider will surface errors at step 6.
+- CI mode: LLM probe is skipped (``CI=1`` env var → mock pipeline).
+"""
+
+from __future__ import annotations
+
+import os
+
+from ..config import TTSProviderType, get_settings
+from ..models import Context
+from ..utils.errors import ConfigError
+from ..utils.llm import get_llm_client
+
+__all__ = ["PreflightError", "run_preflight"]
+
+
+class PreflightError(ConfigError):
+    """Raised when a required service (LLM / TTS) is not usable.
+
+    Extends ``ConfigError`` so the CLI can emit a remediation hint
+    instead of a stack trace.
+    """
+
+
+def _is_ci() -> bool:
+    return bool(os.getenv("CI"))
+
+
+def _check_llm(ctx: Context) -> None:
+    """Probe LLM connectivity with a 1-token completion request."""
+    console = ctx.services.console
+    settings = get_settings()
+
+    if _is_ci():
+        console.debug("  preflight: CI mode — skipping LLM probe")
+        return
+
+    console.debug(f"  preflight: probing LLM at {settings.llm_base_url} "
+                  f"(model={settings.llm_model})")
+    try:
+        with get_llm_client() as llm:
+            llm.client.chat.completions.create(
+                model=llm.model,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+            )
+    except Exception as e:
+        raise PreflightError(
+            f"LLM not reachable at {settings.llm_base_url} "
+            f"(model={settings.llm_model}): {e}\n"
+            f"  Check MN_LLM_BASE_URL, MN_LLM_API_KEY, MN_LLM_MODEL in "
+            f"~/.movie-narrator/.env or your project .env file."
+        ) from e
+    console.debug("  preflight: LLM OK")
+
+
+def _check_tts(ctx: Context) -> None:
+    """Verify TTS provider can be constructed.
+
+    For edge TTS, no probe is needed.  For openai / mimo, provider
+    construction validates credentials and raises ``ConfigError`` on
+    failure — we catch and re-raise as ``PreflightError`` with a hint.
+    """
+    console = ctx.services.console
+    settings = get_settings()
+    provider_type = settings.tts_provider
+
+    console.debug(f"  preflight: TTS provider={provider_type.value}")
+
+    if provider_type is TTSProviderType.EDGE:
+        # Edge TTS is free and credential-less — nothing to validate.
+        console.debug("  preflight: TTS OK (edge, no probe needed)")
+        return
+
+    # For openai / mimo, instantiate the provider to catch ConfigError
+    # (missing credentials).  We avoid a real synthesis probe to prevent
+    # cost / latency — the provider will surface network errors at step 6.
+    try:
+        from ..tts import get_tts_provider
+        get_tts_provider(settings)
+    except ConfigError as e:
+        raise PreflightError(
+            f"TTS provider '{provider_type.value}' is not properly configured: {e}\n"
+            f"  Check your .env file or switch to edge TTS "
+            f"(MN_TTS_PROVIDER=edge)."
+        ) from e
+
+    console.debug(f"  preflight: TTS OK ({provider_type.value})")
+
+
+def run_preflight(ctx: Context) -> None:
+    """Validate LLM and TTS availability before running the pipeline.
+
+    Raises ``PreflightError`` if a required service is not usable.
+    Called by ``run_pipeline`` before the step loop begins.
+    """
+    console = ctx.services.console
+    console.step("preflight")
+    _check_llm(ctx)
+    _check_tts(ctx)
+    console.step_ok("preflight", 0.0)

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -13,6 +13,7 @@ from .bgm import mix_bgm
 from .errors import PipelineCancelled, PipelineStrictError, RunController, check_cancelled
 from .export_clips import export_clips
 from .match import match_clips
+from .preflight import PreflightError, run_preflight
 from .research import research_plot
 from .resolve import resolve_video
 from .scenes import detect_scenes
@@ -190,6 +191,13 @@ def run_pipeline(
     """
     console = ctx.services.console
     workflow_steps: Optional[Dict[str, bool]] = ctx.metadata.get("workflow_steps")
+
+    # ── Preflight: fail fast if LLM / TTS is not usable ────
+    # Avoids silent degradation to mock content when services are down.
+    try:
+        run_preflight(ctx)
+    except PreflightError:
+        raise
 
     total_start = time.time()
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,115 @@
+"""Tests for preflight LLM/TTS validation."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from movie_narrator.config import Settings, TTSProviderType
+from movie_narrator.models import Context, Services
+from movie_narrator.pipeline.preflight import (
+    PreflightError,
+    _check_llm,
+    _check_tts,
+    run_preflight,
+)
+
+
+def _make_ctx(tmp_path):
+    return Context(
+        movie_name="test",
+        output_dir=str(tmp_path),
+        services=Services(console=MagicMock()),
+    )
+
+
+def test_check_llm_skipped_in_ci(tmp_path, monkeypatch):
+    """CI mode skips LLM probe entirely."""
+    monkeypatch.setenv("CI", "1")
+    ctx = _make_ctx(tmp_path)
+    _check_llm(ctx)  # should not raise
+
+
+def test_check_llm_raises_on_connection_error(tmp_path, monkeypatch):
+    """Non-CI LLM probe raises PreflightError on connection failure."""
+    monkeypatch.delenv("CI", raising=False)
+    ctx = _make_ctx(tmp_path)
+
+    mock_llm = MagicMock()
+    mock_llm.client.chat.completions.create.side_effect = ConnectionError("refused")
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=mock_llm)
+    mock_cm.__exit__ = MagicMock(return_value=False)
+
+    with patch("movie_narrator.pipeline.preflight.get_llm_client", return_value=mock_cm):
+        with patch("movie_narrator.pipeline.preflight._is_ci", return_value=False):
+            with pytest.raises(PreflightError) as exc_info:
+                _check_llm(ctx)
+    assert "LLM not reachable" in str(exc_info.value)
+    assert "MN_LLM_BASE_URL" in str(exc_info.value)
+
+
+def test_check_llm_passes_on_success(tmp_path, monkeypatch):
+    """Non-CI LLM probe passes when the API call succeeds."""
+    monkeypatch.delenv("CI", raising=False)
+    ctx = _make_ctx(tmp_path)
+
+    mock_llm = MagicMock()
+    mock_llm.client.chat.completions.create.return_value = MagicMock()
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=mock_llm)
+    mock_cm.__exit__ = MagicMock(return_value=False)
+
+    with patch("movie_narrator.pipeline.preflight.get_llm_client", return_value=mock_cm):
+        with patch("movie_narrator.pipeline.preflight._is_ci", return_value=False):
+            _check_llm(ctx)  # should not raise
+
+
+def test_check_tts_edge_no_error(tmp_path):
+    """Edge TTS requires no probe — should always pass."""
+    ctx = _make_ctx(tmp_path)
+    settings = MagicMock()
+    settings.tts_provider = TTSProviderType.EDGE
+    with patch("movie_narrator.pipeline.preflight.get_settings", return_value=settings):
+        _check_tts(ctx)  # should not raise
+
+
+def test_check_tts_openai_missing_key_raises(tmp_path):
+    """OpenAI TTS with missing credentials raises PreflightError."""
+    from movie_narrator.utils.errors import ConfigError
+
+    ctx = _make_ctx(tmp_path)
+    settings = MagicMock()
+    settings.tts_provider = TTSProviderType.OPENAI
+
+    with patch("movie_narrator.pipeline.preflight.get_settings", return_value=settings):
+        with patch("movie_narrator.tts.get_tts_provider", side_effect=ConfigError("missing key")):
+            with pytest.raises(PreflightError) as exc_info:
+                _check_tts(ctx)
+    assert "not properly configured" in str(exc_info.value)
+
+
+def test_check_tts_mimo_ok(tmp_path):
+    """MiMo TTS with valid credentials passes."""
+    ctx = _make_ctx(tmp_path)
+    settings = MagicMock()
+    settings.tts_provider = TTSProviderType.MIMO
+
+    mock_provider = MagicMock()
+    with patch("movie_narrator.pipeline.preflight.get_settings", return_value=settings):
+        with patch("movie_narrator.tts.get_tts_provider", return_value=mock_provider):
+            _check_tts(ctx)  # should not raise
+
+
+def test_run_preflight_integration_ci(tmp_path, monkeypatch):
+    """Full preflight in CI mode: both checks skipped/passed."""
+    monkeypatch.setenv("CI", "1")
+    ctx = _make_ctx(tmp_path)
+    settings = MagicMock()
+    settings.tts_provider = TTSProviderType.EDGE
+
+    with patch("movie_narrator.pipeline.preflight.get_settings", return_value=settings):
+        run_preflight(ctx)  # should not raise
+
+    ctx.services.console.step.assert_called_with("preflight")
+    ctx.services.console.step_ok.assert_called_once()


### PR DESCRIPTION
## Summary

Add a preflight validation step that probes LLM and TTS availability before any pipeline step runs. Fails fast with a clear remediation hint instead of silently degrading to mock content.

## Problem

Currently, when LLM is unreachable:
- `research_plot` silently fails → empty research.json
- `generate_script` retries 3× then falls back to hardcoded `MOCK_SEGMENTS` (generic text unrelated to the movie)
- `translate_subtitles` fails → subtitles stay as raw Chinese
- Final output is a "working but wrong" half-product

When TTS is misconfigured (e.g., missing `MN_OPENAI_TTS_API_KEY`), the error only surfaces at step 6 (`generate_voice`) after 5 steps have already executed.

## Solution

### New module: `pipeline/preflight.py`

| Check | Behavior |
|-------|----------|
| LLM | `chat.completions.create(max_tokens=1)` — verifies endpoint, credentials, model |
| TTS edge | No probe (free, credential-less) |
| TTS openai/mimo | Instantiate provider to catch `ConfigError` on missing credentials |
| CI mode | LLM probe skipped (`CI=1` env var → mock pipeline) |

### Integration

- `runner.py`: `run_preflight(ctx)` called at top of `run_pipeline()`, before the step loop
- `cli.py`: `PreflightError` caught and printed to stderr with remediation hint
- `PreflightError` extends `ConfigError` for consistent error handling

### Tests: `test_preflight.py` (7 tests)

- `test_check_llm_skipped_in_ci` — CI mode bypass
- `test_check_llm_raises_on_connection_error` — fail-fast on unreachable LLM
- `test_check_llm_passes_on_success` — happy path
- `test_check_tts_edge_no_error` — edge TTS always passes
- `test_check_tts_openai_missing_key_raises` — credential validation
- `test_check_tts_mimo_ok` — MiMo happy path
- `test_run_preflight_integration_ci` — full integration in CI mode

## Test Results
- 247 passed, 11 skipped, 2 failed (pre-existing local .env pollution)
- New preflight tests: 7/7 pass
