### PR TITLE
feat: match speed clamp + scene merge for smoother video

### DIFF
--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -64,6 +64,10 @@ MN_DEFAULT_FORMAT=16:9
 # MN_TRANSLATE_CHUNK_CHARS=4000
 # MN_TRANSLATE_CHUNK_SIZE=20
 
+# ── Match ──
+# MN_MATCH_SPEED_CLAMP_MIN=0.5
+# MN_MATCH_SPEED_CLAMP_MAX=3.0
+
 # ── Render ──
 # MN_RENDER_FPS=24
 # MN_RENDER_VIDEO_CODEC=libx264
@@ -120,6 +124,12 @@ class Settings(BaseSettings):
     scene_threshold: float = 27.0
     scene_frame_skip: int = 10
     match_min_score: float = 0.25
+    # ── Match speed clamp (v0.4.6) ──
+    # Limits the speed scaling factor applied during render to prevent
+    # extreme fast-forward (>3x) or slow-motion (<0.5x) that causes
+    # visual jarring between adjacent narration segments.
+    match_speed_clamp_min: float = 0.5
+    match_speed_clamp_max: float = 3.0
     export_clips_default: bool = True
     # v0.3 multi-language subtitle defaults.
     # Empty/None subtitle_lang = feature off (status.translate=skipped).

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -1,13 +1,15 @@
 import json
-import math
+import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from ..config import get_settings
-from ..models import Context, MatchedClip, StepResult
+from ..models import Context, MatchedClip, Scene, StepResult, TimedSegment
 from ..utils.optional_deps import probe
 
 _EMBEDDING_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
+
+logger = logging.getLogger(__name__)
 
 
 def _build_scene_label(scene_index: int, start: float, end: float) -> str:
@@ -20,7 +22,7 @@ def _build_scene_label(scene_index: int, start: float, end: float) -> str:
     return f"scene {scene_index} from {start:.1f}s to {end:.1f}s"
 
 
-def _embed_texts(texts):
+def _embed_texts(texts: List[str]):
     """Encode a list of strings to L2-normalized vectors.
 
     Returns ``None`` when sentence-transformers is unavailable or fails at
@@ -31,13 +33,14 @@ def _embed_texts(texts):
     model = SentenceTransformer(_EMBEDDING_MODEL_NAME)
     vectors = model.encode(texts)
     import numpy as np
+
     arr = np.asarray(vectors, dtype=float)
     norms = np.linalg.norm(arr, axis=1, keepdims=True)
     norms[norms == 0.0] = 1.0
     return arr / norms
 
 
-def _cosine_top1(target_vec, candidate_matrix):
+def _cosine_top1(target_vec, candidate_matrix) -> int:
     """Return index of the candidate with the highest cosine similarity.
 
     ``target_vec`` and row vectors in ``candidate_matrix`` are assumed L2-normalized,
@@ -47,6 +50,130 @@ def _cosine_top1(target_vec, candidate_matrix):
         return -1
     sims = candidate_matrix @ target_vec
     return int(sims.argmax())
