### PR TITLE
fix: connect disconnected config + promote LLM params to Settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,16 @@ MN_LLM_BASE_URL=http://localhost:11434/v1
 MN_LLM_API_KEY=ollama
 MN_LLM_MODEL=qwen2.5:7b
 
+# LLM call tuning (optional)
+# MN_LLM_TIMEOUT=60                # httpx client timeout (seconds)
+# MN_SCRIPT_TEMPERATURE=0.7        # script generation temperature
+# MN_SCRIPT_MAX_TOKENS=2048        # script generation max_tokens
+# MN_SCRIPT_RETRIES=3              # script generation retry attempts
+# MN_SCRIPT_RETRY_DELAY=1.5        # delay between retries (seconds)
+# MN_RESEARCH_TEMPERATURE=0.3      # research temperature
+# MN_RESEARCH_MAX_TOKENS=1024      # research max_tokens
+# MN_TRANSLATE_MAX_TOKENS=4096     # translation max_tokens
+
 # ============================================================
 # TTS — narration voice synthesis
 # ============================================================

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -76,6 +76,15 @@ class Settings(BaseSettings):
     llm_base_url: str = "http://localhost:11434/v1"
     llm_api_key: str = "ollama"
     llm_model: str = "qwen2.5:7b"
+    # ── LLM call tuning ──
+    llm_timeout: int = 60                    # httpx client timeout (seconds)
+    script_temperature: float = 0.7          # script generation LLM temperature
+    script_max_tokens: int = 2048            # script generation LLM max_tokens
+    script_retries: int = 3                  # script generation retry attempts
+    script_retry_delay: float = 1.5          # delay between retries (seconds)
+    research_temperature: float = 0.3        # research LLM temperature
+    research_max_tokens: int = 1024          # research LLM max_tokens
+    translate_max_tokens: int = 4096         # translation LLM max_tokens
     default_voice: str = "zh-CN-YunxiNeural"
     default_format: str = "16:9"
     # v0.2 optional

--- a/src/movie_narrator/pipeline/export_clips.py
+++ b/src/movie_narrator/pipeline/export_clips.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from tqdm import tqdm
 
+from ..config import get_settings
 from ..models import Context, StepResult
 from ..utils.optional_deps import probe
 from ..utils.warnings import append_warning
@@ -44,6 +45,7 @@ def export_clips(ctx: Context) -> Context:
     clips_dir = output_dir / "clips"
     clips_dir.mkdir(parents=True, exist_ok=True)
 
+    settings = get_settings()
     failed = 0
     for scene in tqdm(ctx.scenes, desc="Exporting clips", unit="clip"):
         try:
@@ -56,8 +58,8 @@ def export_clips(ctx: Context) -> Context:
                 "-ss", str(scene.start),
                 "-to", str(scene.end),
                 "-i", ctx.source_video_path,
-                "-c:v", "libx264",
-                "-c:a", "aac",
+                "-c:v", settings.render_video_codec,
+                "-c:a", settings.render_audio_codec,
                 "-movflags", "+faststart",
                 str(clip_path),
             ]

--- a/src/movie_narrator/pipeline/research.py
+++ b/src/movie_narrator/pipeline/research.py
@@ -53,13 +53,14 @@ def research_plot(ctx: Context) -> Context:
         return ctx
 
     try:
+        settings = get_settings()
         with get_llm_client() as llm:
             prompt = RESEARCH_PROMPT.format(movie=ctx.movie_name)
             response = llm.client.chat.completions.create(
                 model=llm.model,
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.3,
-                max_tokens=1024,
+                temperature=settings.research_temperature,
+                max_tokens=settings.research_max_tokens,
             )
             raw = response.choices[0].message.content or ""
             data = extract_json(raw)

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -172,6 +172,8 @@ def build_context(
             "scene_threshold", "match_min_score", "research_provider",
             "match_speed_clamp_min", "match_speed_clamp_max",
             "scene_merge_min_duration",
+            "translate_chunk_chars", "translate_chunk_size",
+            "bgm_gain_db", "tts_pause_ms", "embedding_model_name",
         ):
             if key in params and params[key] is not None:
                 ctx.metadata[key] = params[key]

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -1,3 +1,4 @@
+from ..config import get_settings
 from ..models import Context, ScriptSegment
 from ..utils.prompts import SCRIPT_PROMPT
 from ..utils.llm import get_llm_client
