### PR TITLE
release: v0.4.3 — docs sync + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.3.4] - 2026-07-13
+## [Unreleased]
+
+## [0.4.3] - 2026-07-14
+
+### Changed
+- Version bump to reflect accumulated documentation and robustness changes since 0.4.2
+
+## [0.4.2] - 2026-07-14
 
 ### Added
-- Multi-language subtitle support (v0.3): `--subtitle-lang` / `--subtitle-mode` plus YAML `subtitle_lang` / `subtitle_mode` / `steps.translate` / `params.translate_*`
-- New soft step `translate_subtitles` (LLM provider, pluggable). Failure policy: retry-then-soft-degrade (translate provider returns the original text on chunk failure; warnings surfaced via `metadata.warnings`)
-- Three-file subtitle output: `subtitle.srt` (original, invariant) + `subtitle.<lang>.srt` (translated) + `subtitle.bilingual.srt` (original + LF + translation per cue)
-- `render_subtitle_path` field picks the overlay track per `subtitle_mode`; `subtitle_path` remains original-only for backward compatibility
-- `content_language` / `subtitle_mode` / `translate_provider` / `subtitle_paths` / `warnings` exported to `metadata.json`
-- `JobConfigError` raised when `subtitle_mode ∈ {translated, bilingual}` is set without `subtitle_lang`
-- Tests: `tests/test_translate.py` covering disabled/skipped/empty/provider-unknown/CI-passthrough/length-mismatch/blank-item paths; subtitle SRT tests extended for translated + bilingual file outputs and render_subtitle_path resolution
+- Preflight LLM/TTS validation (`pipeline/preflight.py`): probes LLM connectivity (1-token completion) and TTS provider construction before any pipeline step runs. CI mode skips LLM probe. `PreflightError` extends `ConfigError` with remediation hints
+- Step-level retry mechanism: `StepAction` enum (RETRY/SKIP/ABORT) in `pipeline/errors.py`; runner wraps step execution in retry loop; `--retry` CLI flag enables `InteractiveCLIController` that prompts [R]etry / [S]kip / [A]bort on hard step failure. Retry preserves ctx state (TTS cache, partial results). Backward compatible — controllers without `on_step_error` get ABORT
+- Auto-create `~/.movie-narrator/.env` on first run: `ensure_user_config()` in `config.py` writes default template (27 fields) if file is missing. Never overwrites existing files
+- `audioop-lts>=0.2.0` dependency for Python 3.13+ (stdlib `audioop` removed)
+- Python 3.13 added to CI test matrix
 
-## [Unreleased]
+### Changed
+- MoviePy 1.x → 2.x upgrade: `moviepy>=2.0,<3.0` (was `>=1.0.3,<2.0`). API migration in `render.py`: `subclip`→`subclipped`, `speedx`→`with_speed_scaled`, `set_start`→`with_start`, `set_duration`→`with_duration`, `set_audio`→`with_audio`, `ImageClip(transparent=True)`→`ImageClip(is_mask=False)`
+- Gradio constraint widened from `>=4.44,<5` to `>=4.44,<7` for Python 3.13+ compatibility
+- `whisperx` and `sentence-transformers` gated with `python_version < "3.14"` (torch lacks 3.14 wheels)
+- Python 3.13 classifier added to `pyproject.toml`
+- `export_clips.py`: direct `subprocess.run(["ffmpeg", ...])` — now documented as a design choice (not a MoviePy 1.x workaround), since export_clips only does seek+cut+encode
+- `.env.example` reorganized into clear sections matching `config.py` field set
+- README.md: document auto-creation behavior and Python 3.13+ `[ml]` extras note
+- `errors.py` description updated: now contains `PipelineStrictError`, `PipelineCancelled`, `RunController`, `StepAction`
+
+### Fixed
+- `test_render_real.py`: mock API names updated for MoviePy 2.x (`subclipped`, `with_speed_scaled`, `with_start`, `with_duration`, `with_position`, `with_audio`, `resized`)
 
 ## [0.4.1] - 2026-07-14
 
@@ -77,6 +93,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.3.4] - 2026-07-13
 