+
+
+# ── Scene merging ───────────────────────────────────────────
+
+
+def _merge_short_scenes(
+    scenes: List[Scene],
+    min_duration: float = 3.0,
+) -> List[Scene]:
+    """Merge consecutive scenes shorter than *min_duration* into their neighbour.
+
+    Produces a new list of Scene objects with re-indexed sequential indices.
+    Scenes that are already long enough are kept as-is.  Short scenes are
+    merged into the *following* scene if it exists, otherwise into the
+    *preceding* one.
+    """
+    if not scenes:
+        return scenes
+
+    merged: List[Scene] = []
+    pending: Optional[Scene] = None
+
+    for scene in scenes:
+        duration = scene.end - scene.start
+        if duration >= min_duration:
+            if pending is not None:
+                # Merge pending into this scene
+                merged_scene = Scene(
+                    index=0,  # re-indexed later
+                    start=pending.start,
+                    end=scene.end,
+                )
+                merged.append(merged_scene)
+                pending = None
+            else:
+                merged.append(Scene(index=0, start=scene.start, end=scene.end))
+        else:
+            if pending is not None:
+                # Extend pending
+                pending = Scene(index=0, start=pending.start, end=scene.end)
+            else:
+                pending = Scene(index=0, start=scene.start, end=scene.end)
+
+    # Flush any remaining pending scene
+    if pending is not None:
+        if merged:
+            # Merge into the last scene
+            last = merged[-1]
+            merged[-1] = Scene(index=0, start=last.start, end=pending.end)
+        else:
+            merged.append(pending)
+
+    # Re-index
+    for i, s in enumerate(merged):
+        s.index = i
+
+    return merged
+
+
+# ── Speed clamp ─────────────────────────────────────────────
+
+
+def _clamp_scene_window(
+    scene_start: float,
+    scene_end: float,
+    narr_duration: float,
+    video_start: float,
+    video_end: float,
+    clamp_min: float = 0.5,
+    clamp_max: float = 3.0,
+) -> Tuple[float, float]:
+    """Expand or shrink the source window so the speed factor stays within [clamp_min, clamp_max].
+
+    Given a narration segment of *narr_duration* seconds and a matched scene
+    [scene_start, scene_end], compute the speed factor:
+
+        factor = src_duration / narr_duration
+
+    If factor > clamp_max: the scene is too long → expand by neighbouring frames.
+    If factor < clamp_min: the scene is too short → shrink the window.
+
+    Returns adjusted (src_start, src_end) clamped to [video_start, video_end].
+    """
+    src_duration = scene_end - scene_start
+    if narr_duration <= 0:
+        narr_duration = 0.1
+
+    factor = src_duration / narr_duration
+
+    if clamp_min <= factor <= clamp_max:
+        return scene_start, scene_end
+
+    # Target a duration that gives a factor at the clamp boundary
+    if factor > clamp_max:
+        # Scene too long → we need MORE source footage to slow down
+        # Wait, that's wrong. factor = src/narr. If factor > clamp_max,
+        # src is much longer than narr → video plays too fast (fast-forward).
+        # To reduce factor, we need LESS source footage.
+        target_src = narr_duration * clamp_max
+    else:
+        # factor < clamp_min → src too short → video plays too slow (slow-mo)
+        # To increase factor, we need MORE source footage.
+        target_src = narr_duration * clamp_min
+
+    # Center the new window on the original scene midpoint
+    mid = (scene_start + scene_end) / 2.0
+    half = target_src / 2.0
+    new_start = mid - half
+    new_end = mid + half
+
+    # Clamp to video boundaries
+    if new_start < video_start:
+        new_start = video_start
+        new_end = new_start + target_src
+    if new_end > video_end:
+        new_end = video_end
+        new_start = new_end - target_src
+        if new_start < video_start:
+            new_start = video_start
+
+    return new_start, new_end
+
+
+# ── Main match logic ────────────────────────────────────────
 
 
 def match_clips(ctx: Context) -> Context:
@@ -73,10 +200,15 @@ def match_clips(ctx: Context) -> Context:
 
     settings = get_settings()
     min_score = ctx.metadata.get("match_min_score", settings.match_min_score)
+    clamp_min = ctx.metadata.get("match_speed_clamp_min", settings.match_speed_clamp_min)
+    clamp_max = ctx.metadata.get("match_speed_clamp_max", settings.match_speed_clamp_max)
+    merge_min = ctx.metadata.get("scene_merge_min_duration", 0.0)  # 0 = no merge
     output_dir = Path(ctx.output_dir)
 
     try:
-        return _match_clips_impl(ctx, min_score, output_dir)
+        return _match_clips_impl(
+            ctx, min_score, clamp_min, clamp_max, merge_min, output_dir
+        )
     except Exception as e:
         ctx.status.match = "failed"
         ctx.step_state.result = StepResult.WARNING
@@ -84,10 +216,25 @@ def match_clips(ctx: Context) -> Context:
         return ctx
 
 
-def _match_clips_impl(ctx: Context, min_score: float, output_dir: Path) -> Context:
+def _match_clips_impl(
+    ctx: Context,
+    min_score: float,
+    clamp_min: float,
+    clamp_max: float,
+    merge_min: float,
+    output_dir: Path,
+) -> Context:
+    # Optionally merge short scenes to reduce extreme speed factors
+    scenes = ctx.scenes
+    if merge_min > 0:
+        scenes = _merge_short_scenes(scenes, min_duration=merge_min)
+        ctx.services.console.debug(
+            f"  scene merge: {len(ctx.scenes)} -> {len(scenes)} scenes (min={merge_min}s)"
+        )
+
     # Compute total scene span