@@ -13,7 +14,8 @@ MOCK_SEGMENTS = [
 
 
 def generate_script(ctx: Context) -> Context:
-    for attempt in range(3):
+    settings = get_settings()
+    for attempt in range(settings.script_retries):
         try:
             with get_llm_client() as llm:
 
@@ -30,8 +32,8 @@ def generate_script(ctx: Context) -> Context:
                 response = llm.client.chat.completions.create(
                     model=llm.model,
                     messages=[{"role": "user", "content": prompt}],
-                    temperature=0.7,
-                    max_tokens=2048,
+                    temperature=settings.script_temperature,
+                    max_tokens=settings.script_max_tokens,
                 )
                 raw = response.choices[0].message.content or ""
                 data = extract_json(raw)
@@ -48,8 +50,8 @@ def generate_script(ctx: Context) -> Context:
                 ctx.metadata["script_source"] = "llm"
                 return ctx
         except Exception as e:
-            if attempt == 2:
-                ctx.services.console.inline_warn(f"LLM fallback (3 attempts failed): {e}")
+            if attempt == settings.script_retries - 1:
+                ctx.services.console.inline_warn(f"LLM fallback ({settings.script_retries} attempts failed): {e}")
                 ctx.segments = [
                     ScriptSegment(text=s.format(movie_name=ctx.movie_name))
                     for s in MOCK_SEGMENTS
@@ -57,5 +59,5 @@ def generate_script(ctx: Context) -> Context:
                 ctx.metadata["script_source"] = "mock"
                 ctx.metadata["script_degraded"] = True
                 return ctx
-            sleep(1.5)
+            sleep(settings.script_retry_delay)
     return ctx

--- a/src/movie_narrator/pipeline/translate.py
+++ b/src/movie_narrator/pipeline/translate.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Sequence
 
 from tqdm import tqdm
 
+from ..config import get_settings
 from ..models import Context, StepResult
 from ..utils.json_parser import extract_json
 from ..utils.llm import get_llm_client
@@ -109,7 +110,7 @@ def _call_llm_chunk(
         resp = llm.client.chat.completions.create(
             model=llm.model,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=4096,
+            max_tokens=get_settings().translate_max_tokens,
         )
     raw = (resp.choices[0].message.content or "").strip()
     parsed = extract_json(raw)
@@ -136,6 +137,8 @@ def _translate_via_llm(
     target_lang: str,
     source_lang: str,
     retries: int,
+    max_chars: int = DEFAULT_CHUNK_CHARS,
+    max_items: int = DEFAULT_CHUNK_SIZE,
     llm_factory=None,
 ) -> List[str]:
     """Translate via the LLM provider, chunked, with per-chunk retry.
@@ -145,9 +148,6 @@ def _translate_via_llm(
 
     ``llm_factory`` is forwarded to ``_call_llm_chunk`` for test injection.
     """
-    max_chars = DEFAULT_CHUNK_CHARS
-    max_items = DEFAULT_CHUNK_SIZE
-
     chunks = _chunk_texts(texts, max_chars=max_chars, max_items=max_items)
     result: List[Optional[str]] = [None] * len(texts)
 
@@ -234,7 +234,10 @@ def translate_subtitles(ctx: Context) -> Context:
         ctx.step_state.message = "ci-passthrough"
         return ctx
 
-    retries = int(ctx.metadata.get("translate_retries", 3))
+    retries = int(ctx.metadata.get("translate_retries", get_settings().translate_retries))
+    settings = get_settings()
+    max_chars = int(ctx.metadata.get("translate_chunk_chars", settings.translate_chunk_chars))
+    max_items = int(ctx.metadata.get("translate_chunk_size", settings.translate_chunk_size))
 
     try:
         ctx.translated_texts = _translate_via_llm(
@@ -242,6 +245,8 @@ def translate_subtitles(ctx: Context) -> Context:
             target_lang=target_lang,
             source_lang=source_lang,
             retries=retries,
+            max_chars=max_chars,
+            max_items=max_items,
         )
     except _ChunkFailure as cf:
         # At least one chunk failed after retries. Fill failed slots

--- a/src/movie_narrator/utils/llm.py
+++ b/src/movie_narrator/utils/llm.py
@@ -17,7 +17,7 @@ class LLMClient:
 def get_llm_client():
     """Yield an LLMClient backed by a managed httpx.Client (closed on exit)."""
     settings = get_settings()
-    http_client = httpx.Client(timeout=60)
+    http_client = httpx.Client(timeout=settings.llm_timeout)
     try:
         client = OpenAI(
             base_url=settings.llm_base_url,


### PR DESCRIPTION
## Fixes

### 1. translate.py chunk params not connected to Settings (bug)

Settings had `translate_chunk_chars` and `translate_chunk_size`, YAML whitelist allowed them, but they were never copied to `ctx.metadata` and `_translate_via_llm` used hardcoded module constants. **User config was silently ignored.**

- `runner.py`: params copy loop now includes `translate_chunk_chars`, `translate_chunk_size`, `bgm_gain_db`, `tts_pause_ms`, `embedding_model_name`
- `translate.py`: `_translate_via_llm` accepts `max_chars`/`max_items` params; `translate_subtitles` reads from `ctx.metadata` with Settings fallback
- `translate_retries` fallback now uses `Settings.translate_retries` instead of hardcoded `3`

### 2. export_clips.py codecs hardcoded

`"libx264"` and `"aac"` were hardcoded in ffmpeg command, ignoring `Settings.render_video_codec` / `render_audio_codec`. Now uses Settings values.

### 3. LLM call params promoted to Settings

| Setting | Env var | Default | Old location |
|---------|---------|---------|-------------|
| `llm_timeout` | `MN_LLM_TIMEOUT` | 60 | `utils/llm.py:20` hardcoded |
| `script_temperature` | `MN_SCRIPT_TEMPERATURE` | 0.7 | `script.py:33` hardcoded |
| `script_max_tokens` | `MN_SCRIPT_MAX_TOKENS` | 2048 | `script.py:34` hardcoded |
| `script_retries` | `MN_SCRIPT_RETRIES` | 3 | `script.py:16` hardcoded |
| `script_retry_delay` | `MN_SCRIPT_RETRY_DELAY` | 1.5 | `script.py:60` hardcoded |
| `research_temperature` | `MN_RESEARCH_TEMPERATURE` | 0.3 | `research.py:61` hardcoded |
| `research_max_tokens` | `MN_RESEARCH_MAX_TOKENS` | 1024 | `research.py:62` hardcoded |
| `translate_max_tokens` | `MN_TRANSLATE_MAX_TOKENS` | 4096 | `translate.py:112` hardcoded |

## Test results
- 273 passed, 2 pre-existing env failures (user .env sets MN_TTS_PROVIDER=mimo)
