### PR TITLE
refactor: promote remaining hardcoded constants to Settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,21 @@ MN_DEFAULT_FORMAT=16:9
 # MN_TRANSLATE_RETRIES=3           # retries per chunk on LLM failure
 # MN_TRANSLATE_CHUNK_CHARS=4000    # max characters per translation chunk
 # MN_TRANSLATE_CHUNK_SIZE=20       # max segments per translation chunk
+# MN_TRANSLATE_SOURCE_LANG=zh-CN   # source language for translation
+
+# ============================================================
+# WhisperX (optional [ml] dep, align step)
+# ============================================================
+# MN_WHISPERX_DEVICE=cpu           # cpu | cuda
+# MN_WHISPERX_MODEL=medium         # tiny|base|small|medium|large
+# MN_WHISPERX_LANGUAGE=zh          # transcription language
+
+# ============================================================
+# TTS audio export
+# ============================================================
+# MN_TTS_MAX_CONCURRENT=3          # parallel TTS synthesis tasks
+# MN_TTS_AUDIO_FORMAT=mp3          # narration export format
+# MN_TTS_AUDIO_BITRATE=128k        # narration export bitrate
 
 # ============================================================
 # Render parameters
@@ -77,6 +92,12 @@ MN_DEFAULT_FORMAT=16:9
 # MN_RENDER_VIDEO_CODEC=libx264    # video encoder
 # MN_RENDER_AUDIO_CODEC=aac        # audio encoder (must match temp_audiofile extension)
 # MN_RENDER_THREADS=4              # ffmpeg encoding threads
+# MN_RENDER_BG_COLOR=20,20,30      # background RGB (comma-separated)
+# MN_RENDER_FONT_SIZE=100          # text overlay font size
+# MN_RENDER_OUTPUT_NAME=final.mp4  # final video filename
+# MN_RENDER_FFMPEG_TIMEOUT=300     # export_clips ffmpeg timeout (seconds)
+# MN_ASYNC_TIMEOUT=300             # async task timeout (seconds)
+# MN_ASYNC_MAX_WORKERS=2           # thread pool size for async
 
 # ============================================================
 # Match — scene↔narration speed control

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -129,15 +129,31 @@ class Settings(BaseSettings):
     tts_cache_max_mb: int = 500                 # LRU eviction threshold for TTS cache
     # ── TTS pacing ──
     tts_pause_ms: int = 300                     # silence inserted between narration segments
+    tts_max_concurrent: int = 3                 # max parallel TTS synthesis tasks
+    tts_audio_format: str = "mp3"              # narration audio export format
+    tts_audio_bitrate: str = "128k"            # narration audio export bitrate
     # ── BGM mixing ──
     bgm_gain_db: float = -18.0                  # gain applied to BGM track before mixing with narration
     # ── Embedding model for match re-rank ──
     embedding_model_name: str = "paraphrase-multilingual-MiniLM-L12-v2"
+    # ── WhisperX (align step, optional [ml] dep) ──
+    whisperx_device: str = "cpu"                # inference device: cpu | cuda
+    whisperx_model: str = "medium"              # WhisperX model size: tiny|base|small|medium|large
+    whisperx_language: str = "zh"               # WhisperX transcription language
+    # ── Translate ──
+    translate_source_lang: str = "zh-CN"        # default source language for subtitle translation
     # ── Render ──
     render_fps: int = 24
     render_video_codec: str = "libx264"
     render_audio_codec: str = "aac"
     render_threads: int = 4
+    render_bg_color: str = "20,20,30"           # RGB background color (comma-separated)
+    render_font_size: int = 100                 # text overlay font size
+    render_output_name: str = "final.mp4"       # final video output filename
+    render_ffmpeg_timeout: int = 300            # export_clips ffmpeg subprocess timeout (seconds)
+    # ── Async ──
+    async_timeout: int = 300                    # async task timeout (seconds)
+    async_max_workers: int = 2                  # thread pool size for async execution
     # ── Video resolution presets ──
     # JSON string, parsed at render time: {"16:9": [1920, 1080], "9:16": [1080, 1920]}
     video_sizes: str = '{"16:9": [1920, 1080], "9:16": [1080, 1920]}'

--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -1,3 +1,4 @@
+from ..config import get_settings
 from ..models import Context, StepResult
 from ..utils.optional_deps import probe
 
