### PR TITLE
feat: auto-discover YAML config + read .env.example for first-run

### DIFF
--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -53,6 +53,7 @@ subtitle_mode: original     # original | translated | bilingual
 # 白名单（其余键会被拒绝）：
 #   scene_threshold / scene_frame_skip / match_min_score
 #   match_speed_clamp_min / match_speed_clamp_max / scene_merge_min_duration
+#   bgm_gain_db / tts_pause_ms / embedding_model_name
 #   research_provider / translate_provider / translate_retries
 #   translate_chunk_chars / translate_chunk_size
 params:
@@ -67,6 +68,11 @@ params:
   match_speed_clamp_min: 0.5    # 最慢速度因子（<1 = 慢放上限）
   match_speed_clamp_max: 3.0    # 最快速度因子（>1 = 快进上限）
   scene_merge_min_duration: 0   # 场景最短时长（秒），0=不合并；设为 3.0 可给 clamp 更大窗口
+  # ---- 音频 ----
+  # bgm_gain_db: -18          # BGM 混音增益（dB），默认 -18
+  # tts_pause_ms: 300         # 解说片段间静音时长（毫秒），默认 300
+  # ---- 匹配模型 ----
+  # embedding_model_name: paraphrase-multilingual-MiniLM-L12-v2
   # ---- 后端选择 ----
   research_provider: llm    # 调研后端（目前仅支持 llm）
   translate_provider: llm   # 翻译后端（目前仅支持 llm）

--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -13,6 +13,9 @@ from .pipeline.runner import build_context, run_pipeline
 
 app = typer.Typer(help="Generate narrated movie recap videos from a single prompt.")
 
+# Packaged example YAML — used as fallback when no --config and no cwd/job.yaml.
+_EXAMPLE_YAML = Path(__file__).resolve().parent.parent.parent / "examples" / "job.example.yaml"
+
 
 class InteractiveCLIController:
     """RunController with interactive retry/skip/abort on hard step failure.
@@ -101,6 +104,8 @@ def create(
             param_hint="--movie",
         )
 
+    # Auto-discover YAML config: explicit --config > job.yaml (cwd) >
+    # job.example.yaml (package examples dir) > none.
     job = None
     config_path = None
     if config is not None:
@@ -110,6 +115,18 @@ def create(
                 f"config not found: {config_path}",
                 param_hint="--config",
             )
+    else:
+        # Try cwd/job.yaml first (user's project-level config).
+        cwd_yaml = Path.cwd() / "job.yaml"
+        if cwd_yaml.is_file():
+            config_path = str(cwd_yaml)
+        else:
+            # Fall back to the packaged example so new users get sensible
+            # defaults without needing to create a YAML manually.
+            if _EXAMPLE_YAML.is_file():
+                config_path = str(_EXAMPLE_YAML)
+
+    if config_path is not None:
         try:
             job = load_job_config(config_path)
         except JobConfigError as e:

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -10,83 +10,36 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 _USER_DIR = Path.home() / ".movie-narrator"
 _USER_ENV = _USER_DIR / ".env"
 
-# Template written to ~/.movie-narrator/.env on first run.
-# Mirrors .env.example — kept inline so it works regardless of install method.
-_DEFAULT_ENV_TEMPLATE = """\
-# ============================================================
-# Movie Narrator — global configuration
-# ============================================================
-# This file was auto-created on first run.  Edit values as needed.
-# Project-level .env (current directory) and MN_* environment
-# variables override entries here.
-# ============================================================
+# Package-level .env.example — single source of truth for default config.
+# At runtime we resolve it relative to this file so it works in editable
+# installs, wheels, and source checkouts alike.
+_PACKAGE_DIR = Path(__file__).resolve().parent          # src/movie_narrator/
+_SRC_DIR = _PACKAGE_DIR.parent                            # src/
+_PROJECT_ROOT = _SRC_DIR.parent                           # movie-narrator/
+_EXAMPLE_ENV = _PROJECT_ROOT / ".env.example"
 
-# ── LLM ──
-MN_LLM_BASE_URL=http://localhost:11434/v1
-MN_LLM_API_KEY=ollama
-MN_LLM_MODEL=qwen2.5:7b
 