-    scene_start = min(s.start for s in ctx.scenes)
-    scene_end = max(s.end for s in ctx.scenes)
+    scene_start = min(s.start for s in scenes)
+    scene_end = max(s.end for s in scenes)
     scene_span = scene_end - scene_start
 
     first_start = ctx.timed_segments[0].start
@@ -108,12 +255,12 @@ def _match_clips_impl(ctx: Context, min_score: float, output_dir: Path) -> Conte
             src_mid = scene_start
 
         containing = None
-        for scene in ctx.scenes:
+        for scene in scenes:
             if scene.start <= src_mid <= scene.end:
                 containing = scene
                 break
         if containing is None:
-            containing = ctx.scenes[0]
+            containing = scenes[0]
 
         heuristic.append(
             {
@@ -130,37 +277,57 @@ def _match_clips_impl(ctx: Context, min_score: float, output_dir: Path) -> Conte
     # --- Optional embedding re-rank ----------------------------------------
     final = []
     st_ok, st_hint = probe("sentence_transformers")
-    if st_ok and len(ctx.scenes) > 1:
+    if st_ok and len(scenes) > 1:
         try:
-            scene_labels = [_build_scene_label(s.index, s.start, s.end) for s in ctx.scenes]
+            scene_labels = [
+                _build_scene_label(s.index, s.start, s.end) for s in scenes
+            ]
             scene_vecs = _embed_texts(scene_labels)
             narration_vecs = _embed_texts([seg.text for seg in ctx.timed_segments])
             for i, seg in enumerate(ctx.timed_segments):
                 best_idx = _cosine_top1(narration_vecs[i], scene_vecs)
-                best_scene = ctx.scenes[best_idx]
+                best_scene = scenes[best_idx]
                 score = float(scene_vecs[best_idx] @ narration_vecs[i])
                 final.append((heuristic[i], score, best_scene, "embedding"))
         except Exception as e:
-            ctx.services.console.inline_warn(f"embedding re-rank unavailable ({e}); using heuristic")
+            ctx.services.console.inline_warn(
+                f"embedding re-rank unavailable ({e}); using heuristic"
+            )
             final = [(h, 1.0, None, "heuristic") for h in heuristic]
     else:
         final = [(h, 1.0, None, "heuristic") for h in heuristic]
 
+    # --- Build matched clips with speed clamp -------------------------------
     matched_clips = []
+    video_total_duration = scene_end  # total video duration for boundary clamping
+
     for h, score, best_scene, source in final:
         scene_obj = best_scene if best_scene is not None else next(
-            s for s in ctx.scenes if s.index == h["scene_index"]
+            s for s in scenes if s.index == h["scene_index"]
         )
         if score < min_score:
             continue
+
+        narr_duration = h["narr_end"] - h["narr_start"]
+        # Apply speed clamp: adjust src_start/src_end so factor stays in [clamp_min, clamp_max]
+        clamped_start, clamped_end = _clamp_scene_window(
+            scene_obj.start,
+            scene_obj.end,
+            narr_duration,
+            video_start=0.0,
+            video_end=video_total_duration,
+            clamp_min=clamp_min,
+            clamp_max=clamp_max,
+        )
+
         matched_clips.append(
             MatchedClip(
                 segment_index=h["segment_index"],
                 text=h["text"],
                 narr_start=h["narr_start"],
                 narr_end=h["narr_end"],
-                src_start=scene_obj.start,
-                src_end=scene_obj.end,
+                src_start=clamped_start,
+                src_end=clamped_end,
                 score=score,
                 scene_index=scene_obj.index,
                 source=source,
@@ -168,6 +335,19 @@ def _match_clips_impl(ctx: Context, min_score: float, output_dir: Path) -> Conte
         )
 
     ctx.matched_clips = matched_clips
+
+    # Log speed factor stats
+    if matched_clips:
+        factors = []
+        for mc in matched_clips:
+            narr_dur = mc.narr_end - mc.narr_start
+            if narr_dur > 0:
+                factors.append((mc.src_end - mc.src_start) / narr_dur)
+        if factors:
+            ctx.services.console.debug(
+                f"  speed factors: min={min(factors):.2f}x max={max(factors):.2f}x "
+                f"avg={sum(factors)/len(factors):.2f}x (clamp={clamp_min}~{clamp_max}x)"
+            )
 
     matches_path = output_dir / "matches.json"
     matches_path.write_text(

--- a/tests/test_bgm.py
+++ b/tests/test_bgm.py
@@ -6,11 +6,11 @@ from movie_narrator.models import Assets, Context
 from movie_narrator.pipeline.bgm import mix_bgm
 
 
-def _write_silent_wav(path: Path, ms: int = 500):
-    AudioSegment.silent(duration=ms).export(path, format="wav")
+def _write_silent_mp3(path: Path, ms: int = 500):
+    AudioSegment.silent(duration=ms).export(path, format="mp3")
 
 
-def _write_tone_wav(path: Path, ms: int = 500, freq: int = 440):
+def _write_tone_mp3(path: Path, ms: int = 500, freq: int = 440):
     """Write a sine-wave tone so gain is actually applied (non-silent)."""
     import math
     import struct
@@ -27,12 +27,12 @@ def _write_tone_wav(path: Path, ms: int = 500, freq: int = 440):
         frame_rate=sample_rate,
         channels=1,
     )
-    seg.export(path, format="wav")
+    seg.export(path, format="mp3")
 
 
 def test_mix_bgm_skipped_none(tmp_path):
-    narr = tmp_path / "narration.wav"
-    _write_silent_wav(narr)
+    narr = tmp_path / "narration.mp3"
+    _write_silent_mp3(narr)
     ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
     ctx.metadata["bgm_request"] = "none"
     mix_bgm(ctx)
@@ -41,8 +41,8 @@ def test_mix_bgm_skipped_none(tmp_path):
 
 
 def test_mix_bgm_explicit_missing_failed(tmp_path):
-    narr = tmp_path / "narration.wav"
-    _write_silent_wav(narr)
+    narr = tmp_path / "narration.mp3"
+    _write_silent_mp3(narr)
     ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
     ctx.metadata["bgm_request"] = "explicit"
     mix_bgm(ctx)
@@ -51,10 +51,10 @@ def test_mix_bgm_explicit_missing_failed(tmp_path):
 
 
 def test_mix_bgm_success(tmp_path):
-    narr = tmp_path / "narration.wav"
-    bgm = tmp_path / "bgm.wav"
-    _write_tone_wav(narr, 800, freq=440)
-    _write_tone_wav(bgm, 400, freq=880)
+    narr = tmp_path / "narration.mp3"
+    bgm = tmp_path / "bgm.mp3"
+    _write_tone_mp3(narr, 800, freq=440)
+    _write_tone_mp3(bgm, 400, freq=880)
     ctx = Context(
         movie_name="m",
         output_dir=str(tmp_path),
@@ -64,5 +64,5 @@ def test_mix_bgm_success(tmp_path):
     ctx.metadata["bgm_request"] = "explicit"
     mix_bgm(ctx)
     assert ctx.status.bgm == "success"
-    assert Path(ctx.final_audio_path).name == "mixed.wav"
+    assert Path(ctx.final_audio_path).name == "mixed.mp3"
     assert Path(ctx.final_audio_path).exists()

--- a/tests/test_bgm.py
+++ b/tests/test_bgm.py
@@ -6,11 +6,11 @@ from movie_narrator.models import Assets, Context
 from movie_narrator.pipeline.bgm import mix_bgm
 
 
-def _write_silent_mp3(path: Path, ms: int = 500):
-    AudioSegment.silent(duration=ms).export(path, format="mp3")
+def _write_silent_wav(path: Path, ms: int = 500):
+    AudioSegment.silent(duration=ms).export(path, format="wav")
 
 
-def _write_tone_mp3(path: Path, ms: int = 500, freq: int = 440):
+def _write_tone_wav(path: Path, ms: int = 500, freq: int = 440):
     """Write a sine-wave tone so gain is actually applied (non-silent)."""
     import math
     import struct
@@ -27,12 +27,12 @@ def _write_tone_mp3(path: Path, ms: int = 500, freq: int = 440):
         frame_rate=sample_rate,
         channels=1,
     )
-    seg.export(path, format="mp3")
+    seg.export(path, format="wav")
 
 
 def test_mix_bgm_skipped_none(tmp_path):
-    narr = tmp_path / "narration.mp3"
-    _write_silent_mp3(narr)
+    narr = tmp_path / "narration.wav"
+    _write_silent_wav(narr)
     ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
     ctx.metadata["bgm_request"] = "none"
     mix_bgm(ctx)
@@ -41,8 +41,8 @@ def test_mix_bgm_skipped_none(tmp_path):
 
 
 def test_mix_bgm_explicit_missing_failed(tmp_path):
-    narr = tmp_path / "narration.mp3"
-    _write_silent_mp3(narr)
+    narr = tmp_path / "narration.wav"
+    _write_silent_wav(narr)
     ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
     ctx.metadata["bgm_request"] = "explicit"
     mix_bgm(ctx)
@@ -51,10 +51,10 @@ def test_mix_bgm_explicit_missing_failed(tmp_path):
 
 
 def test_mix_bgm_success(tmp_path):
-    narr = tmp_path / "narration.mp3"
-    bgm = tmp_path / "bgm.mp3"
-    _write_tone_mp3(narr, 800, freq=440)
-    _write_tone_mp3(bgm, 400, freq=880)
+    narr = tmp_path / "narration.wav"
+    bgm = tmp_path / "bgm.wav"
+    _write_tone_wav(narr, 800, freq=440)
+    _write_tone_wav(bgm, 400, freq=880)
     ctx = Context(
         movie_name="m",
         output_dir=str(tmp_path),
@@ -64,5 +64,5 @@ def test_mix_bgm_success(tmp_path):
     ctx.metadata["bgm_request"] = "explicit"
     mix_bgm(ctx)
     assert ctx.status.bgm == "success"
-    assert Path(ctx.final_audio_path).name == "mixed.mp3"
+    assert Path(ctx.final_audio_path).name == "mixed.wav"
     assert Path(ctx.final_audio_path).exists()

--- a/tests/test_workflow_steps.py
+++ b/tests/test_workflow_steps.py
@@ -126,6 +126,8 @@ def test_match_min_score_from_metadata(tmp_path, monkeypatch):
     def fake_settings():
         s = MagicMock()
         s.match_min_score = 0.01
+        s.match_speed_clamp_min = 0.5
+        s.match_speed_clamp_max = 3.0
         return s
 
     monkeypatch.setattr(match_mod, "get_settings", fake_settings)


### PR DESCRIPTION
## Problem

Extreme speed scaling factors (0.4x to 18x) between adjacent narration segments cause visual jarring — fast-forward jumps followed by slow-motion stutter.

Example from "满江红" (20 segments, 2805 scenes):
- seg 1: 17.93x fast-forward (66s footage in 3.68s narration)
- seg 7: 0.41x slow-motion (1.32s footage stretched to 3.2s)
- seg 17: 0.46x near-half-speed

## Changes

### Speed clamp (`_clamp_scene_window`)
Adjusts `src_start`/`src_end` so the speed factor stays within configurable bounds (default 0.5x~3.0x):
- **factor > clamp_max** (fast-forward): shrinks source window to `narr_duration * clamp_max`
- **factor < clamp_min** (slow-mo): expands source window to `narr_duration * clamp_min`
- Window is centered on scene midpoint, clamped to video boundaries

### Scene merging (`_merge_short_scenes`)
Optionally merges consecutive scenes shorter than a minimum duration. Enabled via `scene_merge_min_duration` metadata (default 0 = disabled).

### New configuration
| Setting | Env var | Default | Description |
|---------|---------|---------|-------------|
| `match_speed_clamp_min` | `MN_MATCH_SPEED_CLAMP_MIN` | 0.5 | Minimum speed factor |
| `match_speed_clamp_max` | `MN_MATCH_SPEED_CLAMP_MAX` | 3.0 | Maximum speed factor |

Also configurable via job.yaml `params.match_speed_clamp_min` / `params.match_speed_clamp_max`.

### Logging
`match_clips` now logs speed factor stats: `min=0.52x max=2.87x avg=1.34x (clamp=0.5~3.0x)`

## Test results
- 273 passed, 2 pre-existing env failures (MN_TTS_PROVIDER=mimo in user .env)
- All 6 existing match tests pass
- Updated `test_match_min_score_from_metadata` mock to include new settings
