### PR TITLE
fix: add 5 missing .env.example entries + scene_frame_skip in runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,9 +81,18 @@ MN_DEFAULT_FORMAT=16:9
 # ============================================================
 # TTS audio export
 # ============================================================
+# MN_TTS_CACHE_MAX_MB=500          # LRU eviction threshold for TTS cache
+# MN_TTS_PAUSE_MS=300             # silence between narration segments (ms)
 # MN_TTS_MAX_CONCURRENT=3          # parallel TTS synthesis tasks
 # MN_TTS_AUDIO_FORMAT=mp3          # narration export format
 # MN_TTS_AUDIO_BITRATE=128k        # narration export bitrate
+
+# ============================================================
+# BGM / Embedding / Video sizes
+# ============================================================
+# MN_BGM_GAIN_DB=-18               # BGM mixing gain (dB)
+# MN_EMBEDDING_MODEL_NAME=paraphrase-multilingual-MiniLM-L12-v2
+# MN_VIDEO_SIZES={"16:9": [1920, 1080], "9:16": [1080, 1920]}
 
 # ============================================================
 # Render parameters

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -169,7 +169,7 @@ def build_context(
         ctx.metadata["workflow_steps"] = dict(workflow_steps)
     if params:
         for key in (
-            "scene_threshold", "match_min_score", "research_provider",
+            "scene_threshold", "scene_frame_skip", "match_min_score", "research_provider",
             "match_speed_clamp_min", "match_speed_clamp_max",
             "scene_merge_min_duration",
             "translate_chunk_chars", "translate_chunk_size",


### PR DESCRIPTION
Audit found 2 issues after PR #15:

## 1. .env.example missing 5 Settings fields

Lost during PR #15 reorganization. Added:
- \MN_TTS_CACHE_MAX_MB\ (TTS cache LRU threshold)
- \MN_TTS_PAUSE_MS\ (silence between narration segments)
- \MN_BGM_GAIN_DB\ (BGM mixing gain)
- \MN_EMBEDDING_MODEL_NAME\ (match re-rank model)
- \MN_VIDEO_SIZES\ (JSON resolution presets)

**Verified**: 60 Settings fields = 60 .env.example keys (perfect match).

## 2. runner.py params copy loop missing scene_frame_skip

YAML \params.scene_frame_skip\ was parsed by \load.py\ and copied by \merge.py\, but \unner.py build_context\ never copied it to \ctx.metadata\. \scenes.py\ fell back to Settings default (10), silently ignoring the user's YAML value.

**Fixed**: Added \scene_frame_skip\ to the copy loop.

**Verified**: 14 JobParams fields all covered in runner (12 in copy loop + 2 handled separately in metadata init).

## Test results
- 75 passed