### PR TITLE
fix: match params whitelist + scene_merge settings + comment cleanup

### DIFF
--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -67,6 +67,7 @@ MN_DEFAULT_FORMAT=16:9
 # ── Match ──
 # MN_MATCH_SPEED_CLAMP_MIN=0.5
 # MN_MATCH_SPEED_CLAMP_MAX=3.0
+# MN_SCENE_MERGE_MIN_DURATION=0
 
 # ── Render ──
 # MN_RENDER_FPS=24
@@ -130,6 +131,9 @@ class Settings(BaseSettings):
     # visual jarring between adjacent narration segments.
     match_speed_clamp_min: float = 0.5
     match_speed_clamp_max: float = 3.0
+    # Merge consecutive scenes shorter than this (0 = disabled).
+    # Reduces extreme speed factors by giving match_clips wider windows.
+    scene_merge_min_duration: float = 0.0
     export_clips_default: bool = True
     # v0.3 multi-language subtitle defaults.
     # Empty/None subtitle_lang = feature off (status.translate=skipped).

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -121,17 +121,15 @@ def _clamp_scene_window(
     clamp_min: float = 0.5,
     clamp_max: float = 3.0,
 ) -> Tuple[float, float]:
-    """Expand or shrink the source window so the speed factor stays within [clamp_min, clamp_max].
+    """Adjust the source window so the speed factor stays within [clamp_min, clamp_max].
 
-    Given a narration segment of *narr_duration* seconds and a matched scene
-    [scene_start, scene_end], compute the speed factor:
+    Speed factor = src_duration / narr_duration.
+    When the factor exceeds clamp_max (fast-forward), the window is shrunk.
+    When it falls below clamp_min (slow-motion), the window is expanded.
+    The window is centered on the original scene midpoint and clamped to
+    [video_start, video_end].
 
-        factor = src_duration / narr_duration
-
-    If factor > clamp_max: the scene is too long → expand by neighbouring frames.
-    If factor < clamp_min: the scene is too short → shrink the window.
-
-    Returns adjusted (src_start, src_end) clamped to [video_start, video_end].
+    Returns adjusted (src_start, src_end).
     """
     src_duration = scene_end - scene_start
     if narr_duration <= 0:
@@ -142,16 +140,13 @@ def _clamp_scene_window(
     if clamp_min <= factor <= clamp_max:
         return scene_start, scene_end
 
-    # Target a duration that gives a factor at the clamp boundary
+    # Target a duration that gives a factor at the clamp boundary.
+    # factor = src_duration / narr_duration:
+    #   factor > clamp_max → src too long (fast-forward) → shrink window
+    #   factor < clamp_min → src too short (slow-mo)   → expand window
     if factor > clamp_max:
-        # Scene too long → we need MORE source footage to slow down
-        # Wait, that's wrong. factor = src/narr. If factor > clamp_max,
-        # src is much longer than narr → video plays too fast (fast-forward).
-        # To reduce factor, we need LESS source footage.
         target_src = narr_duration * clamp_max
     else:
-        # factor < clamp_min → src too short → video plays too slow (slow-mo)
-        # To increase factor, we need MORE source footage.
         target_src = narr_duration * clamp_min
 
     # Center the new window on the original scene midpoint
@@ -202,7 +197,7 @@ def match_clips(ctx: Context) -> Context:
     min_score = ctx.metadata.get("match_min_score", settings.match_min_score)
     clamp_min = ctx.metadata.get("match_speed_clamp_min", settings.match_speed_clamp_min)
     clamp_max = ctx.metadata.get("match_speed_clamp_max", settings.match_speed_clamp_max)
-    merge_min = ctx.metadata.get("scene_merge_min_duration", 0.0)  # 0 = no merge
+    merge_min = ctx.metadata.get("scene_merge_min_duration", settings.scene_merge_min_duration)
     output_dir = Path(ctx.output_dir)
 
     try:

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -69,7 +69,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
     if "params" in data and data["params"] is not None:
         if not isinstance(data["params"], dict):
             raise JobConfigError("params must be a mapping")
-        allowed_params = {"scene_threshold", "scene_frame_skip", "match_min_score", "research_provider", "translate_provider", "translate_retries", "translate_chunk_chars", "translate_chunk_size"}
+        allowed_params = {"scene_threshold", "scene_frame_skip", "match_min_score", "research_provider", "translate_provider", "translate_retries", "translate_chunk_chars", "translate_chunk_size", "match_speed_clamp_min", "match_speed_clamp_max", "scene_merge_min_duration"}
         for k in data["params"].keys():
             if k not in allowed_params:
                 raise JobConfigError(

--- a/tests/test_workflow_steps.py
+++ b/tests/test_workflow_steps.py
@@ -128,6 +128,7 @@ def test_match_min_score_from_metadata(tmp_path, monkeypatch):
         s.match_min_score = 0.01
         s.match_speed_clamp_min = 0.5
         s.match_speed_clamp_max = 3.0
+        s.scene_merge_min_duration = 0.0
         return s
 
     monkeypatch.setattr(match_mod, "get_settings", fake_settings)


### PR DESCRIPTION
## Fixes for PR #9 review issues

1. **`scene_merge_min_duration` added to Settings** — previously only readable via `ctx.metadata`, now has a proper Settings field (default 0.0 = disabled), env var `MN_SCENE_MERGE_MIN_DURATION`, and env template entry. `match.py` reads from settings as fallback.

2. **Workflow params whitelist updated** — `load.py` `allowed_params` now includes `match_speed_clamp_min`, `match_speed_clamp_max`, `scene_merge_min_duration`. Without this, users writing these keys in job YAML `params:` would get `unknown key` error.

3. **`_clamp_scene_window` comments cleaned up** — removed the self-contradicting comment block ("Wait, that's wrong..."). Replaced with clear 2-line summary: `factor > clamp_max → shrink window`, `factor < clamp_min → expand window`.

4. **Test mock updated** — `test_match_min_score_from_metadata` mock now includes `scene_merge_min_duration` field.

## Test results
- 26 passed (test_match + test_workflow_steps + test_cli_config)
- No regressions
