### PR TITLE
fix: silent video audio codec mismatch

### DIFF
--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -118,13 +118,29 @@ def render_video(ctx: Context) -> Context:
     tmp_dir.mkdir(exist_ok=True)
 
     settings = get_settings()
+    # temp_audiofile extension MUST match the audio_codec so the final
+    # mux step ("-acodec copy") reads a correctly-typed bitstream.
+    # With audio_codec="aac", a ".wav" extension causes a RIFF/WAV
+    # header wrapping AAC data — ffmpeg then decodes only ~6 ms.
+    temp_ext = settings.render_audio_codec
+    # "copy" is a passthrough pseudo-codec; "aac" works for both AAC-LC
+    # and the HE-AAC variants.  Map libmp3lame → mp3 so the temp file
+    # always carries a real container extension.
+    if temp_ext == "copy":
+        temp_ext = "aac"
+    elif temp_ext.startswith("lib"):
+        temp_ext = temp_ext[3:]  # libmp3lame → mp3lame
+    # Normalise a few known aliases to a short file extension.
+    _EXT_NORM = {"mp3lame": "mp3", "libfdk_aac": "aac", "pcm_s16le": "wav"}
+    temp_ext = _EXT_NORM.get(temp_ext, temp_ext)
+
     write_kwargs = dict(
         fps=settings.render_fps,
         codec=settings.render_video_codec,
         audio_codec=settings.render_audio_codec,
         threads=settings.render_threads,
         logger=_RenderProgressLogger(),
-        temp_audiofile=str(tmp_dir / "temp_audio.wav"),
+        temp_audiofile=str(tmp_dir / f"temp_audio.{temp_ext}"),
     )
     try:
         final_video.write_videofile(str(video_path), **write_kwargs)


### PR DESCRIPTION
## Root Cause

`render.py` hardcoded `temp_audiofile=str(tmp_dir / "temp_audio.wav")` — the `.wav` extension doesn't match the configured `audio_codec="aac"`.

When MoviePy's `write_videofile` receives both an explicit `temp_audiofile` path AND an explicit `audio_codec`:
1. It calls `write_audiofile(temp_audiofile, codec="aac")` → encodes audio as AAC inside a `.wav` RIFF container
2. The final mux runs `ffmpeg ... -i temp_audio.wav -acodec copy ...` → FFmpeg expects PCM (from RIFF header), gets AAC data, decodes only ~6ms

## The Fix

`render.py` now derives the temp file extension from the audio codec:
- `"aac"` → `temp_audio.aac`
- `"libmp3lame"` → `temp_audio.mp3`
- `"pcm_s16le"` → `temp_audio.wav`
- `"copy"` (passthrough) → defaults to `temp_audio.aac`

## Verified

| Test | Result |
|------|--------|
| Original (.wav + aac) | 6ms audio — broken |
| Without temp_audiofile | 67.5s audio — correct |
| .aac ext + aac codec | 67.6s audio — correct |
| Fixed code (.aac + aac) | 67.6s audio — correct |
| Unit tests (285/289) | Pass — 4 pre-existing env failures unchanged |
