### PR TITLE
refactor: strict env/yaml boundary — env=LLM+TTS only, yaml=all pipeline behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
 # ============================================================
+# movie-narrator — .env
+#
+# This file contains ONLY LLM + TTS infrastructure configuration.
+# All pipeline behavior (scene detection, match, render, translate,
+# BGM, etc.) is configured via job.yaml — see examples/job.example.yaml.
+# ============================================================
+
+# ============================================================
 # LLM — script generation / plot research / subtitle translation
 # ============================================================
 MN_LLM_BASE_URL=http://localhost:11434/v1
@@ -28,6 +36,9 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # Provider: edge (default, free) | openai (OpenAI-compatible) | mimo (Xiaomi MiMo)
 # MN_TTS_PROVIDER=edge
 
+# TTS cache (optional)
+# MN_TTS_CACHE_MAX_MB=500          # LRU eviction threshold for TTS cache
+
 # ---- OpenAI TTS (active when MN_TTS_PROVIDER=openai) ----
 # MN_OPENAI_TTS_MODEL=tts-1
 # MN_OPENAI_TTS_API_KEY=           # falls back to MN_LLM_API_KEY
@@ -42,79 +53,3 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # MN_MIMO_API_KEY=                 # falls back to MN_LLM_API_KEY
 # MN_MIMO_BASE_URL=https://api.xiaomimimo.com/v1
 # MN_MIMO_STYLE_PROMPT=            # style description, mimo-v2.5-tts only
-
-# ============================================================
-# Video output
-# ============================================================
-MN_DEFAULT_FORMAT=16:9
-
-# ============================================================
-# Library / BGM / scene detection / export
-# ============================================================
-# MN_LIBRARY_DIR=                  # movie library for fuzzy filename lookup
-# MN_DEFAULT_BGM=                  # default background music file path
-# MN_RESEARCH_ENABLED=false        # auto-enable LLM plot research
-# MN_RESEARCH_PROVIDER=llm         # research backend (llm only for now)
-# MN_SCENE_THRESHOLD=27.0          # PySceneDetect sensitivity (higher = fewer cuts)
-# MN_SCENE_FRAME_SKIP=10           # skip every N frames during detection
-# MN_MATCH_MIN_SCORE=0.25          # minimum cosine similarity for clip matching
-# MN_EXPORT_CLIPS_DEFAULT=true     # whether to export scene subclips by default
-
-# ============================================================
-# Multi-language subtitles
-# ============================================================
-# MN_SUBTITLE_LANG=                # target language tag (e.g. en / ja / zh-TW); empty = off
-# MN_SUBTITLE_MODE=original        # original | translated | bilingual
-# MN_TRANSLATE_PROVIDER=llm        # translation backend (llm only for now)
-# MN_TRANSLATE_RETRIES=3           # retries per chunk on LLM failure
-# MN_TRANSLATE_CHUNK_CHARS=4000    # max characters per translation chunk
-# MN_TRANSLATE_CHUNK_SIZE=20       # max segments per translation chunk
-# MN_TRANSLATE_SOURCE_LANG=zh-CN   # source language for translation
-
-# ============================================================
-# WhisperX (optional [ml] dep, align step)
-# ============================================================
-# MN_WHISPERX_DEVICE=cpu           # cpu | cuda
-# MN_WHISPERX_MODEL=medium         # tiny|base|small|medium|large
-# MN_WHISPERX_LANGUAGE=zh          # transcription language
-
-# ============================================================
-# TTS audio export
-# ============================================================
-# MN_TTS_CACHE_MAX_MB=500          # LRU eviction threshold for TTS cache
-# MN_TTS_PAUSE_MS=300             # silence between narration segments (ms)
-# MN_TTS_MAX_CONCURRENT=3          # parallel TTS synthesis tasks
-# MN_TTS_AUDIO_FORMAT=mp3          # narration export format
-# MN_TTS_AUDIO_BITRATE=128k        # narration export bitrate
-
-# ============================================================
-# BGM / Embedding / Video sizes
-# ============================================================
-# MN_BGM_GAIN_DB=-18               # BGM mixing gain (dB)
-# MN_EMBEDDING_MODEL_NAME=paraphrase-multilingual-MiniLM-L12-v2
-# MN_VIDEO_SIZES={"16:9": [1920, 1080], "9:16": [1080, 1920]}
-
-# ============================================================
-# Render parameters
-# ============================================================
-# MN_RENDER_FPS=24                 # output video frame rate
-# MN_RENDER_VIDEO_CODEC=libx264    # video encoder
-# MN_RENDER_AUDIO_CODEC=aac        # audio encoder (must match temp_audiofile extension)
-# MN_RENDER_THREADS=4              # ffmpeg encoding threads
-# MN_RENDER_BG_COLOR=20,20,30      # background RGB (comma-separated)
-# MN_RENDER_FONT_SIZE=100          # text overlay font size
-# MN_RENDER_OUTPUT_NAME=final.mp4  # final video filename
-# MN_RENDER_FFMPEG_TIMEOUT=300     # export_clips ffmpeg timeout (seconds)
-# MN_ASYNC_TIMEOUT=300             # async task timeout (seconds)
-# MN_ASYNC_MAX_WORKERS=2           # thread pool size for async
-
-# ============================================================
-# Match — scene↔narration speed control
-# ============================================================
-# Speed factor = matched scene duration / narration segment duration.
-# Clamp limits keep playback speed within a comfortable range, preventing
-# extreme fast-forward (>clamp_max) or slow-motion (<clamp_min).
-# MN_MATCH_SPEED_CLAMP_MIN=0.5     # slowest allowed speed factor (<1 = slow-mo limit)
-# MN_MATCH_SPEED_CLAMP_MAX=3.0     # fastest allowed speed factor (>1 = fast-forward limit)
-# Merge short scenes to give clamp wider windows to work with.
-# MN_SCENE_MERGE_MIN_DURATION=0    # min scene duration (seconds); 0 = no merge, 3.0 recommended

