### PR TITLE
docs: sync all documentation with v0.4.7 config system changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added (v0.4.7 — config system overhaul)
+- 33 hardcoded constants promoted to configurable Settings fields with `MN_*` env var support:
+  - LLM call tuning: `llm_timeout`, `script_temperature`, `script_max_tokens`, `script_retries`, `script_retry_delay`, `research_temperature`, `research_max_tokens`, `translate_max_tokens`
+  - TTS: `tts_max_concurrent`, `tts_audio_format`, `tts_audio_bitrate`
+  - WhisperX: `whisperx_device`, `whisperx_model`, `whisperx_language`
+  - Translate: `translate_source_lang`
+  - Render: `render_bg_color`, `render_font_size`, `render_output_name`, `render_ffmpeg_timeout`
+  - Async: `async_timeout`, `async_max_workers`
+  - Match: `embedding_model_name`, `match_speed_clamp_min`, `match_speed_clamp_max`, `scene_merge_min_duration`
+  - BGM: `bgm_gain_db`
+  - TTS pacing: `tts_pause_ms`
+  - Video: `video_sizes` (JSON string)
+- YAML config auto-discovery: `--config` not passed → `cwd/job.yaml` → packaged `examples/job.example.yaml` → none. New users can run `mn create --movie X` without creating any config file
+- `ensure_user_config()` now reads `.env.example` as single source of truth (was divergent inline template)
+- `examples/job.example.yaml` updated with all 14 whitelisted params + inline comments
+
+### Fixed (v0.4.7)
+- `translate_chunk_chars` / `translate_chunk_size` were in Settings + YAML whitelist but never copied to `ctx.metadata` by `build_context`; `_translate_via_llm` used hardcoded module constants. User YAML config was silently ignored — now properly connected
+- `export_clips.py` hardcoded `libx264` / `aac` codecs instead of using `settings.render_video_codec` / `render_audio_codec`
+- `scene_frame_skip` missing from `runner.py` params copy loop — YAML value silently ignored, always fell back to Settings default
+- `.env.example` missing 5 Settings fields (lost during reorg): `MN_TTS_CACHE_MAX_MB`, `MN_TTS_PAUSE_MS`, `MN_BGM_GAIN_DB`, `MN_EMBEDDING_MODEL_NAME`, `MN_VIDEO_SIZES`
+- `JobParams` model (uses `extra="forbid"`) missing 3 fields added to `load.py` whitelist — would cause `AttributeError` when accessed
+- `_match_clips_impl` referenced undefined `settings` variable — now uses `get_settings()`
+
+### Changed (v0.4.7)
+- `.env.example` verified: 60 Settings fields = 60 `MN_*` env vars (perfect match)
+- `runner.py` params copy loop now includes all 12 parametric fields (2 others handled separately in metadata init)
+- `merge.py` `_STYLE/DURATION/FORMAT_DEFAULT` documented as typer sentinels (not user-configurable Settings)
+
 ## [0.4.6] - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -168,7 +168,14 @@ mn create --config examples/job.example.yaml
 mn create --config examples/job.example.yaml --movie "OtherTitle" --no-clips
 ```
 
-See [`examples/job.example.yaml`](examples/job.example.yaml) for the full whitelist: soft-step toggles under `steps:` (`research`, `align`, `scene`, `match`, `bgm`, `export`, `translate`), `params:` (`scene_threshold`, `match_min_score`, `research_provider`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`), and the multi-language subtitle top-level keys `subtitle_lang` / `subtitle_mode`. Relative `video` / `bgm` / `library_dir` paths resolve against the YAML file's directory. LLM credentials stay in `.env` / `MN_*` only.
+When `--config` is not passed, the CLI auto-discovers a YAML config in priority order:
+1. `cwd/job.yaml` (project-level user config)
+2. Packaged `examples/job.example.yaml` (sensible defaults for new users)
+3. None (pure CLI args)
+
+This means new users can run `mn create --movie X` without creating any config file — the example YAML provides default steps/params automatically.
+
+See [`examples/job.example.yaml`](examples/job.example.yaml) for the full whitelist: soft-step toggles under `steps:` (`research`, `align`, `scene`, `match`, `bgm`, `export`, `translate`), all 14 `params:` keys (`scene_threshold`, `scene_frame_skip`, `match_min_score`, `match_speed_clamp_min`, `match_speed_clamp_max`, `scene_merge_min_duration`, `bgm_gain_db`, `tts_pause_ms`, `embedding_model_name`, `research_provider`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`), and the multi-language subtitle top-level keys `subtitle_lang` / `subtitle_mode`. Relative `video` / `bgm` / `library_dir` paths resolve against the YAML file's directory. LLM credentials stay in `.env` / `MN_*` only.
 
 ### Multi-language subtitles
 
@@ -275,7 +282,7 @@ mn create --movie "飞驰人生" --duration 60
 
 ### Full reference
 
-See [`.env.example`](.env.example) for the complete list of all 27 environment variables with defaults and inline comments.
+See [`.env.example`](.env.example) for the complete list of all 60 environment variables with defaults and inline comments.
 
 ### LLM Provider Guides
 
@@ -487,6 +494,7 @@ movie-narrator/
 - [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
 - [x] Auto-create `~/.movie-narrator/.env` on first run
 - [x] `export_clips` direct ffmpeg subprocess (design choice, not workaround)
+- [x] Config system overhaul: 33 hardcoded constants promoted to Settings (60 total `MN_*` env vars); YAML auto-discovery (`--config` not passed → `cwd/job.yaml` → packaged example); `.env.example` as single source of truth for first-run; all YAML params properly connected through `runner.py` → `ctx.metadata` → pipeline steps
 
 ### v0.5.x — Ecosystem (Planned)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,7 +166,14 @@ mn create --config examples/job.example.yaml
 mn create --config examples/job.example.yaml --movie "其他电影" --no-clips
 ```
 
-详细白名单请参考 [`examples/job.example.yaml`](examples/job.example.yaml)：软步骤开关（`steps:` 下的 `research` / `align` / `scene` / `match` / `bgm` / `export` / `translate`）、参数（`params:` 下的 `scene_threshold` / `match_min_score` / `research_provider` / `translate_provider` / `translate_retries` / `translate_chunk_chars` / `translate_chunk_size`），以及多语言字幕顶层键 `subtitle_lang` / `subtitle_mode`。相对路径 `video` / `bgm` / `library_dir` 相对于 YAML 所在目录解析。LLM 凭据请保留在 `.env` / `MN_*` 环境变量中。
+未传 `--config` 时，CLI 按以下优先级自动发现 YAML 配置：
+1. `cwd/job.yaml`（项目级用户配置）
+2. 打包的 `examples/job.example.yaml`（新用户默认值）
+3. 无（纯 CLI 参数）
+
+这意味着新用户可以直接 `mn create --movie X` 而无需创建任何配置文件——示例 YAML 会自动提供默认的 steps/params。
+
+详细白名单请参考 [`examples/job.example.yaml`](examples/job.example.yaml)：软步骤开关（`steps:` 下的 `research` / `align` / `scene` / `match` / `bgm` / `export` / `translate`）、全部 14 个 `params:` 键（`scene_threshold` / `scene_frame_skip` / `match_min_score` / `match_speed_clamp_min` / `match_speed_clamp_max` / `scene_merge_min_duration` / `bgm_gain_db` / `tts_pause_ms` / `embedding_model_name` / `research_provider` / `translate_provider` / `translate_retries` / `translate_chunk_chars` / `translate_chunk_size`），以及多语言字幕顶层键 `subtitle_lang` / `subtitle_mode`。相对路径 `video` / `bgm` / `library_dir` 相对于 YAML 所在目录解析。LLM 凭据请保留在 `.env` / `MN_*` 环境变量中。
 
 ### 多语言字幕
 
@@ -273,7 +280,7 @@ mn create --movie "飞驰人生" --duration 60
 
 ### 完整配置项
 
-完整环境变量列表（共 27 项）及默认值和说明，请查看 [`.env.example`](.env.example)。
+完整环境变量列表（共 60 项）及默认值和说明，请查看 [`.env.example`](.env.example)。
 
 ### LLM 服务商导航
 
@@ -485,6 +492,7 @@ movie-narrator/
 - [x] 步骤级重试机制（`--retry` 标志，`StepAction` 枚举）
 - [x] 首次运行自动创建 `~/.movie-narrator/.env`
 - [x] `export_clips` 直调 ffmpeg 子进程（设计选择，非临时方案）
+- [x] 配置系统全面重构：33 个硬编码常量提升为 Settings（共 60 个 `MN_*` 环境变量）；YAML 自动发现（未传 `--config` → `cwd/job.yaml` → 打包示例）；`.env.example` 作为首次运行单一真相源；所有 YAML 参数正确连接 `runner.py` → `ctx.metadata` → 流水线步骤
 
 ### v0.5.x — 生态系统（规划中）
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,9 +54,11 @@ run_pipeline(...) # STEPS order unchanged
 
 - Module: `movie_narrator.workflow` (`load_job_config`, `merge_job`, `JobConfigError`)
 - Soft steps honor `metadata["workflow_steps"][<field>] is False` → `status.<field> = "disabled"`
-- Params whitelist (`scene_threshold`, `match_min_score`, `research_provider`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`) land in `ctx.metadata`
+- Params whitelist (`scene_threshold`, `scene_frame_skip`, `match_min_score`, `match_speed_clamp_min`, `match_speed_clamp_max`, `scene_merge_min_duration`, `bgm_gain_db`, `tts_pause_ms`, `embedding_model_name`, `research_provider`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`) land in `ctx.metadata` via `build_context` copy loop
 - Multi-language subtitle top-level keys: `subtitle_lang`, `subtitle_mode` (validated in `JobConfig` — `subtitle_mode ∈ {translated, bilingual}` without `subtitle_lang` raises `JobConfigError` at merge time)
 - `STEPS` remains the single source of step order; no DAG / plugins in v0.3
+- YAML auto-discovery (v0.4.7): `--config` not passed → `cwd/job.yaml` → packaged `examples/job.example.yaml` → none
+- `.env.example` is the single source of truth for first-run config (read by `ensure_user_config()`, not a divergent inline template)
 
 ## Web UI Layer (v0.3.5)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,6 +80,16 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 - [x] Auto-create `~/.movie-narrator/.env` on first run
 - [x] `export_clips` direct ffmpeg subprocess (design choice)
 
+### v0.4.7 Config system overhaul
+
+- [x] 33 hardcoded constants promoted to Settings (60 total `MN_*` env vars)
+- [x] YAML auto-discovery: `--config` not passed → `cwd/job.yaml` → packaged example → none
+- [x] `.env.example` as single source of truth for first-run config (replaces divergent inline template)
+- [x] All 14 YAML params properly connected through `runner.py` → `ctx.metadata` → pipeline steps
+- [x] Fixed `translate_chunk_chars/size` silently ignored (never copied to `ctx.metadata`)
+- [x] Fixed `export_clips` codecs hardcoded (now uses `settings.render_video_codec/audio_codec`)
+- [x] Fixed `scene_frame_skip` missing from runner copy loop
+
 ### v0.4 Environment variables
 
 - `MN_TTS_PROVIDER` — `edge` (default), `openai`, or `mimo`
@@ -91,6 +101,21 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 - `MN_MIMO_API_KEY` — MiMo API key (falls back to `MN_LLM_API_KEY`)
 - `MN_MIMO_BASE_URL` — MiMo base URL (default `https://api.xiaomimimo.com/v1`)
 - `MN_MIMO_STYLE_PROMPT` — Style description for `mimo-v2.5-tts` user message (default empty)
+
+### v0.4.7 Environment variables (config system overhaul)
+
+See [`.env.example`](../.env.example) for the complete list of all 60 `MN_*` env vars. Key additions:
+
+- LLM tuning: `MN_LLM_TIMEOUT`, `MN_SCRIPT_TEMPERATURE`, `MN_SCRIPT_MAX_TOKENS`, `MN_SCRIPT_RETRIES`, `MN_SCRIPT_RETRY_DELAY`, `MN_RESEARCH_TEMPERATURE`, `MN_RESEARCH_MAX_TOKENS`, `MN_TRANSLATE_MAX_TOKENS`
+- TTS: `MN_TTS_MAX_CONCURRENT`, `MN_TTS_AUDIO_FORMAT`, `MN_TTS_AUDIO_BITRATE`
+- WhisperX: `MN_WHISPERX_DEVICE`, `MN_WHISPERX_MODEL`, `MN_WHISPERX_LANGUAGE`
+- Translate: `MN_TRANSLATE_SOURCE_LANG`
+- Render: `MN_RENDER_BG_COLOR`, `MN_RENDER_FONT_SIZE`, `MN_RENDER_OUTPUT_NAME`, `MN_RENDER_FFMPEG_TIMEOUT`
+- Match: `MN_MATCH_SPEED_CLAMP_MIN`, `MN_MATCH_SPEED_CLAMP_MAX`, `MN_SCENE_MERGE_MIN_DURATION`, `MN_EMBEDDING_MODEL_NAME`
+- BGM: `MN_BGM_GAIN_DB`
+- TTS pacing: `MN_TTS_PAUSE_MS`, `MN_TTS_CACHE_MAX_MB`
+- Video: `MN_VIDEO_SIZES` (JSON string)
+- Async: `MN_ASYNC_TIMEOUT`, `MN_ASYNC_MAX_WORKERS`
 
 ### Provider env-var naming convention
 


### PR DESCRIPTION
Updated 6 files to match current codebase state after PRs #11-#16.

## Files changed

### CHANGELOG.md
- \[Unreleased]\ section populated with Added/Fixed/Changed covering all 6 PRs
- 33 hardcoded constants promoted, YAML auto-discovery, .env.example as single source of truth, all bug fixes

### README.md + README.zh-CN.md
- Params whitelist: 7 -> 14 keys (added scene_frame_skip, match_speed_clamp_min/max, scene_merge_min_duration, bgm_gain_db, tts_pause_ms, embedding_model_name)
- Env var count: 27 -> 60
- YAML auto-discovery: documented 3-level priority
- Roadmap v0.4.x: added config system overhaul

### docs/ARCHITECTURE.md
- Params whitelist updated to 14 keys
- Added YAML auto-discovery + .env.example single-source notes

### docs/ROADMAP.md
- Added v0.4.7 Config system overhaul subsection
- Added v0.4.7 Environment variables subsection