+### Added
+- Multi-language subtitle support (v0.3): `--subtitle-lang` / `--subtitle-mode` plus YAML `subtitle_lang` / `subtitle_mode` / `steps.translate` / `params.translate_*`
+- New soft step `translate_subtitles` (LLM provider, pluggable). Failure policy: retry-then-soft-degrade (translate provider returns the original text on chunk failure; warnings surfaced via `metadata.warnings`)
+- Three-file subtitle output: `subtitle.srt` (original, invariant) + `subtitle.<lang>.srt` (translated) + `subtitle.bilingual.srt` (original + LF + translation per cue)
+- `render_subtitle_path` field picks the overlay track per `subtitle_mode`; `subtitle_path` remains original-only for backward compatibility
+- `content_language` / `subtitle_mode` / `translate_provider` / `subtitle_paths` / `warnings` exported to `metadata.json`
+- `JobConfigError` raised when `subtitle_mode ∈ {translated, bilingual}` is set without `subtitle_lang`
+- Tests: `tests/test_translate.py` covering disabled/skipped/empty/provider-unknown/CI-passthrough/length-mismatch/blank-item paths; subtitle SRT tests extended for translated + bilingual file outputs and render_subtitle_path resolution
+
 ### Changed
 - 移除 `render.py` 中重复的自定义 tqdm 进度条；MoviePy 内部 `logger="bar"` 接管进度展示（commit `7980ccd`）
 
@@ -116,12 +141,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - workflow_steps 和 params 元数据注入
 - 控制台日志重构设计
 
-[Unreleased]: https://github.com/zcbacxc/movie-narrator/compare/v0.4.1...HEAD
-0.4.1: https://github.com/zcbacxc/movie-narrator/compare/v0.4.0...v0.4.1
-0.4.0: https://github.com/zcbacxc/movie-narrator/compare/v0.3.5...v0.4.0
-0.3.5: https://github.com/zcbacxc/movie-narrator/compare/v0.3.4...v0.3.5
-0.3.4: https://github.com/zcbacxc/movie-narrator/compare/v0.3.3...v0.3.4
-0.3.3: https://github.com/zcbacxc/movie-narrator/compare/v0.3.2...v0.3.3
-0.3.2: https://github.com/zcbacxc/movie-narrator/compare/v0.3.1...v0.3.2
-0.3.1: https://github.com/zcbacxc/movie-narrator/compare/v0.3.0...v0.3.1
-0.3.0: https://github.com/zcbacxc/movie-narrator/compare/v0.2.2...v0.3.0
+[Unreleased]: https://github.com/zcbacxc/movie-narrator/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/zcbacxc/movie-narrator/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/zcbacxc/movie-narrator/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/zcbacxc/movie-narrator/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/zcbacxc/movie-narrator/compare/v0.3.5...v0.4.0
+[0.3.5]: https://github.com/zcbacxc/movie-narrator/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/zcbacxc/movie-narrator/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/zcbacxc/movie-narrator/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/zcbacxc/movie-narrator/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/zcbacxc/movie-narrator/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/zcbacxc/movie-narrator/compare/v0.2.2...v0.3.0

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ mn create --movie "飞驰人生" --keep-cache
 | `--movie, -m` | Movie name (required) | - |
 | `--style, -s` | Narration style | `热血搞笑` |
 | `--duration, -d` | Target duration (seconds) | `60` |
-| `--voice, -v` | Edge-TTS voice | `zh-CN-YunxiNeural` |
+| `--voice, -v` | TTS voice (provider-interpreted) | `zh-CN-YunxiNeural` |
 | `--format, -f` | Video format (`16:9` or `9:16`) | `16:9` |
 | `--video, -V` | Source movie file path | - |
 | `--library-dir` | Movie library directory | - |
@@ -152,6 +152,8 @@ mn create --movie "飞驰人生" --keep-cache
 | `--no-bgm` | Disable BGM even if default is set | `false` |
 | `--no-clips` | Skip scene-level clip export | `false` |
 | `--strict` | Abort pipeline on soft step failure | `false` |