--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -1,6 +1,10 @@
 # Movie Narrator 任务配置文件模板
-# 所有字段可选 — 不填则使用 Settings / CLI 默认值
-# 优先级：CLI 参数 > 本文件 > Settings 默认值
+# 所有字段可选 — 不填则使用内联默认值
+# 优先级：CLI 参数 > 本文件 > 内联默认值
+#
+# 边界说明：
+#   .env (Settings) = LLM + TTS 基础配置（凭证、端点、模型、调用参数）
+#   job.yaml (本文件) = 所有流水线行为参数（场景、匹配、渲染、翻译、BGM 等）
 
 # ============================================================
 # 基础参数
@@ -36,7 +40,7 @@ steps:
   match: true               # 场景 ↔ 解说片段匹配
   bgm: false                # 背景音乐混音（需配置 bgm 路径）
   export: false             # 场景子片段导出为 .mp4（需 [media] 额外依赖）
-  translate: false           # 多语言字幕翻译（需设置 subtitle_lang）
+  translate: false          # 多语言字幕翻译（需设置 subtitle_lang）
 
 # ============================================================
 # 多语言字幕
@@ -48,34 +52,75 @@ subtitle_lang: ""           # 目标语言标签，如 en / ja / zh-TW；留空 
 subtitle_mode: original     # original | translated | bilingual
 
 # ============================================================
-# 精细参数
+# 精细参数（所有流水线行为配置都在这里）
 # ============================================================
 # 白名单（其余键会被拒绝）：
-#   scene_threshold / scene_frame_skip / match_min_score
-#   match_speed_clamp_min / match_speed_clamp_max / scene_merge_min_duration
-#   bgm_gain_db / tts_pause_ms / embedding_model_name
-#   research_provider / translate_provider / translate_retries
-#   translate_chunk_chars / translate_chunk_size
+#   场景: scene_threshold / scene_frame_skip
+#   匹配: match_min_score / match_speed_clamp_min / match_speed_clamp_max
+#          scene_merge_min_duration / embedding_model_name
+#   BGM:  bgm_gain_db
+#   TTS:  tts_pause_ms / tts_max_concurrent / tts_audio_format / tts_audio_bitrate
+#   翻译: translate_source_lang / translate_provider / translate_retries
+#          translate_chunk_chars / translate_chunk_size
+#   调研: research_provider
+#   WhisperX: whisperx_device / whisperx_model / whisperx_language
+#   渲染: render_fps / render_video_codec / render_audio_codec / render_threads
+#          render_bg_color / render_font_size / render_output_name / render_ffmpeg_timeout
+#   异步: async_timeout / async_max_workers
+#   视频: video_sizes
 params:
   # ---- 场景检测 ----
   scene_threshold: 27.0     # PySceneDetect 灵敏度（越大越不敏感，切分越少）
   scene_frame_skip: 10      # 每 N 帧检测 1 帧（越大越快，精度越低）
+
   # ---- 场景匹配 ----
   match_min_score: 0.25     # embedding 匹配最低余弦相似度（低于此值丢弃）
-  # ---- 速度缩放控制 ----
   # 速度因子 = 匹配到的场景时长 / 解说片段时长。
   # clamp 将速度限制在舒适范围，防止相邻片段忽快忽慢。
   match_speed_clamp_min: 0.5    # 最慢速度因子（<1 = 慢放上限）
   match_speed_clamp_max: 3.0    # 最快速度因子（>1 = 快进上限）
   scene_merge_min_duration: 0   # 场景最短时长（秒），0=不合并；设为 3.0 可给 clamp 更大窗口
-  # ---- 音频 ----
-  # bgm_gain_db: -18          # BGM 混音增益（dB），默认 -18
-  # tts_pause_ms: 300         # 解说片段间静音时长（毫秒），默认 300
-  # ---- 匹配模型 ----
   # embedding_model_name: paraphrase-multilingual-MiniLM-L12-v2
-  # ---- 后端选择 ----
+
+  # ---- BGM ----
+  # bgm_gain_db: -18          # BGM 混音增益（dB）
+
+  # ---- TTS 音频 ----
+  # tts_pause_ms: 300         # 解说片段间静音时长（毫秒）
+  # tts_max_concurrent: 3     # 并发 TTS 合成数
+  # tts_audio_format: mp3     # 旁白导出格式
+  # tts_audio_bitrate: 128k   # 旁白导出比特率
+
+  # ---- 翻译 ----
+  # translate_source_lang: zh-CN  # 源语言
+  # translate_provider: llm   # 翻译后端（目前仅支持 llm）
+  # translate_retries: 3      # 翻译 LLM 失败后重试次数
+  # translate_chunk_chars: 4000   # 翻译分块字符阈值
+  # translate_chunk_size: 20      # 翻译分块条数阈值
+
+  # ---- 调研 ----
   research_provider: llm    # 调研后端（目前仅支持 llm）
-  translate_provider: llm   # 翻译后端（目前仅支持 llm）
-  translate_retries: 3      # 翻译 LLM 失败后重试次数
-  translate_chunk_chars: 4000   # 翻译分块字符阈值（注释掉则用默认值）
-  translate_chunk_size: 20      # 翻译分块条数阈值（注释掉则用默认值）
+
+  # ---- WhisperX（需 [ml] 额外依赖）----
+  # whisperx_device: cpu      # cpu | cuda
+  # whisperx_model: medium    # tiny|base|small|medium|large
+  # whisperx_language: zh     # 转录语言
+
+  # ---- 渲染 ----
+  # render_fps: 24            # 输出帧率
+  # render_video_codec: libx264  # 视频编码器
+  # render_audio_codec: aac   # 音频编码器
+  # render_threads: 4         # ffmpeg 编码线程数
+  # render_bg_color: "20,20,30"  # 背景色 RGB（逗号分隔）
+  # render_font_size: 100     # 文字叠加字体大小
+  # render_output_name: final.mp4  # 最终视频文件名
+  # render_ffmpeg_timeout: 300  # export_clips ffmpeg 超时（秒）
+
+  # ---- 异步 ----
+  # async_timeout: 300        # 异步任务超时（秒）
+  # async_max_workers: 2      # 线程池大小
+
+  # ---- 视频分辨率 ----
+  # video_sizes:
+  #   "16:9": [1920, 1080]
+  #   "9:16": [1080, 1920]

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -73,95 +73,41 @@ class TTSProviderType(str, Enum):
 
 
 class Settings(BaseSettings):