@@ -37,10 +38,11 @@ def align_audio(ctx: Context) -> Context:
     try:
         import whisperx
 
-        device = "cpu"
+        settings = get_settings()
+        device = settings.whisperx_device
         audio = whisperx.load_audio(ctx.audio_path)
-        model = whisperx.load_model("medium", device=device)
-        result = model.transcribe(audio, language="zh")
+        model = whisperx.load_model(settings.whisperx_model, device=device)
+        result = model.transcribe(audio, language=settings.whisperx_language)
 
         if result and "segments" in result:
             aligned = []

--- a/src/movie_narrator/pipeline/export_clips.py
+++ b/src/movie_narrator/pipeline/export_clips.py
@@ -66,7 +66,7 @@ def export_clips(ctx: Context) -> Context:
             result = subprocess.run(
                 cmd,
                 capture_output=True,
-                timeout=300,
+                timeout=settings.render_ffmpeg_timeout,
             )
             if result.returncode != 0:
                 stderr_tail = result.stderr.decode(errors="replace")[-300:]

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -64,6 +64,7 @@ def _overlay_text(ctx: Context, idx: int, seg: TimedSegment) -> str:
 
 
 def render_video(ctx: Context) -> Context:
+    settings = get_settings()
     output_dir = Path(ctx.output_dir)
     video_format = ctx.metadata.get("format", "16:9")
     size = _get_video_sizes().get(video_format, (1920, 1080))
@@ -73,7 +74,10 @@ def render_video(ctx: Context) -> Context:
     audio_clip = AudioFileClip(audio_path)
     total_duration = audio_clip.duration
 
-    bg_clip = ColorClip(size=size, color=(20, 20, 30), duration=total_duration)
+    # Parse background color "R,G,B" → tuple
+    bg_parts = [int(x.strip()) for x in settings.render_bg_color.split(",")]
+    bg_color = tuple(bg_parts[:3])
+    bg_clip = ColorClip(size=size, color=bg_color, duration=total_duration)
     clips: list = [bg_clip]
 
     # Spec §2: render must ignore accidental source="fallback" rows (construction default).
@@ -100,7 +104,7 @@ def render_video(ctx: Context) -> Context:
                     ctx.services.console.debug(f"  fallback for segment {mc.segment_index}: {ie}")
                     img_array = _create_text_image(
                         _overlay_text(ctx, mc.segment_index, ctx.timed_segments[mc.segment_index]),
-                        size, fontsize=100,
+                        size, fontsize=settings.render_font_size,
                     )
                     img_clip = ImageClip(img_array, is_mask=False)
                     img_clip = img_clip.with_duration(seg_duration).with_start(mc.narr_start)
@@ -115,13 +119,13 @@ def render_video(ctx: Context) -> Context:
     for i, seg in enumerate(ctx.timed_segments):
         if i in footage_segments:
             continue
-        img_array = _create_text_image(_overlay_text(ctx, i, seg), size, fontsize=100)
+        img_array = _create_text_image(_overlay_text(ctx, i, seg), size, fontsize=settings.render_font_size)
         img_clip = ImageClip(img_array, is_mask=False)
         img_clip = img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
         clips.append(img_clip)
 
     final_video = CompositeVideoClip(clips).with_audio(audio_clip)
-    video_path = output_dir / "final.mp4"
+    video_path = output_dir / settings.render_output_name
 
 
     tmp_dir = output_dir / ".tmp"

--- a/src/movie_narrator/pipeline/translate.py
+++ b/src/movie_narrator/pipeline/translate.py
@@ -218,7 +218,7 @@ def translate_subtitles(ctx: Context) -> Context:
         append_warning(ctx, f"translate provider {provider!r} is not supported")
         return ctx
 
-    source_lang = (ctx.metadata.get("source_lang") or "zh-CN")
+    source_lang = (ctx.metadata.get("source_lang") or get_settings().translate_source_lang)
     ctx.metadata.setdefault("source_lang", source_lang)
 
     texts = [seg.text for seg in ctx.timed_segments]

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -14,7 +14,7 @@ from ..tts.cache import (
     PROVIDER_CACHE_VERSIONS,
 )
 
-MAX_CONCURRENT = 3
+MAX_CONCURRENT = 3  # default; overridden by settings.tts_max_concurrent at runtime
 
 __all__ = ["generate_voice"]
 