+| `--keep-cache` | Keep TTS cache files for debugging | `false` |
+| `--retry` | Enable interactive retry on hard step failure | `false` |
 | `--subtitle-lang` | Target language tag (`en`, `ja`, `zh-TW`, ...); empty = feature off | - |
 | `--subtitle-mode` | Overlay mode: `original` / `translated` / `bilingual` | `original` |
 | `--config` | Path to job YAML (movie/steps/params); CLI flags override YAML | - |
@@ -292,6 +294,8 @@ mn create --movie "飞驰人生" --duration 60
 | `MN_SUBTITLE_MODE` | Default overlay mode (`original` / `translated` / `bilingual`) | `original` |
 | `MN_TRANSLATE_PROVIDER` | Translation backend (v0.3: `llm` only) | `llm` |
 | `MN_TRANSLATE_RETRIES` | LLM translation retries before soft-degrade | `3` |
+| `MN_TRANSLATE_CHUNK_CHARS` | Max characters per translation chunk | `4000` |
+| `MN_TRANSLATE_CHUNK_SIZE` | Max segments per translation chunk | `20` |
 | `MN_TTS_PROVIDER` | TTS backend: `edge` (default), `openai`, or `mimo` | `edge` |
 | `MN_OPENAI_TTS_MODEL` | OpenAI TTS model (when `MN_TTS_PROVIDER=openai`) | `tts-1` |
 | `MN_OPENAI_TTS_API_KEY` | OpenAI TTS API key (falls back to `MN_LLM_API_KEY`) | - |
@@ -379,9 +383,10 @@ movie-narrator/
 │   │   ├── bgm.py           # Background music mixing
 │   │   ├── translate.py     # Multi-language subtitle translation (LLM)
 │   │   ├── subtitle.py      # SRT generation (single / translated / bilingual)
-│   │   ├── render.py        # MoviePy video rendering
-│   │   ├── export_clips.py  # Per-segment clip export
-│   │   └── errors.py        # PipelineStrictError
+│   │   ├── render.py        # MoviePy 2.x video rendering
+│   │   ├── export_clips.py  # Per-segment clip export (direct ffmpeg)
+│   │   ├── preflight.py     # Pre-run LLM/TTS validation (fail-fast)
+│   │   └── errors.py        # PipelineStrictError, PipelineCancelled, RunController, StepAction
 │   ├── workflow/
 │   │   ├── schema.py        # JobConfig / JobSteps / JobParams
 │   │   ├── load.py          # YAML loader + validation
@@ -483,7 +488,7 @@ movie-narrator/
 - [x] Multi-language subtitle support (`--subtitle-lang` / `--subtitle-mode`; LLM translation with retry-then-soft-degrade; `subtitle.<lang>.srt` + `subtitle.bilingual.srt` outputs)
 - [x] Web UI (Gradio local browser app via `mn web`; cooperative cancel; requires `[web]` extra)
 
-### v0.4.x — TTS Abstraction & Infrastructure
+### v0.4.x — TTS Abstraction & Infrastructure ✅
 
 - [x] TTS provider abstraction (`TTSProvider` protocol, Edge + OpenAI + MiMo backends)
 - [x] Provider selection via `MN_TTS_PROVIDER` (`edge` / `openai` / `mimo`)
@@ -493,6 +498,11 @@ movie-narrator/
 - [x] CI temp-file isolation (silent audio never enters cache)
 - [x] `is_ci()` single source of truth for CI detection
 - [x] `ConfigError` cross-cutting error class