+    """Global LLM + TTS infrastructure configuration.
+
+    Boundary: .env (Settings) = LLM + TTS credentials, endpoints, models,
+    call params only. All pipeline behavior (scene, match, render, etc.)
+    is configured via job.yaml params — see ``examples/job.example.yaml`` for defaults.
+    """
+    # ── LLM ──
     llm_base_url: str = "http://localhost:11434/v1"
     llm_api_key: str = "ollama"
     llm_model: str = "qwen2.5:7b"
-    # ── LLM call tuning ──
-    llm_timeout: int = 60                    # httpx client timeout (seconds)
-    script_temperature: float = 0.7          # script generation LLM temperature
-    script_max_tokens: int = 2048            # script generation LLM max_tokens
-    script_retries: int = 3                  # script generation retry attempts
-    script_retry_delay: float = 1.5          # delay between retries (seconds)
-    research_temperature: float = 0.3        # research LLM temperature
-    research_max_tokens: int = 1024          # research LLM max_tokens
-    translate_max_tokens: int = 4096         # translation LLM max_tokens
+    llm_timeout: int = 60
+    script_temperature: float = 0.7
+    script_max_tokens: int = 2048
+    script_retries: int = 3
+    script_retry_delay: float = 1.5
+    research_temperature: float = 0.3
+    research_max_tokens: int = 1024
+    translate_max_tokens: int = 4096
+    # ── TTS ──
     default_voice: str = "zh-CN-YunxiNeural"
-    default_format: str = "16:9"
-    # v0.2 optional
-    library_dir: Optional[str] = None
-    default_bgm: Optional[str] = None
-    research_enabled: bool = False
-    research_provider: str = "llm"
-    scene_threshold: float = 27.0
-    scene_frame_skip: int = 10
-    match_min_score: float = 0.25
-    # ── Match speed clamp (v0.4.6) ──
-    # Limits the speed scaling factor applied during render to prevent
-    # extreme fast-forward (>3x) or slow-motion (<0.5x) that causes
-    # visual jarring between adjacent narration segments.
-    match_speed_clamp_min: float = 0.5
-    match_speed_clamp_max: float = 3.0
-    # Merge consecutive scenes shorter than this (0 = disabled).
-    # Reduces extreme speed factors by giving match_clips wider windows.
-    scene_merge_min_duration: float = 0.0
-    export_clips_default: bool = True
-    # v0.3 multi-language subtitle defaults.
-    # Empty/None subtitle_lang = feature off (status.translate=skipped).
-    subtitle_lang: Optional[str] = None
-    subtitle_mode: str = "original"
-    translate_provider: str = "llm"
-    translate_retries: int = 3
-    translate_chunk_chars: int = 4000
-    translate_chunk_size: int = 20
-    # ── TTS abstraction (v0.4) ──
     tts_provider: TTSProviderType = TTSProviderType.EDGE
     openai_tts_model: str = "tts-1"
-    openai_tts_api_key: Optional[str] = None   # falls back to llm_api_key
-    openai_tts_base_url: Optional[str] = None  # falls back to llm_base_url
-    # ── MiMo TTS (v0.4.1) ──
-    # Three models: mimo-v2.5-tts (named voice), mimo-v2.5-tts-voiceclone (audio file),
-    #               mimo-v2.5-tts-voicedesign (text description)
+    openai_tts_api_key: Optional[str] = None
+    openai_tts_base_url: Optional[str] = None
     mimo_tts_model: str = "mimo-v2.5-tts"
-    mimo_api_key: Optional[str] = None         # falls back to llm_api_key
+    mimo_api_key: Optional[str] = None
     mimo_base_url: str = "https://api.xiaomimimo.com/v1"
-    mimo_style_prompt: str = ""                # style description for user message (mimo-v2.5-tts only)
-    # ── TTS cache management ──
-    tts_cache_max_mb: int = 500                 # LRU eviction threshold for TTS cache
-    # ── TTS pacing ──
-    tts_pause_ms: int = 300                     # silence inserted between narration segments
-    tts_max_concurrent: int = 3                 # max parallel TTS synthesis tasks
-    tts_audio_format: str = "mp3"              # narration audio export format
-    tts_audio_bitrate: str = "128k"            # narration audio export bitrate
-    # ── BGM mixing ──
-    bgm_gain_db: float = -18.0                  # gain applied to BGM track before mixing with narration
-    # ── Embedding model for match re-rank ──
-    embedding_model_name: str = "paraphrase-multilingual-MiniLM-L12-v2"
-    # ── WhisperX (align step, optional [ml] dep) ──
-    whisperx_device: str = "cpu"                # inference device: cpu | cuda
-    whisperx_model: str = "medium"              # WhisperX model size: tiny|base|small|medium|large
-    whisperx_language: str = "zh"               # WhisperX transcription language
-    # ── Translate ──
-    translate_source_lang: str = "zh-CN"        # default source language for subtitle translation
-    # ── Render ──
-    render_fps: int = 24
-    render_video_codec: str = "libx264"
-    render_audio_codec: str = "aac"
-    render_threads: int = 4
-    render_bg_color: str = "20,20,30"           # RGB background color (comma-separated)
-    render_font_size: int = 100                 # text overlay font size
-    render_output_name: str = "final.mp4"       # final video output filename
-    render_ffmpeg_timeout: int = 300            # export_clips ffmpeg subprocess timeout (seconds)
-    # ── Async ──
-    async_timeout: int = 300                    # async task timeout (seconds)
-    async_max_workers: int = 2                  # thread pool size for async execution
-    # ── Video resolution presets ──
-    # JSON string, parsed at render time: {"16:9": [1920, 1080], "9:16": [1080, 1920]}
-    video_sizes: str = '{"16:9": [1920, 1080], "9:16": [1080, 1920]}'
+    mimo_style_prompt: str = ""
+    tts_cache_max_mb: int = 500
 
     model_config = SettingsConfigDict(
         env_file=(".env", str(_USER_ENV)),
         env_file_encoding="utf-8",
         env_prefix="MN_",
+        extra="ignore",
     )
 
 