-# ── TTS voice (unified, interpreted per-provider) ──
-MN_DEFAULT_VOICE=zh-CN-YunxiNeural
+def _read_example_env() -> str:
+    """Return the contents of ``.env.example``.
 
-# ── Video output ──
-MN_DEFAULT_FORMAT=16:9
-
-# ── TTS provider: edge | openai | mimo ──
-# MN_TTS_PROVIDER=edge
-
-# ── OpenAI TTS (active when MN_TTS_PROVIDER=openai) ──
-# MN_OPENAI_TTS_MODEL=tts-1
-# MN_OPENAI_TTS_API_KEY=           # falls back to MN_LLM_API_KEY
-# MN_OPENAI_TTS_BASE_URL=          # falls back to MN_LLM_BASE_URL
-
-# ── MiMo TTS (active when MN_TTS_PROVIDER=mimo) ──
-# MN_MIMO_TTS_MODEL=mimo-v2.5-tts
-# MN_MIMO_API_KEY=                 # falls back to MN_LLM_API_KEY
-# MN_MIMO_BASE_URL=https://api.xiaomimimo.com/v1
-# MN_MIMO_STYLE_PROMPT=            # style description, mimo-v2.5-tts only
-
-# ── v0.2 optional ──
-# MN_LIBRARY_DIR=
-# MN_DEFAULT_BGM=
-# MN_RESEARCH_ENABLED=false
-# MN_RESEARCH_PROVIDER=llm
-# MN_SCENE_THRESHOLD=27.0
-# MN_SCENE_FRAME_SKIP=10
-# MN_MATCH_MIN_SCORE=0.25
-# MN_EXPORT_CLIPS_DEFAULT=true
-
-# ── v0.3 multi-language subtitles ──
-# MN_SUBTITLE_LANG=                # empty = feature off
-# MN_SUBTITLE_MODE=original
-# MN_TRANSLATE_PROVIDER=llm
-# MN_TRANSLATE_RETRIES=3
-# MN_TRANSLATE_CHUNK_CHARS=4000
-# MN_TRANSLATE_CHUNK_SIZE=20
-
-# ── Match ──
-# MN_TTS_CACHE_MAX_MB=500
-# MN_TTS_PAUSE_MS=300
-
-# ── BGM ──
-# MN_BGM_GAIN_DB=-18
-
-# ── Match ──
-# MN_MATCH_SPEED_CLAMP_MIN=0.5
-# MN_MATCH_SPEED_CLAMP_MAX=3.0
-# MN_SCENE_MERGE_MIN_DURATION=0
-# MN_EMBEDDING_MODEL_NAME=paraphrase-multilingual-MiniLM-L12-v2
-
-# ── Render ──
-# MN_RENDER_FPS=24
-# MN_RENDER_VIDEO_CODEC=libx264
-# MN_RENDER_AUDIO_CODEC=aac
-# MN_RENDER_THREADS=4
-"""
+    Falls back to a minimal inline template if the file is missing
+    (e.g. some packaging configurations strip it).
+    """
+    if _EXAMPLE_ENV.is_file():
+        return _EXAMPLE_ENV.read_text(encoding="utf-8")
+    # Minimal fallback — kept short to avoid drift with .env.example.
+    return (
+        "# Movie Narrator — auto-generated minimal config\n"
+        "MN_LLM_BASE_URL=http://localhost:11434/v1\n"
+        "MN_LLM_API_KEY=ollama\n"
+        "MN_LLM_MODEL=qwen2.5:7b\n"
+        "MN_DEFAULT_VOICE=zh-CN-YunxiNeural\n"
+        "MN_DEFAULT_FORMAT=16:9\n"
+    )
 
 
 def ensure_user_config() -> Path:
-    """Create ``~/.movie-narrator/.env`` from defaults if it does not exist.
+    """Create ``~/.movie-narrator/.env`` from ``.env.example`` if it does not exist.
 
     Returns the path to the user-level .env (existing or newly created).
     Safe to call multiple times — never overwrites an existing file.
@@ -102,7 +55,7 @@ def ensure_user_config() -> Path:
         fd, tmp_path = tempfile.mkstemp(dir=_USER_DIR, suffix=".env.tmp")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(_DEFAULT_ENV_TEMPLATE)
+                f.write(_read_example_env())
             os.replace(tmp_path, _USER_ENV)  # atomic on same filesystem
         except BaseException:
             try:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -128,6 +128,9 @@ def test_create_passes_workflow_steps_and_params(tmp_path, monkeypatch):
 
 def test_create_no_config_backward_compatible_kwargs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    # Suppress auto-discovery of the packaged job.example.yaml so this test
+    # verifies the pure-CLI path (no YAML at all).
+    monkeypatch.setattr("movie_narrator.cli._EXAMPLE_YAML", tmp_path / "nonexistent.yaml")
     bc, rp = _patch_pipeline(tmp_path)
     with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
         result = runner.invoke(app, ["create", "--movie", "OnlyCLI", "--duration", "12"])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from movie_narrator.config import Settings, ensure_user_config, _DEFAULT_ENV_TEMPLATE
+from movie_narrator.config import Settings, ensure_user_config, _read_example_env
 from movie_narrator.utils.environment import collect_environment
 
 


### PR DESCRIPTION
## Summary

Two improvements to the config loading chain for better new-user experience:

### 1. ENV: Read `.env.example` as single source of truth

`ensure_user_config()` previously used a 70-line inline `_DEFAULT_ENV_TEMPLATE` that diverged from the actual `.env.example` file. Now it reads `.env.example` directly, with a minimal 6-line fallback for packaged wheels where `.env.example` might be stripped.

**Before**: Two separate copies of default config (inline template + `.env.example`), constantly drifting.
**After**: `.env.example` is the single source of truth. First run copies it to `~/.movie-narrator/.env`.

### 2. YAML: Auto-discover config file

`cli.py` now auto-discovers YAML config in priority order:
1. Explicit `--config path` (if provided)
2. `cwd/job.yaml` (project-level user config)
3. Packaged `examples/job.example.yaml` (sensible defaults for new users)
4. None (pure CLI args only)

**Before**: No `--config` = no YAML at all. New users had to create a YAML manually or pass everything via CLI.
**After**: New users can run `mn create --movie X` without any config file — the example YAML provides default steps/params.

### Additional changes
- `examples/job.example.yaml`: added `bgm_gain_db`, `tts_pause_ms`, `embedding_model_name` to params section
- `test_settings.py`: import `_read_example_env` instead of removed `_DEFAULT_ENV_TEMPLATE`
- `test_cli_config.py`: monkeypatch `_EXAMPLE_YAML` to suppress auto-discovery in backward-compat test

## Test results
- 46 passed (test_settings + test_match + test_workflow_steps + test_cli_config + test_workflow_merge)