+- [x] MoviePy 1.x → 2.x upgrade (Python 3.13+ compatibility)
+- [x] Preflight LLM/TTS validation before pipeline execution
+- [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
+- [x] Auto-create `~/.movie-narrator/.env` on first run
+- [x] `export_clips` direct ffmpeg subprocess (design choice, not workaround)
 
 ### v0.5.x — Ecosystem (Planned)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,7 +140,7 @@ mn create --movie "飞驰人生" --keep-cache
 | `--movie, -m` | 电影名称（必填） | - |
 | `--style, -s` | 解说风格 | `热血搞笑` |
 | `--duration, -d` | 目标时长（秒） | `60` |
-| `--voice, -v` | Edge-TTS 音色 | `zh-CN-YunxiNeural` |
+| `--voice, -v` | TTS 音色（由 Provider 解释） | `zh-CN-YunxiNeural` |
 | `--format, -f` | 视频比例（`16:9` 或 `9:16`） | `16:9` |
 | `--video, -V` | 源电影文件路径 | - |
 | `--library-dir` | 电影库目录 | - |
@@ -151,6 +151,7 @@ mn create --movie "飞驰人生" --keep-cache
 | `--no-clips` | 跳过场景片段导出 | `false` |
 | `--strict` | 软步骤失败时中止 | `false` |
 | `--keep-cache` | 保留 TTS 缓存文件 | `false` |
+| `--retry` | 硬步骤失败时启用交互式重试 | `false` |
 | `--subtitle-lang` | 目标语言标签（`en`、`ja`、`zh-TW`...），留空 = 关闭翻译 | - |
 | `--subtitle-mode` | 渲染叠加模式：`original` / `translated` / `bilingual` | `original` |
 | `--config` | Job YAML 配置文件路径（movie/steps/params）；CLI 参数覆盖 YAML | - |
@@ -235,7 +236,7 @@ mn --help    # 查看帮助
 
 ### 通过 `.env` 文件（推荐）
 
-在项目目录创建 `.env`（或 `~/.movie-narrator/.env` 作为全局配置——该文件在包目录之外，`pip install/upgrade/uninstall` 均不会触碰）：
+在项目目录创建 `.env`（或 `~/.movie-narrator/.env` 作为全局配置——首次运行时自动创建并填入默认值，该文件在包目录之外，`pip install/upgrade/uninstall` 均不会触碰）：
 
 ```bash
 MN_LLM_BASE_URL=http://localhost:11434/v1
@@ -291,6 +292,8 @@ mn create --movie "飞驰人生" --duration 60
 | `MN_SUBTITLE_MODE` | 默认叠加模式（`original` / `translated` / `bilingual`） | `original` |
 | `MN_TRANSLATE_PROVIDER` | 翻译后端（v0.3 仅支持 `llm`） | `llm` |
 | `MN_TRANSLATE_RETRIES` | LLM 翻译失败重试次数，超出后软降级 | `3` |
+| `MN_TRANSLATE_CHUNK_CHARS` | 每个翻译块的最大字符数 | `4000` |
+| `MN_TRANSLATE_CHUNK_SIZE` | 每个翻译块的最大段数 | `20` |
 | `MN_TTS_PROVIDER` | TTS 后端：`edge`（默认）、`openai` 或 `mimo` | `edge` |
 | `MN_OPENAI_TTS_MODEL` | OpenAI TTS 模型（`MN_TTS_PROVIDER=openai` 时生效） | `tts-1` |
 | `MN_OPENAI_TTS_API_KEY` | OpenAI TTS API 密钥（回退到 `MN_LLM_API_KEY`） | - |
@@ -378,9 +381,10 @@ movie-narrator/
 │   │   ├── bgm.py           # 背景音乐混音
 │   │   ├── translate.py     # 多语言字幕翻译（LLM）
 │   │   ├── subtitle.py      # SRT 生成（原版 / 翻译 / 双语）
-│   │   ├── render.py        # MoviePy 视频渲染
-│   │   ├── export_clips.py  # 场景片段导出
-│   │   └── errors.py        # PipelineStrictError
+│   │   ├── render.py        # MoviePy 2.x 视频渲染
+│   │   ├── export_clips.py  # 场景片段导出（直调 ffmpeg）
+│   │   ├── preflight.py     # 运行前 LLM/TTS 校验（快速失败）
+│   │   └── errors.py        # PipelineStrictError, PipelineCancelled, RunController, StepAction
 │   ├── workflow/
 │   │   ├── schema.py        # JobConfig / JobSteps / JobParams
 │   │   ├── load.py          # YAML 加载与验证
@@ -492,6 +496,11 @@ movie-narrator/
 - [x] CI 临时文件隔离（静音音频不进入缓存）
 - [x] `is_ci()` CI 检测单一来源
 - [x] `ConfigError` 横切配置错误类
+- [x] MoviePy 1.x → 2.x 升级（Python 3.13+ 兼容）
+- [x] 运行前 LLM/TTS 预检（preflight 校验）
+- [x] 步骤级重试机制（`--retry` 标志，`StepAction` 枚举）
+- [x] 首次运行自动创建 `~/.movie-narrator/.env`
+- [x] `export_clips` 直调 ffmpeg 子进程（设计选择，非临时方案）
 
 ### v0.5.x — 生态系统（规划中）
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Pipeline Overview
 
-14-step sequential pipeline orchestrated by `pipeline/runner.py`:
+14-step sequential pipeline orchestrated by `pipeline/runner.py`. Before any step executes, `preflight.py` probes LLM connectivity and TTS provider configuration — failing fast with `PreflightError` instead of silently degrading to mock content.
 
 ```text
 resolve_video → prepare_assets → research_plot → generate_script →
@@ -152,7 +152,7 @@ pipeline probes duration via AudioSegment.from_mp3
 ```
 output/<movie>/
 ├── narration.mp3          # TTS output
-├── final_audio.mp3        # narration + BGM mix (when BGM enabled)
+├── mixed.mp3        # narration + BGM mix (when BGM enabled)
 ├── subtitle.srt           # SRT subtitles (original narration; always written)
 ├── subtitle.<lang>.srt    # translated subtitles (when --subtitle-lang set)
 ├── subtitle.bilingual.srt # bilingual subtitles (when --subtitle-lang set; cue body "src\ndst")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,6 +74,11 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 - [x] CI temp-file isolation (silent audio never enters cache)
 - [x] `is_ci()` single source of truth for CI detection
 - [x] `ConfigError` cross-cutting error class
+- [x] MoviePy 1.x → 2.x upgrade (Python 3.13+ compatibility)
+- [x] Preflight LLM/TTS validation before pipeline execution
+- [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
+- [x] Auto-create `~/.movie-narrator/.env` on first run
+- [x] `export_clips` direct ffmpeg subprocess (design choice)
 
 ### v0.4 Environment variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.4.2"
+version = "0.4.3"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0"


### PR DESCRIPTION
## Summary

Sync all documentation with the actual codebase and bump version to 0.4.3. This is a documentation-only release — no code changes.

## Changes (6 files, +82/-31)

### CHANGELOG.md
- Add `[0.4.2]` entry with 7 Added items (preflight, --retry, auto-init config, audioop-lts, Python 3.13 CI) and 6 Changed items (MoviePy 2.x, Gradio <7, torch gating, export_clips design choice)
- Add `[0.4.3]` release entry
- Fix version ordering (was: 0.3.4 → Unreleased → 0.4.1 → 0.4.0 → 0.3.5 → 0.3.4)
- Merge duplicate `[0.3.4]` entries
- Update compare links

### README.md + README.zh-CN.md
- Add `--retry` and `--keep-cache` to CLI options table
- Fix `--voice` description: "Edge-TTS voice" → "TTS voice (provider-interpreted)"
- Add `preflight.py` to project structure
- Update `errors.py` description (add StepAction, PipelineCancelled, RunController)
- Add `MN_TRANSLATE_CHUNK_CHARS` and `MN_TRANSLATE_CHUNK_SIZE` to config reference
- Add 6 v0.4.2 completed items to roadmap
- EN: Add ✅ to v0.4.x roadmap title
- ZH-CN: Document auto-creation of `~/.movie-narrator/.env`

### docs/ROADMAP.md
- Add 6 v0.4.2 completed items to v0.4.x section

### docs/ARCHITECTURE.md
- Add `generate_subtitle` to Hard steps table (was 13, now 14)
- Fix `final_audio.mp3` → `mixed.mp3` in output structure
- Add preflight description to Pipeline Overview
- Add MoviePy 2.x reference to render_video
- Add preflight and interactive retry to Extension Points

### pyproject.toml
- Version bump 0.4.2 → 0.4.3

## Test Results
- 258 passed, 11 skipped, 2 failed (pre-existing local .env pollution)
