### PR TITLE
feat: step-level retry mechanism for hard step failures

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -13,6 +13,43 @@ from .pipeline.runner import build_context, run_pipeline
 
 app = typer.Typer(help="Generate narrated movie recap videos from a single prompt.")
 
+
+class InteractiveCLIController:
+    """RunController with interactive retry/skip/abort on hard step failure.
+
+    Used when ``--retry`` is passed to ``mn create``.  When a hard step
+    raises an exception, the user is prompted to choose:
+
+    - **R** — retry the step (ctx state is preserved, so cached partial
+      results like TTS segments are reused)
+    - **S** — skip the step and continue (downstream may fail)
+    - **A** — abort the pipeline
+    """
+
+    def __init__(self):
+        self._cancelled = False
+
+    def is_cancelled(self) -> bool:
+        return self._cancelled
+
+    def on_step_error(self, step_name: str, error: Exception, attempt: int):
+        from .pipeline.errors import StepAction
+
+        typer.echo(
+            f"\n  Step '{step_name}' failed (attempt {attempt}): {error}",
+            err=True,
+        )
+        typer.echo("  [R]etry  [S]kip  [A]bort", err=True)
+        try:
+            choice = input("  > ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            return StepAction.ABORT
+        if choice.startswith("r"):
+            return StepAction.RETRY
+        elif choice.startswith("s"):
+            return StepAction.SKIP
+        return StepAction.ABORT
+
 _RESERVED_NAMES = {
     "CON", "PRN", "AUX", "NUL",
     *(f"COM{i}" for i in range(1, 10)),
@@ -45,6 +82,7 @@ def create(
     no_bgm: bool = typer.Option(False, "--no-bgm", help="Disable BGM even if default set"),
     no_clips: bool = typer.Option(False, "--no-clips", help="Skip clips/export"),
     strict: bool = typer.Option(False, "--strict", help="Abort on soft step failure"),
+    retry: bool = typer.Option(False, "--retry", help="Enable interactive retry on hard step failure"),
     config: Optional[str] = typer.Option(None, "--config", help="Path to job YAML config"),
     # Multi-language subtitle (v0.3).
     subtitle_lang: Optional[str] = typer.Option(
@@ -92,6 +130,7 @@ def create(
         "no_bgm": no_bgm,
         "no_clips": no_clips,
         "strict": strict,
+        "retry": retry,
         "config_path": config_path,
         "subtitle_lang": subtitle_lang,
         "subtitle_mode": subtitle_mode,
@@ -134,8 +173,9 @@ def create(
         subtitle_lang=resolved.subtitle_lang,
         subtitle_mode=resolved.subtitle_mode,
     )
+    controller = InteractiveCLIController() if retry else None
     try:
-        ctx = run_pipeline(ctx)
+        ctx = run_pipeline(ctx, controller=controller)
     except Exception as e:
         # PreflightError gets a targeted remediation hint.
         from .pipeline.preflight import PreflightError

--- a/src/movie_narrator/pipeline/errors.py
+++ b/src/movie_narrator/pipeline/errors.py
@@ -1,4 +1,21 @@
+from enum import Enum
 from typing import Any, Dict, Optional, Protocol
+
+
+class StepAction(Enum):
+    """User's choice when a hard step fails and interactive retry is enabled.
+
+    - ``RETRY``: re-run the step (ctx state is preserved, so cached
+      partial results like TTS segments are reused).
+    - ``SKIP``: mark the step as skipped/warning and continue to the
+      next step.  Downstream steps may fail if they depend on the
+      skipped step's output.
+    - ``ABORT``: stop the pipeline (re-raise the original exception).
+    """
+
+    RETRY = "retry"
+    SKIP = "skip"
+    ABORT = "abort"
 
 
 class PipelineStrictError(RuntimeError):

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -10,7 +10,7 @@ from ..utils.environment import collect_environment
 from .align import align_audio
 from .assets import prepare_assets
 from .bgm import mix_bgm
-from .errors import PipelineCancelled, PipelineStrictError, RunController, check_cancelled
+from .errors import PipelineCancelled, PipelineStrictError, RunController, StepAction, check_cancelled
 from .export_clips import export_clips
 from .match import match_clips
 from .preflight import PreflightError, run_preflight
@@ -221,28 +221,47 @@ def run_pipeline(
 
         # ── Execute step with soft/hard exception fork ───────
         # Soft steps: exception → ⚠ + continue (no abort).
-        # Hard steps: exception → ✗ + re-raise (abort pipeline).
+        # Hard steps: exception → ✗ + re-raise (abort pipeline),
+        #   unless the controller offers interactive retry.
         ctx.step_state = StepState()  # reset before execution
         step_start = time.time()
         console.step(name)
 
-        try:
-            ctx = step(ctx)
-        except PipelineCancelled:
-            console.cancelled("Pipeline cancelled.")
-            raise
-        except Exception as e:
-            elapsed = time.time() - step_start
-            if name in SOFT_STATUS_STEPS:
-                _set_pipeline_status_failed(ctx, name)
-                ctx.step_state = StepState(
-                    result=StepResult.WARNING, message=str(e)
-                )
-                console.step_warn(name, ctx.step_state.message)
-                _check_strict(ctx, name)
-                continue
-            console.step_err(name, e, elapsed)
-            raise
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                ctx = step(ctx)
+                break  # success — exit retry loop
+            except PipelineCancelled:
+                console.cancelled("Pipeline cancelled.")
+                raise
+            except Exception as e:
+                elapsed = time.time() - step_start
+                if name in SOFT_STATUS_STEPS:
+                    _set_pipeline_status_failed(ctx, name)
+                    ctx.step_state = StepState(
+                        result=StepResult.WARNING, message=str(e)
+                    )
+                    console.step_warn(name, ctx.step_state.message)
+                    _check_strict(ctx, name)
+                    break  # exit retry loop, continue to next step
+
+                # Hard step failure — check for interactive retry.
+                action = _handle_step_error(controller, name, e, attempt, console)
+                if action is StepAction.RETRY:
+                    console.debug(f"  retrying {name} (attempt {attempt + 1})...")
+                    ctx.step_state = StepState()
+                    continue
+                elif action is StepAction.SKIP:
+                    console.step_warn(name, f"skipped after {attempt} attempt(s): {e}")
+                    ctx.step_state = StepState(
+                        result=StepResult.WARNING, message=f"skipped: {e}"
+                    )
+                    break  # exit retry loop, continue to next step
+
+                console.step_err(name, e, elapsed)
+                raise
 
         elapsed = time.time() - step_start
 
@@ -297,3 +316,24 @@ def _check_strict(ctx: Context, step_name: str) -> None:
         failed = [k for k, v in ctx.status.model_dump().items() if v == "failed"]
         if failed:
             raise PipelineStrictError(step=step_name, status=ctx.status.model_dump())
+
+
+def _handle_step_error(
+    controller: Optional[RunController],
+    name: str,
+    error: Exception,
+    attempt: int,
+    console,
+) -> StepAction:
+    """Ask the controller how to handle a hard step failure.
+
+    If the controller does not implement ``on_step_error`` (e.g. the
+    GradioController or ``controller=None``), returns ``ABORT`` to
+    preserve the existing fail-fast behavior.
+    """
+    if controller is None:
+        return StepAction.ABORT
+    handler = getattr(controller, "on_step_error", None)
+    if handler is None:
+        return StepAction.ABORT
+    return handler(name, error, attempt)

--- a/tests/test_step_retry.py
+++ b/tests/test_step_retry.py
@@ -1,0 +1,130 @@
+"""Tests for step-level retry mechanism in the pipeline runner."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from movie_narrator.config import TTSProviderType
+from movie_narrator.models import Context, Services, StepResult
+from movie_narrator.pipeline.errors import StepAction
+from movie_narrator.pipeline.runner import _handle_step_error
+
+
+def _make_ctx(tmp_path):
+    return Context(
+        movie_name="test",
+        output_dir=str(tmp_path),
+        services=Services(console=MagicMock()),
+    )
+
+
+# ── _handle_step_error helper ──────────────────────────────
+
+
+def test_handle_step_error_no_controller(tmp_path):
+    """No controller → ABORT (existing fail-fast behavior)."""
+    ctx = _make_ctx(tmp_path)
+    action = _handle_step_error(None, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    assert action is StepAction.ABORT
+
+
+def test_handle_step_error_no_handler_method(tmp_path):
+    """Controller without on_step_error → ABORT."""
+    ctx = _make_ctx(tmp_path)
+    controller = MagicMock()
+    del controller.on_step_error  # ensure attribute doesn't exist
+    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    assert action is StepAction.ABORT
+
+
+def test_handle_step_error_retry(tmp_path):
+    """Controller returns RETRY → StepAction.RETRY."""
+    ctx = _make_ctx(tmp_path)
+    controller = MagicMock()
+    controller.on_step_error.return_value = StepAction.RETRY
+    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    assert action is StepAction.RETRY
+    controller.on_step_error.assert_called_once_with("generate_voice", controller.on_step_error.call_args[0][1], 1)
+
+
+def test_handle_step_error_skip(tmp_path):
+    """Controller returns SKIP → StepAction.SKIP."""
+    ctx = _make_ctx(tmp_path)
+    controller = MagicMock()
+    controller.on_step_error.return_value = StepAction.SKIP
+    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    assert action is StepAction.SKIP
+
+
+def test_handle_step_error_abort(tmp_path):
+    """Controller returns ABORT → StepAction.ABORT."""
+    ctx = _make_ctx(tmp_path)
+    controller = MagicMock()
+    controller.on_step_error.return_value = StepAction.ABORT
+    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    assert action is StepAction.ABORT
+
+
+# ── StepAction enum ────────────────────────────────────────
+
+
+def test_step_action_values():
+    """StepAction has exactly RETRY, SKIP, ABORT."""
+    assert StepAction.RETRY.value == "retry"
+    assert StepAction.SKIP.value == "skip"
+    assert StepAction.ABORT.value == "abort"
+    assert len(StepAction) == 3
+
+
+# ── InteractiveCLIController ───────────────────────────────
+
+
+def test_interactive_controller_retry(tmp_path, monkeypatch):
+    """InteractiveCLIController parses 'r' as RETRY."""
+    monkeypatch.setattr("builtins.input", lambda _: "r")
+    from movie_narrator.cli import InteractiveCLIController
+
+    controller = InteractiveCLIController()
+    action = controller.on_step_error("generate_voice", RuntimeError("timeout"), 1)
+    assert action is StepAction.RETRY
+
+
+def test_interactive_controller_skip(tmp_path, monkeypatch):
+    """InteractiveCLIController parses 's' as SKIP."""
+    monkeypatch.setattr("builtins.input", lambda _: "s")
+    from movie_narrator.cli import InteractiveCLIController
+
+    controller = InteractiveCLIController()
+    action = controller.on_step_error("generate_voice", RuntimeError("timeout"), 1)
+    assert action is StepAction.SKIP
+
+
+def test_interactive_controller_abort_default(tmp_path, monkeypatch):
+    """InteractiveCLIController defaults to ABORT on unknown input."""
+    monkeypatch.setattr("builtins.input", lambda _: "x")
+    from movie_narrator.cli import InteractiveCLIController
+
+    controller = InteractiveCLIController()
+    action = controller.on_step_error("generate_voice", RuntimeError("timeout"), 1)
+    assert action is StepAction.ABORT
+
+
+def test_interactive_controller_eof_aborts(tmp_path, monkeypatch):
+    """InteractiveCLIController aborts on EOFError (no stdin)."""
+    def raise_eof(_):
+        raise EOFError()
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+    from movie_narrator.cli import InteractiveCLIController
+
+    controller = InteractiveCLIController()
+    action = controller.on_step_error("generate_voice", RuntimeError("timeout"), 1)
+    assert action is StepAction.ABORT
+
+
+def test_interactive_controller_is_cancelled_default():
+    """InteractiveCLIController.is_cancelled() defaults to False."""
+    from movie_narrator.cli import InteractiveCLIController
+
+    controller = InteractiveCLIController()
+    assert controller.is_cancelled() is False


### PR DESCRIPTION
## Summary

Add step-level retry mechanism so users can retry/skip/abort when a hard step fails (e.g., TTS timeout), without re-running previous steps.

## Problem

When a hard step like `generate_voice` (TTS) fails with a timeout, the entire pipeline aborts. The user must restart from scratch, re-running all previous steps (resolve_video, prepare_assets, research_plot, generate_script, etc.) even though their results are still valid.

## Solution

### New: `StepAction` enum (`pipeline/errors.py`)

| Action | Behavior |
|--------|----------|
| `RETRY` | Re-run the step. ctx state is preserved — TTS cache, partial results are reused |
| `SKIP` | Mark as WARNING and continue to next step. Downstream may fail |
| `ABORT` | Re-raise the exception, stop the pipeline |

### Runner retry loop (`pipeline/runner.py`)

Step execution is wrapped in a `while True` retry loop. When a hard step fails:
1. Check if controller has `on_step_error` method (via `getattr`)
2. If yes, call it to get `StepAction`
3. RETRY → reset `step_state`, re-run step
4. SKIP → mark as WARNING, break to next step
5. ABORT → re-raise

Backward compatible: controllers without `on_step_error` (e.g., `GradioController`, `None`) get ABORT — identical to existing behavior.

### CLI `--retry` flag (`cli.py`)

```bash
mn create --movie "满江红" --retry
```

When a hard step fails, the user sees:
```
  Step 'generate_voice' failed (attempt 1): Request timed out
  [R]etry  [S]kip  [A]bort
  > r
  retrying generate_voice (attempt 2)...
```

`InteractiveCLIController` handles:
- `r` → RETRY
- `s` → SKIP
- Any other input / EOF / Ctrl+C → ABORT

### Tests (`test_step_retry.py` — 11 tests)

- `_handle_step_error`: no controller, no handler, RETRY/SKIP/ABORT paths
- `StepAction` enum values
- `InteractiveCLIController`: retry/skip/abort/EOF/cancelled

## Test Results
- 258 passed, 11 skipped, 2 failed (pre-existing local .env pollution)
- New retry tests: 11/11 pass