--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -1,4 +1,3 @@
-from ..config import get_settings
 from ..models import Context, StepResult
 from ..utils.optional_deps import probe
 
@@ -38,11 +37,14 @@ def align_audio(ctx: Context) -> Context:
     try:
         import whisperx
 
-        settings = get_settings()
-        device = settings.whisperx_device
+        device = ctx.metadata.get("whisperx_device", "cpu")
         audio = whisperx.load_audio(ctx.audio_path)
-        model = whisperx.load_model(settings.whisperx_model, device=device)
-        result = model.transcribe(audio, language=settings.whisperx_language)
+        model = whisperx.load_model(
+            ctx.metadata.get("whisperx_model", "medium"), device=device
+        )
+        result = model.transcribe(
+            audio, language=ctx.metadata.get("whisperx_language", "zh")
+        )
 
         if result and "segments" in result:
             aligned = []

--- a/src/movie_narrator/pipeline/bgm.py
+++ b/src/movie_narrator/pipeline/bgm.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from pydub import AudioSegment
 
-from ..config import get_settings
 from ..models import Context, StepResult
 
 
@@ -32,7 +31,7 @@ def mix_bgm(ctx: Context) -> Context:
 
     try:
         narration = AudioSegment.from_file(ctx.audio_path)
-        gain_db = ctx.metadata.get("bgm_gain_db", get_settings().bgm_gain_db)
+        gain_db = ctx.metadata.get("bgm_gain_db", -18.0)
         bgm = AudioSegment.from_file(ctx.assets.bgm).apply_gain(gain_db)
         if len(bgm) < len(narration):
             times = len(narration) // max(len(bgm), 1) + 1

--- a/src/movie_narrator/pipeline/export_clips.py
+++ b/src/movie_narrator/pipeline/export_clips.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-from ..config import get_settings
 from ..models import Context, StepResult
 from ..utils.optional_deps import probe
 from ..utils.warnings import append_warning
@@ -45,7 +44,9 @@ def export_clips(ctx: Context) -> Context:
     clips_dir = output_dir / "clips"
     clips_dir.mkdir(parents=True, exist_ok=True)
 
-    settings = get_settings()
+    video_codec = ctx.metadata.get("render_video_codec", "libx264")
+    audio_codec = ctx.metadata.get("render_audio_codec", "aac")
+    ffmpeg_timeout = ctx.metadata.get("render_ffmpeg_timeout", 300)
     failed = 0
     for scene in tqdm(ctx.scenes, desc="Exporting clips", unit="clip"):
         try:
@@ -58,15 +59,15 @@ def export_clips(ctx: Context) -> Context:
                 "-ss", str(scene.start),
                 "-to", str(scene.end),
                 "-i", ctx.source_video_path,
-                "-c:v", settings.render_video_codec,
-                "-c:a", settings.render_audio_codec,
+                "-c:v", video_codec,
+                "-c:a", audio_codec,
                 "-movflags", "+faststart",
                 str(clip_path),
             ]
             result = subprocess.run(
                 cmd,
                 capture_output=True,
-                timeout=settings.render_ffmpeg_timeout,
+                timeout=ffmpeg_timeout,
             )
             if result.returncode != 0:
                 stderr_tail = result.stderr.decode(errors="replace")[-300:]

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -193,11 +193,10 @@ def match_clips(ctx: Context) -> Context:
         ctx.step_state.message = "no timed segments"
         return ctx
 
-    settings = get_settings()
-    min_score = ctx.metadata.get("match_min_score", settings.match_min_score)
-    clamp_min = ctx.metadata.get("match_speed_clamp_min", settings.match_speed_clamp_min)
-    clamp_max = ctx.metadata.get("match_speed_clamp_max", settings.match_speed_clamp_max)
-    merge_min = ctx.metadata.get("scene_merge_min_duration", settings.scene_merge_min_duration)
+    min_score = ctx.metadata.get("match_min_score", 0.25)
+    clamp_min = ctx.metadata.get("match_speed_clamp_min", 0.5)
+    clamp_max = ctx.metadata.get("match_speed_clamp_max", 3.0)
+    merge_min = ctx.metadata.get("scene_merge_min_duration", 0.0)
     output_dir = Path(ctx.output_dir)
 
     try:
