### PR TITLE
fix: audio pipeline WAV format

### DIFF
--- a/src/movie_narrator/pipeline/bgm.py
+++ b/src/movie_narrator/pipeline/bgm.py
@@ -39,8 +39,8 @@ def mix_bgm(ctx: Context) -> Context:
             bgm = bgm * times
         bgm = bgm[: len(narration)]
         mixed = narration.overlay(bgm)
-        out = Path(ctx.output_dir) / "mixed.mp3"
-        mixed.export(out, format="mp3")
+        out = Path(ctx.output_dir) / "mixed.wav"
+        mixed.export(out, format="wav")
         ctx.final_audio_path = str(out)
         ctx.status.bgm = "success"
         return ctx

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -60,12 +60,12 @@ def generate_voice(ctx: Context) -> Context:
                     # cache and skip real synthesis.
                     tmp = output_dir / f".ci_{cached.name}"
                     await provider.synthesize(seg.text, voice, tmp)
-                    audio = AudioSegment.from_mp3(tmp)
+                    audio = AudioSegment.from_file(tmp)
                     tmp.unlink(missing_ok=True)
                 else:
                     if not cached.exists():
                         await provider.synthesize(seg.text, voice, cached)
-                    audio = AudioSegment.from_mp3(cached)
+                    audio = AudioSegment.from_file(cached)
                 return audio, round(len(audio) / 1000.0, 3)
 
         return await tqdm_asyncio.gather(
@@ -89,11 +89,12 @@ def generate_voice(ctx: Context) -> Context:
         )
         current_time += duration + pause
 
-    audio_path = output_dir / "narration.mp3"
-    # Explicit bitrate prevents pydub's default 32 kbps export, which
-    # produces MPEG v2.5 audio that ffmpeg (used by MoviePy) can fail
-    # to decode — resulting in a silent final video.
-    combined.export(audio_path, format="mp3", bitrate="128k")
+    audio_path = output_dir / "narration.wav"
+    # Export as WAV (PCM) instead of MP3.  The system ffmpeg may be a
+    # minimal build without MP3 decoder support (--disable-everything),
+    # causing MoviePy's AudioFileClip to silently produce a 6ms empty
+    # track.  WAV is always decodable by any ffmpeg build.
+    combined.export(audio_path, format="wav")
     ctx.audio_path = str(audio_path)
     ctx.timed_segments = timed_segments
     ctx.metadata["voice_used"] = voice
@@ -105,7 +106,7 @@ def generate_voice(ctx: Context) -> Context:
     _max_bytes = settings.tts_cache_max_mb * 1024 * 1024
     cache_parent = output_dir / "cache" / "tts"
     if cache_parent.exists():
-        mp3_files = list(cache_parent.rglob("*.mp3"))
+        mp3_files = list(cache_parent.rglob("*.wav")) + list(cache_parent.rglob("*.mp3"))
         total = sum(f.stat().st_size for f in mp3_files)
         if total > _max_bytes:
             for oldest in sorted(mp3_files, key=lambda f: f.stat().st_mtime):

--- a/src/movie_narrator/tts/base.py
+++ b/src/movie_narrator/tts/base.py
@@ -45,13 +45,13 @@ class BaseTTSProvider(TTSProvider):
         """Write silence sized to text; CI mode never blocks on network.
 
         Duration is NOT returned — the pipeline probes it from the
-        resulting file via ``AudioSegment.from_mp3``. This keeps duration
+        resulting file via ``AudioSegment.from_file``. This keeps duration
         calculation in one place across cache-hit, cache-miss, and CI paths.
         """
         dur = _estimate_duration_s(text)
         audio = AudioSegment.silent(duration=int(dur * 1000))
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        audio.export(output_path, format="mp3")
+        audio.export(output_path, format="wav")
 
     @abstractmethod
     async def _real_synthesize(self, text: str, voice: str, output_path: Path) -> None:

--- a/src/movie_narrator/tts/mimo_provider.py
+++ b/src/movie_narrator/tts/mimo_provider.py
@@ -6,7 +6,7 @@ Supports three models (all limited-time free):
   - mimo-v2.5-tts-voicedesign: Design voice from text description
 
 All three return base64-encoded wav audio in completion.choices[0].message.audio.data.
-The provider converts wav → mp3 so the pipeline's AudioSegment.from_mp3() works unchanged.
+The provider saves as WAV so the pipeline's AudioSegment.from_file() works without ffmpeg mp3 support.
 """
 
 import asyncio
@@ -84,9 +84,10 @@ class MimoTTSProvider(BaseTTSProvider):
 
         raw = base64.b64decode(message.audio.data)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        # MiMo outputs wav; convert to mp3 so the pipeline's from_mp3() works.
+        # MiMo outputs wav; keep as WAV to avoid ffmpeg mp3 encoder dependency.
+        # The pipeline reads cache via AudioSegment.from_file() which auto-detects.
         audio = AudioSegment.from_file(BytesIO(raw), format="wav")
-        audio.export(output_path, format="mp3")
+        audio.export(output_path, format="wav")
 
     def _call_api(self, text: str, user_content: str, audio_param: dict):
         return self._client.chat.completions.create(


### PR DESCRIPTION
## Root Cause

TRAE's bundled ffmpeg (\d:\soft\TRAE SOLO CN\resources\app\bin\ffmpeg.exe\) is a minimal build with \--disable-everything\ — no MP3 decoder, encoder, or demuxer. This causes:

1. \
arration.mp3\ cannot be decoded by MoviePy's \AudioFileClip\ (ffmpeg fails silently)
2. \inal.mp4\ audio stream is 6ms of silence (bitrate shows garbage 1.28Gbps)

## Fix

Switch the entire audio pipeline from MP3 to WAV (PCM):
- \	ts.py\: narration exports as WAV
- \	ts.py\: cache reading uses \rom_file()\ instead of \rom_mp3()\
- \mimo_provider.py\: cache files saved as WAV
- \ase.py\: CI silent synthesize exports WAV
- \gm.py\: mixed audio exports as WAV

WAV is PCM-based — pydub can export it natively without ffmpeg, and any ffmpeg build can decode it.