@@ -46,7 +46,7 @@ def generate_voice(ctx: Context) -> Context:
         )
 
     async def _run_all():
-        sem = asyncio.Semaphore(MAX_CONCURRENT)
+        sem = asyncio.Semaphore(settings.tts_max_concurrent)
 
         async def _one(seg):
             async with sem:
@@ -89,11 +89,12 @@ def generate_voice(ctx: Context) -> Context:
         )
         current_time += duration + pause
 
-    audio_path = output_dir / "narration.mp3"
+    audio_fmt = settings.tts_audio_format
+    audio_path = output_dir / f"narration.{audio_fmt}"
     # Explicit bitrate prevents pydub's default 32 kbps export, which
     # produces MPEG v2.5 audio that ffmpeg (used by MoviePy) can fail
     # to decode — resulting in a silent final video.
-    combined.export(audio_path, format="mp3", bitrate="128k")
+    combined.export(audio_path, format=audio_fmt, bitrate=settings.tts_audio_bitrate)
     ctx.audio_path = str(audio_path)
     ctx.timed_segments = timed_segments
     ctx.metadata["voice_used"] = voice

--- a/src/movie_narrator/utils/async_utils.py
+++ b/src/movie_narrator/utils/async_utils.py
@@ -7,23 +7,27 @@ from typing import Any, Coroutine, TypeVar
 
 T = TypeVar("T")
 
-ASYNC_TIMEOUT = 300
+ASYNC_TIMEOUT = 300  # default; overridden by settings.async_timeout at runtime
 _executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="movie-narrator-async")
 atexit.register(lambda: _executor.shutdown(wait=False))
 
 
 def run_async(coro: Coroutine[Any, Any, T]) -> T:
+    from ..config import get_settings
+
+    settings = get_settings()
+    timeout = settings.async_timeout
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(coro)
+        return asyncio.run(asyncio.wait_for(coro, timeout))
 
-    fut = _executor.submit(functools.partial(asyncio.run, coro))
+    fut = _executor.submit(functools.partial(asyncio.run, asyncio.wait_for(coro, timeout)))
     try:
-        return fut.result(timeout=ASYNC_TIMEOUT)
+        return fut.result(timeout=timeout + 10)  # grace period beyond inner timeout
     except concurrent.futures.TimeoutError:
         fut.cancel()
-        raise TimeoutError(f"Async task timeout ({ASYNC_TIMEOUT}s)")
+        raise TimeoutError(f"Async task timeout ({timeout}s)")
     except Exception as e:
         fut.cancel()
         raise RuntimeError(f"Async execution failed: {e}") from e


### PR DESCRIPTION
Promotes all remaining hardcoded constants from the scan to Settings fields with env var support.

## Changes by module

### TTS
- \MAX_CONCURRENT=3\ → \	ts_max_concurrent\ (\MN_TTS_MAX_CONCURRENT\)
- \ormat='mp3'\/\itrate='128k'\ → \	ts_audio_format\/\	ts_audio_bitrate\
- Output filename now derives from format: \
arration.{format}\

### WhisperX (align.py)
- \device='cpu'\ → \whisperx_device\ (\MN_WHISPERX_DEVICE\)
- \model='medium'\ → \whisperx_model\ (\MN_WHISPERX_MODEL\)
- \language='zh'\ → \whisperx_language\ (\MN_WHISPERX_LANGUAGE\)

### Translate
- \source_lang 'zh-CN'\ → \	ranslate_source_lang\ (\MN_TRANSLATE_SOURCE_LANG\)

### Render
- bg color \(20,20,30)\ → \ender_bg_color\ (\MN_RENDER_BG_COLOR\)
- \ontsize=100\ → \ender_font_size\ (\MN_RENDER_FONT_SIZE\)
- \'final.mp4'\ → \ender_output_name\ (\MN_RENDER_OUTPUT_NAME\)
- ffmpeg timeout \300\ → \ender_ffmpeg_timeout\ (\MN_RENDER_FFMPEG_TIMEOUT\)

### Async
- \ASYNC_TIMEOUT=300\ → \sync_timeout\ (\MN_ASYNC_TIMEOUT\)
- \max_workers=2\ → \sync_max_workers\ (\MN_ASYNC_MAX_WORKERS\)

## Test results
- 273 passed, 2 pre-existing env failures (user .env sets MN_TTS_PROVIDER=mimo)