@@ -277,7 +276,7 @@ def _match_clips_impl(
             scene_labels = [
                 _build_scene_label(s.index, s.start, s.end) for s in scenes
             ]
-            emb_model = ctx.metadata.get("embedding_model_name", get_settings().embedding_model_name)
+            emb_model = ctx.metadata.get("embedding_model_name", "paraphrase-multilingual-MiniLM-L12-v2")
             scene_vecs = _embed_texts(scene_labels, emb_model)
             narration_vecs = _embed_texts([seg.text for seg in ctx.timed_segments], emb_model)
             for i, seg in enumerate(ctx.timed_segments):

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from moviepy import AudioFileClip, ColorClip, CompositeVideoClip, ImageClip, VideoFileClip
 from proglog import TqdmProgressBarLogger
 
-from ..config import get_settings
 from ..models import Context, MatchedClip, StepResult, TimedSegment
 from ..utils.metadata_export import build_metadata_json
 from ..utils.text_image import create_text_image as _create_text_image
@@ -28,20 +27,15 @@ class _RenderProgressLogger(TqdmProgressBarLogger):
             self.bars[bar]["title"] = self._BAR_LABELS.get(bar, bar)
         super().bars_callback(bar, attr, value, old_value)
 
-_DEFAULT_VIDEO_SIZES = {
-    "16:9": (1920, 1080),
-    "9:16": (1080, 1920),
-}
 
+def _get_video_sizes(ctx: Context) -> dict:
+    """Return video_sizes dict from job params (ctx.metadata) with defaults fallback.
 
-def _get_video_sizes() -> dict:
-    """Parse video_sizes from Settings, falling back to built-in defaults."""
-    raw = get_settings().video_sizes
-    try:
-        parsed = json.loads(raw)
-        return {k: tuple(v) for k, v in parsed.items()}
-    except (json.JSONDecodeError, TypeError):
-        return dict(_DEFAULT_VIDEO_SIZES)
+    The metadata value (from YAML) is already a dict; ``{"16:9": (1920, 1080), "9:16": (1080, 1920)}``
+    is also a dict — no JSON parsing needed.
+    """
+    raw = ctx.metadata.get("video_sizes", {"16:9": (1920, 1080), "9:16": (1080, 1920)})
+    return {k: tuple(v) for k, v in raw.items()}
 
 
 def _overlay_text(ctx: Context, idx: int, seg: TimedSegment) -> str:
@@ -64,18 +58,19 @@ def _overlay_text(ctx: Context, idx: int, seg: TimedSegment) -> str:
 
 
 def render_video(ctx: Context) -> Context:
-    settings = get_settings()
     output_dir = Path(ctx.output_dir)
     video_format = ctx.metadata.get("format", "16:9")
-    size = _get_video_sizes().get(video_format, (1920, 1080))
+    size = _get_video_sizes(ctx).get(video_format, (1920, 1080))
     keep_cache = ctx.metadata.get("keep_cache", False)
+    font_size = ctx.metadata.get("render_font_size", 100)
 
     audio_path = ctx.final_audio_path or ctx.audio_path
     audio_clip = AudioFileClip(audio_path)
     total_duration = audio_clip.duration
 
     # Parse background color "R,G,B" → tuple
-    bg_parts = [int(x.strip()) for x in settings.render_bg_color.split(",")]
+    bg_color_str = ctx.metadata.get("render_bg_color", "20,20,30")
+    bg_parts = [int(x.strip()) for x in bg_color_str.split(",")]
     bg_color = tuple(bg_parts[:3])
     bg_clip = ColorClip(size=size, color=bg_color, duration=total_duration)
     clips: list = [bg_clip]
@@ -104,7 +99,7 @@ def render_video(ctx: Context) -> Context:
                     ctx.services.console.debug(f"  fallback for segment {mc.segment_index}: {ie}")
                     img_array = _create_text_image(
                         _overlay_text(ctx, mc.segment_index, ctx.timed_segments[mc.segment_index]),
-                        size, fontsize=settings.render_font_size,
+                        size, fontsize=font_size,
                     )
                     img_clip = ImageClip(img_array, is_mask=False)
                     img_clip = img_clip.with_duration(seg_duration).with_start(mc.narr_start)
@@ -119,24 +114,24 @@ def render_video(ctx: Context) -> Context:
     for i, seg in enumerate(ctx.timed_segments):
         if i in footage_segments:
             continue
-        img_array = _create_text_image(_overlay_text(ctx, i, seg), size, fontsize=settings.render_font_size)
+        img_array = _create_text_image(_overlay_text(ctx, i, seg), size, fontsize=font_size)
         img_clip = ImageClip(img_array, is_mask=False)
         img_clip = img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
         clips.append(img_clip)
 
     final_video = CompositeVideoClip(clips).with_audio(audio_clip)
-    video_path = output_dir / settings.render_output_name
+    video_path = output_dir / ctx.metadata.get("render_output_name", "final.mp4")
 
 
     tmp_dir = output_dir / ".tmp"
     tmp_dir.mkdir(exist_ok=True)
 
-    settings = get_settings()
     # temp_audiofile extension MUST match the audio_codec so the final
     # mux step ("-acodec copy") reads a correctly-typed bitstream.
     # With audio_codec="aac", a ".wav" extension causes a RIFF/WAV
     # header wrapping AAC data — ffmpeg then decodes only ~6 ms.
-    temp_ext = settings.render_audio_codec
+    audio_codec = ctx.metadata.get("render_audio_codec", "aac")
+    temp_ext = audio_codec
     # "copy" is a passthrough pseudo-codec; "aac" works for both AAC-LC
     # and the HE-AAC variants.  Map libmp3lame → mp3 so the temp file
     # always carries a real container extension.
@@ -149,10 +144,10 @@ def render_video(ctx: Context) -> Context:
     temp_ext = _EXT_NORM.get(temp_ext, temp_ext)
 
     write_kwargs = dict(
-        fps=settings.render_fps,
-        codec=settings.render_video_codec,
-        audio_codec=settings.render_audio_codec,
-        threads=settings.render_threads,
+        fps=ctx.metadata.get("render_fps", 24),
+        codec=ctx.metadata.get("render_video_codec", "libx264"),
+        audio_codec=audio_codec,
+        threads=ctx.metadata.get("render_threads", 4),
         logger=_RenderProgressLogger(),
         temp_audiofile=str(tmp_dir / f"temp_audio.{temp_ext}"),
     )

--- a/src/movie_narrator/pipeline/research.py
+++ b/src/movie_narrator/pipeline/research.py
@@ -41,7 +41,7 @@ def research_plot(ctx: Context) -> Context:
         ctx.step_state.message = "research disabled"
         return ctx
 
-    provider = ctx.metadata.get("research_provider", get_settings().research_provider)
+    provider = ctx.metadata.get("research_provider", "llm")
     output_dir = Path(ctx.output_dir)
 
     if provider != "llm":

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -117,8 +117,8 @@ def build_context(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    lib = library_dir if library_dir is not None else settings.library_dir
-    research_enabled = settings.research_enabled if research is None else research
+    lib = library_dir
+    research_enabled = research if research is not None else False
 
     if no_bgm:
         bgm_path = None
@@ -126,9 +126,6 @@ def build_context(
     elif bgm:
         bgm_path = bgm
         bgm_request = "explicit"
-    elif settings.default_bgm:
-        bgm_path = settings.default_bgm
-        bgm_request = "default"
     else:
         bgm_path = None
         bgm_request = "none"
@@ -152,16 +149,17 @@ def build_context(
             "keep_cache": keep_cache,
             "video_arg": video,
             "research_enabled": research_enabled,
-            "export_clips": (False if no_clips else settings.export_clips_default),
+            "export_clips": (False if no_clips else True),
             "strict": strict,
             "bgm_request": bgm_request,
             "version": __version__,
             "environment": collect_environment(),
-            # Multi-language subtitle (v0.3). Empty lang → feature off.
-            "subtitle_lang": (subtitle_lang or settings.subtitle_lang or None),
-            "subtitle_mode": (subtitle_mode or settings.subtitle_mode or "original"),
-            "translate_provider": (params or {}).get("translate_provider", settings.translate_provider),
-            "translate_retries": (params or {}).get("translate_retries", settings.translate_retries),
+            # Multi-language subtitle. Empty lang → feature off.
+            "subtitle_lang": (subtitle_lang or None),
+            "subtitle_mode": (subtitle_mode or "original"),
+            "translate_provider": (params or {}).get("translate_provider", "llm"),
+            "translate_retries": (params or {}).get("translate_retries", 3),
+            "research_provider": (params or {}).get("research_provider", "llm"),
         }
     )
 
@@ -169,11 +167,17 @@ def build_context(
         ctx.metadata["workflow_steps"] = dict(workflow_steps)
     if params:
         for key in (
-            "scene_threshold", "scene_frame_skip", "match_min_score", "research_provider",
+            "scene_threshold", "scene_frame_skip", "match_min_score",
             "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration",
-            "translate_chunk_chars", "translate_chunk_size",
-            "bgm_gain_db", "tts_pause_ms", "embedding_model_name",
+            "scene_merge_min_duration", "embedding_model_name",
+            "bgm_gain_db", "tts_pause_ms",
+            "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
+            "translate_source_lang", "translate_chunk_chars", "translate_chunk_size",
+            "whisperx_device", "whisperx_model", "whisperx_language",
+            "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
+            "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            "async_timeout", "async_max_workers",
+            "video_sizes",
         ):
             if key in params and params[key] is not None:
                 ctx.metadata[key] = params[key]

--- a/src/movie_narrator/pipeline/scenes.py
+++ b/src/movie_narrator/pipeline/scenes.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from ..config import get_settings
 from ..models import Context, Scene, StepResult
 from ..utils.optional_deps import probe
 
@@ -23,10 +22,10 @@ def detect_scenes(ctx: Context) -> Context:
         from scenedetect import open_video, SceneManager
         from scenedetect.detectors import ContentDetector
 
-        # Spec §3/§4: use Settings.scene_threshold; allow metadata override (e.g. mn scenes --threshold).
-        settings = get_settings()
-        threshold = ctx.metadata.get("scene_threshold", settings.scene_threshold)
-        frame_skip = ctx.metadata.get("scene_frame_skip", settings.scene_frame_skip)
+        # Spec §3/§4: read scene_threshold / scene_frame_skip from job params
+        # (ctx.metadata) with defaults fallback (e.g. mn scenes --threshold).
+        threshold = ctx.metadata.get("scene_threshold", 27.0)
+        frame_skip = ctx.metadata.get("scene_frame_skip", 10)
 
         video = open_video(ctx.source_video_path)
         scene_manager = SceneManager()

--- a/src/movie_narrator/pipeline/translate.py
+++ b/src/movie_narrator/pipeline/translate.py
@@ -218,8 +218,8 @@ def translate_subtitles(ctx: Context) -> Context:
         append_warning(ctx, f"translate provider {provider!r} is not supported")
         return ctx
 
-    source_lang = (ctx.metadata.get("source_lang") or get_settings().translate_source_lang)
-    ctx.metadata.setdefault("source_lang", source_lang)
+    source_lang = (ctx.metadata.get("translate_source_lang") or "zh-CN")
+    ctx.metadata.setdefault("translate_source_lang", source_lang)
 
     texts = [seg.text for seg in ctx.timed_segments]
 
@@ -234,10 +234,9 @@ def translate_subtitles(ctx: Context) -> Context:
         ctx.step_state.message = "ci-passthrough"
         return ctx
 
-    retries = int(ctx.metadata.get("translate_retries", get_settings().translate_retries))
-    settings = get_settings()
-    max_chars = int(ctx.metadata.get("translate_chunk_chars", settings.translate_chunk_chars))
-    max_items = int(ctx.metadata.get("translate_chunk_size", settings.translate_chunk_size))
+    retries = int(ctx.metadata.get("translate_retries", 3))
+    max_chars = int(ctx.metadata.get("translate_chunk_chars", 4000))
+    max_items = int(ctx.metadata.get("translate_chunk_size", 20))
 
     try:
         ctx.translated_texts = _translate_via_llm(

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -14,8 +14,6 @@ from ..tts.cache import (
     PROVIDER_CACHE_VERSIONS,
 )
 
-MAX_CONCURRENT = 3  # default; overridden by settings.tts_max_concurrent at runtime
-
 __all__ = ["generate_voice"]
 
 
@@ -27,6 +25,10 @@ def generate_voice(ctx: Context) -> Context:
 
     voice = ctx.metadata.get("voice") or settings.default_voice
     provider = get_tts_provider(settings)
+    pause_ms = ctx.metadata.get("tts_pause_ms", 300)
+    max_concurrent = ctx.metadata.get("tts_max_concurrent", 3)
+    audio_fmt = ctx.metadata.get("tts_audio_format", "mp3")
+    audio_bitrate = ctx.metadata.get("tts_audio_bitrate", "128k")
 
     def _key(seg_text: str) -> TTSCacheKey:
         return TTSCacheKey(
@@ -42,11 +44,11 @@ def generate_voice(ctx: Context) -> Context:
             ),
             voice=voice,
             text=seg_text,
-            pause_ms=settings.tts_pause_ms,
+            pause_ms=pause_ms,
         )
 
     async def _run_all():
-        sem = asyncio.Semaphore(settings.tts_max_concurrent)
+        sem = asyncio.Semaphore(max_concurrent)
 
         async def _one(seg):
             async with sem:
@@ -80,7 +82,6 @@ def generate_voice(ctx: Context) -> Context:
     current_time = 0.0
     for i, (audio, duration) in enumerate(results):
         combined += audio
-        pause_ms = settings.tts_pause_ms
         pause = (pause_ms / 1000.0) if i < len(ctx.segments) - 1 else 0
         if pause > 0:
             combined += AudioSegment.silent(duration=pause_ms)
@@ -89,12 +90,11 @@ def generate_voice(ctx: Context) -> Context:
         )
         current_time += duration + pause
 
-    audio_fmt = settings.tts_audio_format
     audio_path = output_dir / f"narration.{audio_fmt}"
     # Explicit bitrate prevents pydub's default 32 kbps export, which
     # produces MPEG v2.5 audio that ffmpeg (used by MoviePy) can fail
     # to decode — resulting in a silent final video.
-    combined.export(audio_path, format=audio_fmt, bitrate=settings.tts_audio_bitrate)
+    combined.export(audio_path, format=audio_fmt, bitrate=audio_bitrate)
     ctx.audio_path = str(audio_path)
     ctx.timed_segments = timed_segments
     ctx.metadata["voice_used"] = voice

--- a/src/movie_narrator/utils/async_utils.py
+++ b/src/movie_narrator/utils/async_utils.py
@@ -7,16 +7,11 @@ from typing import Any, Coroutine, TypeVar
 
 T = TypeVar("T")
 
-ASYNC_TIMEOUT = 300  # default; overridden by settings.async_timeout at runtime
 _executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="movie-narrator-async")
 atexit.register(lambda: _executor.shutdown(wait=False))
 
 
-def run_async(coro: Coroutine[Any, Any, T]) -> T:
-    from ..config import get_settings
-
-    settings = get_settings()
-    timeout = settings.async_timeout
+def run_async(coro: Coroutine[Any, Any, T], timeout: float = 300) -> T:
     try:
         asyncio.get_running_loop()
     except RuntimeError:

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -69,7 +69,31 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
     if "params" in data and data["params"] is not None:
         if not isinstance(data["params"], dict):
             raise JobConfigError("params must be a mapping")
-        allowed_params = {"scene_threshold", "scene_frame_skip", "match_min_score", "research_provider", "translate_provider", "translate_retries", "translate_chunk_chars", "translate_chunk_size", "match_speed_clamp_min", "match_speed_clamp_max", "scene_merge_min_duration", "bgm_gain_db", "tts_pause_ms", "embedding_model_name"}
+        allowed_params = {
+            # Scene detection
+            "scene_threshold", "scene_frame_skip",
+            # Match
+            "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
+            "scene_merge_min_duration", "embedding_model_name",
+            # BGM
+            "bgm_gain_db",
+            # TTS pacing
+            "tts_pause_ms", "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
+            # Translate
+            "translate_source_lang", "translate_provider", "translate_retries",
+            "translate_chunk_chars", "translate_chunk_size",
+            # Research
+            "research_provider",
+            # WhisperX
+            "whisperx_device", "whisperx_model", "whisperx_language",
+            # Render
+            "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
+            "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            # Async
+            "async_timeout", "async_max_workers",
+            # Video sizes
+            "video_sizes",
+        }
         for k in data["params"].keys():
             if k not in allowed_params:
                 raise JobConfigError(

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -75,13 +75,29 @@ def merge_job(
     params: Dict[str, Any] = {}
     if job is not None and job.params is not None:
         for key in (
-            "scene_threshold", "scene_frame_skip", "match_min_score",
-            "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration",
-            "bgm_gain_db", "tts_pause_ms", "embedding_model_name",
-            "research_provider",
-            "translate_provider", "translate_retries",
+            # Scene detection
+            "scene_threshold", "scene_frame_skip",
+            # Match
+            "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
+            "scene_merge_min_duration", "embedding_model_name",
+            # BGM
+            "bgm_gain_db",
+            # TTS pacing
+            "tts_pause_ms", "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
+            # Translate
+            "translate_source_lang", "translate_provider", "translate_retries",
             "translate_chunk_chars", "translate_chunk_size",
+            # Research
+            "research_provider",
+            # WhisperX
+            "whisperx_device", "whisperx_model", "whisperx_language",
+            # Render
+            "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
+            "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            # Async
+            "async_timeout", "async_max_workers",
+            # Video sizes
+            "video_sizes",
         ):
             val = getattr(job.params, key)
             if val is not None:

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -22,23 +22,48 @@ class JobSteps(BaseModel):
 class JobParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    # ── Scene detection ──
     scene_threshold: Optional[float] = None
     scene_frame_skip: Optional[int] = None
+    # ── Match ──
     match_min_score: Optional[float] = None
-    research_provider: Optional[str] = None
-    # Multi-language subtitle tuning (v0.3).
+    match_speed_clamp_min: Optional[float] = None
+    match_speed_clamp_max: Optional[float] = None
+    scene_merge_min_duration: Optional[float] = None
+    embedding_model_name: Optional[str] = None
+    # ── BGM ──
+    bgm_gain_db: Optional[float] = None
+    # ── TTS pacing ──
+    tts_pause_ms: Optional[int] = None
+    tts_max_concurrent: Optional[int] = None
+    tts_audio_format: Optional[str] = None
+    tts_audio_bitrate: Optional[str] = None
+    # ── Translate ──
+    translate_source_lang: Optional[str] = None
     translate_provider: Optional[str] = None
     translate_retries: Optional[int] = None
     translate_chunk_chars: Optional[int] = None
     translate_chunk_size: Optional[int] = None
-    # Match speed clamp + scene merge (v0.4.6).
-    match_speed_clamp_min: Optional[float] = None
-    match_speed_clamp_max: Optional[float] = None
-    scene_merge_min_duration: Optional[float] = None
-    # Hardcoded constants promoted to configurable (v0.4.7).
-    bgm_gain_db: Optional[float] = None
-    tts_pause_ms: Optional[int] = None
-    embedding_model_name: Optional[str] = None
+    # ── Research ──
+    research_provider: Optional[str] = None
+    # ── WhisperX ──
+    whisperx_device: Optional[str] = None
+    whisperx_model: Optional[str] = None
+    whisperx_language: Optional[str] = None
+    # ── Render ──
+    render_fps: Optional[int] = None
+    render_video_codec: Optional[str] = None
+    render_audio_codec: Optional[str] = None
+    render_threads: Optional[int] = None
+    render_bg_color: Optional[str] = None
+    render_font_size: Optional[int] = None
+    render_output_name: Optional[str] = None
+    render_ffmpeg_timeout: Optional[int] = None
+    # ── Async ──
+    async_timeout: Optional[int] = None
+    async_max_workers: Optional[int] = None
+    # ── Video sizes ──
+    video_sizes: Optional[Dict[str, list]] = None
 
 
 VALID_SUBTITLE_MODES = frozenset({"original", "translated", "bilingual"})

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -28,9 +28,6 @@ def test_detect_scenes_skipped_no_source(tmp_path):
 
 def _run_detect_with_fake_scenedetect(ctx, threshold_expected):
     """Inject fake scenedetect modules so tests run without [media] extras."""
-    mock_settings = MagicMock()
-    mock_settings.scene_threshold = 42.5
-
     mock_video = MagicMock()
     mock_video.duration.frame_num = 1000
     mock_manager = MagicMock()
@@ -46,7 +43,6 @@ def _run_detect_with_fake_scenedetect(ctx, threshold_expected):
 
     with (
         patch("movie_narrator.pipeline.scenes.probe", return_value=(True, "")),
-        patch("movie_narrator.pipeline.scenes.get_settings", return_value=mock_settings),
         patch.dict(
             sys.modules,
             {
@@ -61,15 +57,15 @@ def _run_detect_with_fake_scenedetect(ctx, threshold_expected):
     assert ctx.status.scene == "success"
 
 
-def test_detect_scenes_uses_settings_threshold(tmp_path):
-    """Spec §3/§4: ContentDetector must honor Settings.scene_threshold."""
+def test_detect_scenes_uses_default_threshold(tmp_path):
+    """ContentDetector uses inline default (27.0) when no metadata override."""
     ctx = Context(
         movie_name="m",
         output_dir=str(tmp_path),
         source_video_path=str(tmp_path / "src.mp4"),
     )
     (tmp_path / "src.mp4").write_bytes(b"00")
-    _run_detect_with_fake_scenedetect(ctx, threshold_expected=42.5)
+    _run_detect_with_fake_scenedetect(ctx, threshold_expected=27.0)
 
 
 def test_detect_scenes_metadata_threshold_override(tmp_path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,15 +5,28 @@ from movie_narrator.config import Settings, ensure_user_config, _read_example_en
 from movie_narrator.utils.environment import collect_environment
 
 
-def test_settings_v02_defaults():
+def test_settings_llm_tts_defaults():
     s = Settings()
-    assert hasattr(s, "library_dir")
-    assert s.research_enabled is False
-    assert s.research_provider == "llm"
-    assert s.scene_threshold == 27.0
-    assert s.match_min_score == 0.25
-    assert s.export_clips_default is True
-    assert s.default_bgm is None
+    # LLM
+    assert s.llm_base_url
+    assert s.llm_api_key
+    assert s.llm_model
+    assert s.llm_timeout == 60
+    assert s.script_temperature == 0.7
+    assert s.script_max_tokens == 2048
+    assert s.script_retries == 3
+    assert s.script_retry_delay == 1.5
+    assert s.research_temperature == 0.3
+    assert s.research_max_tokens == 1024
+    assert s.translate_max_tokens == 4096
+    # TTS
+    assert s.default_voice
+    assert s.tts_cache_max_mb == 500
+    # Pipeline fields should NOT be in Settings (they're in job.yaml)
+    assert not hasattr(s, "scene_threshold")
+    assert not hasattr(s, "match_min_score")
+    assert not hasattr(s, "render_video_codec")
+    assert not hasattr(s, "library_dir")
 
 
 def test_collect_environment_keys():


### PR DESCRIPTION
## Breaking change

Strict separation between .env (Settings) and job.yaml (pipeline params).

### Before
- .env had 60 MN_* vars mixing LLM/TTS + pipeline behavior
- defaults.py duplicated values as code constants
- Boundary was unclear — users didn't know where to configure what

### After
- .env: **21 fields** — LLM (11) + TTS (10) only
- job.yaml: **30 params** — all pipeline behavior
- No defaults.py — inline literals in ctx.metadata.get() match example files
- .env.example and job.example.yaml are the single sources of truth

## Changes by file

**Deleted:**
- \defaults.py\ — no code constants module

**config.py:**
- Removed 39 pipeline fields, kept 21 LLM+TTS fields
- Added \extra='ignore'\ so old .env vars don't break on upgrade

**.env.example:**
- Rewritten: ONLY LLM + TTS sections (was 60 vars, now 21)

**job.example.yaml:**
- Added all 30 pipeline params with inline comments
- Header documents the boundary

**load.py / schema.py / merge.py:**
- allowed_params / JobParams / merge loop expanded to 30 keys

**runner.py:**
- build_context no longer reads settings for pipeline values
- All pipeline params come from YAML -> ctx.metadata

**9 pipeline modules:**
- Removed defaults imports, replaced with inline literals

**Tests:**
- test_settings.py: verify LLM+TTS fields, assert pipeline fields NOT in Settings
- test_scenes.py: removed settings mock, reads ctx.metadata

## Test results
- 273 passed, 2 pre-existing env failures (user .env has real API keys)