### PR TITLE
docs: fix 9 factual errors after env/yaml boundary refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (post-v0.4.7 — env/yaml boundary refactor)
+- **Breaking**: `.env` (Settings) now contains ONLY 21 LLM + TTS infrastructure fields. All 30 pipeline behavior params moved to `job.yaml` (params). Previously 60 `MN_*` env vars mixed LLM/TTS + pipeline behavior.
+- **Breaking**: `default_format` removed from Settings (was dead code, never read). `library_dir`, `default_bgm`, `research_enabled`, `export_clips_default`, `subtitle_lang`, `subtitle_mode` also removed — these are CLI/YAML fields, not env vars.
+- Deleted `defaults.py` — no code constants module. Pipeline modules use inline literals in `ctx.metadata.get()` calls, matching example files.
+- `.env.example` rewritten: 21 LLM + TTS vars only (was 60).
+- `job.example.yaml` expanded: all 30 params with inline comments.
+- Settings `extra="ignore"` added so old `.env` vars don't break on upgrade.
+
 ## [0.4.7] - 2026-07-15
 
 ### Added (v0.4.7 — config system overhaul)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ When `--config` is not passed, the CLI auto-discovers a YAML config in priority 
 
 This means new users can run `mn create --movie X` without creating any config file — the example YAML provides default steps/params automatically.
 
-See [`examples/job.example.yaml`](examples/job.example.yaml) for the full whitelist: soft-step toggles under `steps:` (`research`, `align`, `scene`, `match`, `bgm`, `export`, `translate`), all 14 `params:` keys (`scene_threshold`, `scene_frame_skip`, `match_min_score`, `match_speed_clamp_min`, `match_speed_clamp_max`, `scene_merge_min_duration`, `bgm_gain_db`, `tts_pause_ms`, `embedding_model_name`, `research_provider`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`), and the multi-language subtitle top-level keys `subtitle_lang` / `subtitle_mode`. Relative `video` / `bgm` / `library_dir` paths resolve against the YAML file's directory. LLM credentials stay in `.env` / `MN_*` only.
+See [`examples/job.example.yaml`](examples/job.example.yaml) for the full whitelist: soft-step toggles under `steps:` (`research`, `align`, `scene`, `match`, `bgm`, `export`, `translate`), all 30 `params:` keys (scene detection, match, BGM, TTS pacing, translate, research, WhisperX, render, async, video sizes), and the multi-language subtitle top-level keys `subtitle_lang` / `subtitle_mode`. Relative `video` / `bgm` / `library_dir` paths resolve against the YAML file's directory. LLM credentials stay in `.env` / `MN_*` only.
 
 ### Multi-language subtitles
 
@@ -252,7 +252,6 @@ MN_LLM_BASE_URL=http://localhost:11434/v1
 MN_LLM_API_KEY=ollama
 MN_LLM_MODEL=qwen2.5:7b
 MN_DEFAULT_VOICE=zh-CN-YunxiNeural
-MN_DEFAULT_FORMAT=16:9
 ```
 
 ### Via environment variables
@@ -282,7 +281,7 @@ mn create --movie "飞驰人生" --duration 60
 
 ### Full reference
 
-See [`.env.example`](.env.example) for the complete list of all 60 environment variables with defaults and inline comments.
+See [`.env.example`](.env.example) for the complete list of all 21 environment variables (LLM + TTS infrastructure only). All pipeline behavior is configured via [`examples/job.example.yaml`](examples/job.example.yaml) — 30 params keys covering scene detection, match, render, translate, BGM, WhisperX, async, and video sizes.
 
 ### LLM Provider Guides
 
@@ -494,7 +493,7 @@ movie-narrator/
 - [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
 - [x] Auto-create `~/.movie-narrator/.env` on first run
 - [x] `export_clips` direct ffmpeg subprocess (design choice, not workaround)
-- [x] Config system overhaul: 33 hardcoded constants promoted to Settings (60 total `MN_*` env vars); YAML auto-discovery (`--config` not passed → `cwd/job.yaml` → packaged example); `.env.example` as single source of truth for first-run; all YAML params properly connected through `runner.py` → `ctx.metadata` → pipeline steps
+- [x] Config system overhaul: strict env/yaml boundary — `.env` (Settings) contains 21 LLM + TTS infrastructure fields only; `job.yaml` (params) contains all 30 pipeline behavior keys; YAML auto-discovery (`--config` not passed → `cwd/job.yaml` → packaged example); `.env.example` and `job.example.yaml` are the single sources of truth; no code constants module — inline literals match example files
 
 ### v0.5.x — Ecosystem (Planned)
 

--- a/README.md
+++ b/README.md
@@ -137,26 +137,12 @@ mn create --movie "飞驰人生" --keep-cache
 
 ### CLI Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--movie, -m` | Movie name (required) | - |
-| `--style, -s` | Narration style | `热血搞笑` |
-| `--duration, -d` | Target duration (seconds) | `60` |
-| `--voice, -v` | TTS voice (provider-interpreted) | `zh-CN-YunxiNeural` |
-| `--format, -f` | Video format (`16:9` or `9:16`) | `16:9` |
-| `--video, -V` | Source movie file path | - |
-| `--library-dir` | Movie library directory | - |
-| `--research` | Enable plot research via LLM | `false` |
-| `--no-research` | Disable plot research | - |
-| `--bgm` | Background music file path | - |
-| `--no-bgm` | Disable BGM even if default is set | `false` |
-| `--no-clips` | Skip scene-level clip export | `false` |
-| `--strict` | Abort pipeline on soft step failure | `false` |
-| `--keep-cache` | Keep TTS cache files for debugging | `false` |
-| `--retry` | Enable interactive retry on hard step failure | `false` |
-| `--subtitle-lang` | Target language tag (`en`, `ja`, `zh-TW`, ...); empty = feature off | - |
-| `--subtitle-mode` | Overlay mode: `original` / `translated` / `bilingual` | `original` |
-| `--config` | Path to job YAML (movie/steps/params); CLI flags override YAML | - |
+```bash
+# Basic usage
+mn create --movie "飞驰人生" --style "热血搞笑" --duration 60
+```
+
+All 18 CLI flags are documented in [`examples/cli-usage.sh`](examples/cli-usage.sh) with usage examples for every scenario: basic, video/library, research/BGM/clips, multi-language subtitles, and YAML config. Key flags: `--movie/-m`, `--style/-s`, `--duration/-d`, `--voice/-v`, `--format/-f`, `--video/-V`, `--library-dir`, `--research`, `--bgm`, `--no-bgm`, `--no-clips`, `--strict`, `--keep-cache`, `--retry`, `--subtitle-lang`, `--subtitle-mode`, `--config`.
 
 ### Job YAML config (v0.3)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,7 +173,7 @@ mn create --config examples/job.example.yaml --movie "其他电影" --no-clips
 
 这意味着新用户可以直接 `mn create --movie X` 而无需创建任何配置文件——示例 YAML 会自动提供默认的 steps/params。
 
-详细白名单请参考 [`examples/job.example.yaml`](examples/job.example.yaml)：软步骤开关（`steps:` 下的 `research` / `align` / `scene` / `match` / `bgm` / `export` / `translate`）、全部 14 个 `params:` 键（`scene_threshold` / `scene_frame_skip` / `match_min_score` / `match_speed_clamp_min` / `match_speed_clamp_max` / `scene_merge_min_duration` / `bgm_gain_db` / `tts_pause_ms` / `embedding_model_name` / `research_provider` / `translate_provider` / `translate_retries` / `translate_chunk_chars` / `translate_chunk_size`），以及多语言字幕顶层键 `subtitle_lang` / `subtitle_mode`。相对路径 `video` / `bgm` / `library_dir` 相对于 YAML 所在目录解析。LLM 凭据请保留在 `.env` / `MN_*` 环境变量中。
+详细白名单请参考 [`examples/job.example.yaml`](examples/job.example.yaml)：软步骤开关（`steps:` 下的 `research` / `align` / `scene` / `match` / `bgm` / `export` / `translate`）、全部 30 个 `params:` 键（场景检测、匹配、BGM、TTS 速率、翻译、调研、WhisperX、渲染、异步、视频分辨率），以及多语言字幕顶层键 `subtitle_lang` / `subtitle_mode`。相对路径 `video` / `bgm` / `library_dir` 相对于 YAML 所在目录解析。LLM 凭据请保留在 `.env` / `MN_*` 环境变量中。
 
 ### 多语言字幕
 
@@ -250,7 +250,6 @@ MN_LLM_BASE_URL=http://localhost:11434/v1
 MN_LLM_API_KEY=ollama
 MN_LLM_MODEL=qwen2.5:7b
 MN_DEFAULT_VOICE=zh-CN-YunxiNeural
-MN_DEFAULT_FORMAT=16:9
 ```
 
 ### 通过环境变量
@@ -280,7 +279,7 @@ mn create --movie "飞驰人生" --duration 60
 
 ### 完整配置项
 
-完整环境变量列表（共 60 项）及默认值和说明，请查看 [`.env.example`](.env.example)。
+完整环境变量列表（共 21 项，仅 LLM + TTS 基础配置）及默认值和说明，请查看 [`.env.example`](.env.example)。所有流水线行为参数（30 项）通过 [`examples/job.example.yaml`](examples/job.example.yaml) 配置，涵盖场景检测、匹配、渲染、翻译、BGM、WhisperX、异步、视频分辨率等。
 
 ### LLM 服务商导航
 
@@ -492,7 +491,7 @@ movie-narrator/
 - [x] 步骤级重试机制（`--retry` 标志，`StepAction` 枚举）
 - [x] 首次运行自动创建 `~/.movie-narrator/.env`
 - [x] `export_clips` 直调 ffmpeg 子进程（设计选择，非临时方案）
-- [x] 配置系统全面重构：33 个硬编码常量提升为 Settings（共 60 个 `MN_*` 环境变量）；YAML 自动发现（未传 `--config` → `cwd/job.yaml` → 打包示例）；`.env.example` 作为首次运行单一真相源；所有 YAML 参数正确连接 `runner.py` → `ctx.metadata` → 流水线步骤
+- [x] 配置系统全面重构：严格 env/yaml 边界 — `.env`（Settings）仅含 21 个 LLM + TTS 基础配置字段；`job.yaml`（params）含全部 30 个流水线行为键；YAML 自动发现（未传 `--config` → `cwd/job.yaml` → 打包示例）；`.env.example` 和 `job.example.yaml` 作为单一真相源；无代码常量模块——内联字面量与示例文件一致
 
 ### v0.5.x — 生态系统（规划中）
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,26 +135,12 @@ mn create --movie "飞驰人生" --keep-cache
 
 ### CLI 参数
 
-| 参数 | 说明 | 默认值 |
-|------|------|--------|
-| `--movie, -m` | 电影名称（必填） | - |
-| `--style, -s` | 解说风格 | `热血搞笑` |
-| `--duration, -d` | 目标时长（秒） | `60` |
-| `--voice, -v` | TTS 音色（由 Provider 解释） | `zh-CN-YunxiNeural` |
-| `--format, -f` | 视频比例（`16:9` 或 `9:16`） | `16:9` |
-| `--video, -V` | 源电影文件路径 | - |
-| `--library-dir` | 电影库目录 | - |
-| `--research` | 启用 LLM 剧情调研 | `false` |
-| `--no-research` | 禁用剧情调研 | - |
-| `--bgm` | 背景音乐文件路径 | - |
-| `--no-bgm` | 禁用 BGM | `false` |
-| `--no-clips` | 跳过场景片段导出 | `false` |
-| `--strict` | 软步骤失败时中止 | `false` |
-| `--keep-cache` | 保留 TTS 缓存文件 | `false` |
-| `--retry` | 硬步骤失败时启用交互式重试 | `false` |
-| `--subtitle-lang` | 目标语言标签（`en`、`ja`、`zh-TW`...），留空 = 关闭翻译 | - |
-| `--subtitle-mode` | 渲染叠加模式：`original` / `translated` / `bilingual` | `original` |
-| `--config` | Job YAML 配置文件路径（movie/steps/params）；CLI 参数覆盖 YAML | - |
+```bash
+# 基础用法
+mn create --movie "飞驰人生" --style "热血搞笑" --duration 60
+```
+
+全部 18 个 CLI 参数及各场景用法示例（基础、视频/库、调研/BGM/片段、多语言字幕、YAML 配置）请参考 [`examples/cli-usage.sh`](examples/cli-usage.sh)。主要参数：`--movie/-m`、`--style/-s`、`--duration/-d`、`--voice/-v`、`--format/-f`、`--video/-V`、`--library-dir`、`--research`、`--bgm`、`--no-bgm`、`--no-clips`、`--strict`、`--keep-cache`、`--retry`、`--subtitle-lang`、`--subtitle-mode`、`--config`。
 
 ### Job YAML 配置（v0.3）
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,11 +54,12 @@ run_pipeline(...) # STEPS order unchanged
 
 - Module: `movie_narrator.workflow` (`load_job_config`, `merge_job`, `JobConfigError`)
 - Soft steps honor `metadata["workflow_steps"][<field>] is False` → `status.<field> = "disabled"`
-- Params whitelist (`scene_threshold`, `scene_frame_skip`, `match_min_score`, `match_speed_clamp_min`, `match_speed_clamp_max`, `scene_merge_min_duration`, `bgm_gain_db`, `tts_pause_ms`, `embedding_model_name`, `research_provider`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`) land in `ctx.metadata` via `build_context` copy loop
+- Params whitelist (30 keys: scene_threshold, scene_frame_skip, match_min_score, match_speed_clamp_min/max, scene_merge_min_duration, embedding_model_name, bgm_gain_db, tts_pause_ms, tts_max_concurrent, tts_audio_format, tts_audio_bitrate, translate_source_lang, translate_provider, translate_retries, translate_chunk_chars, translate_chunk_size, research_provider, whisperx_device/model/language, render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout, async_timeout, async_max_workers, video_sizes) land in `ctx.metadata` via `build_context` copy loop
 - Multi-language subtitle top-level keys: `subtitle_lang`, `subtitle_mode` (validated in `JobConfig` — `subtitle_mode ∈ {translated, bilingual}` without `subtitle_lang` raises `JobConfigError` at merge time)
 - `STEPS` remains the single source of step order; no DAG / plugins in v0.3
 - YAML auto-discovery (v0.4.7): `--config` not passed → `cwd/job.yaml` → packaged `examples/job.example.yaml` → none
 - `.env.example` is the single source of truth for first-run config (read by `ensure_user_config()`, not a divergent inline template)
+- Strict env/yaml boundary: `.env` (Settings) = 21 LLM + TTS infrastructure fields only; `job.yaml` (params) = 30 pipeline behavior keys; no code constants module — inline literals match example files
 
 ## Web UI Layer (v0.3.5)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,12 +82,12 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 
 ### v0.4.7 Config system overhaul
 
-- [x] 33 hardcoded constants promoted to Settings (60 total `MN_*` env vars)
+- [x] Strict env/yaml boundary: `.env` = 21 LLM + TTS infrastructure fields only; `job.yaml` = 30 pipeline behavior params
 - [x] YAML auto-discovery: `--config` not passed → `cwd/job.yaml` → packaged example → none
-- [x] `.env.example` as single source of truth for first-run config (replaces divergent inline template)
-- [x] All 14 YAML params properly connected through `runner.py` → `ctx.metadata` → pipeline steps
+- [x] `.env.example` and `job.example.yaml` as single sources of truth (no code constants module)
+- [x] All 30 YAML params properly connected through `runner.py` → `ctx.metadata` → pipeline steps
 - [x] Fixed `translate_chunk_chars/size` silently ignored (never copied to `ctx.metadata`)
-- [x] Fixed `export_clips` codecs hardcoded (now uses `settings.render_video_codec/audio_codec`)
+- [x] Fixed `export_clips` codecs hardcoded (now uses `ctx.metadata` → inline literal)
 - [x] Fixed `scene_frame_skip` missing from runner copy loop
 
 ### v0.4 Environment variables
@@ -102,20 +102,25 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 - `MN_MIMO_BASE_URL` — MiMo base URL (default `https://api.xiaomimimo.com/v1`)
 - `MN_MIMO_STYLE_PROMPT` — Style description for `mimo-v2.5-tts` user message (default empty)
 
-### v0.4.7 Environment variables (config system overhaul)
+### v0.4.7 env/yaml boundary (config system overhaul)
 
-See [`.env.example`](../.env.example) for the complete list of all 60 `MN_*` env vars. Key additions:
+Strict separation: `.env` contains ONLY LLM + TTS infrastructure (21 fields); `job.yaml` contains ALL pipeline behavior (30 params).
 
-- LLM tuning: `MN_LLM_TIMEOUT`, `MN_SCRIPT_TEMPERATURE`, `MN_SCRIPT_MAX_TOKENS`, `MN_SCRIPT_RETRIES`, `MN_SCRIPT_RETRY_DELAY`, `MN_RESEARCH_TEMPERATURE`, `MN_RESEARCH_MAX_TOKENS`, `MN_TRANSLATE_MAX_TOKENS`
-- TTS: `MN_TTS_MAX_CONCURRENT`, `MN_TTS_AUDIO_FORMAT`, `MN_TTS_AUDIO_BITRATE`
-- WhisperX: `MN_WHISPERX_DEVICE`, `MN_WHISPERX_MODEL`, `MN_WHISPERX_LANGUAGE`
-- Translate: `MN_TRANSLATE_SOURCE_LANG`
-- Render: `MN_RENDER_BG_COLOR`, `MN_RENDER_FONT_SIZE`, `MN_RENDER_OUTPUT_NAME`, `MN_RENDER_FFMPEG_TIMEOUT`
-- Match: `MN_MATCH_SPEED_CLAMP_MIN`, `MN_MATCH_SPEED_CLAMP_MAX`, `MN_SCENE_MERGE_MIN_DURATION`, `MN_EMBEDDING_MODEL_NAME`
-- BGM: `MN_BGM_GAIN_DB`
-- TTS pacing: `MN_TTS_PAUSE_MS`, `MN_TTS_CACHE_MAX_MB`
-- Video: `MN_VIDEO_SIZES` (JSON string)
-- Async: `MN_ASYNC_TIMEOUT`, `MN_ASYNC_MAX_WORKERS`
+**`.env` (Settings) — 21 fields:** See [`.env.example`](../.env.example)
+- LLM (11): `MN_LLM_BASE_URL`, `MN_LLM_API_KEY`, `MN_LLM_MODEL`, `MN_LLM_TIMEOUT`, `MN_SCRIPT_TEMPERATURE`, `MN_SCRIPT_MAX_TOKENS`, `MN_SCRIPT_RETRIES`, `MN_SCRIPT_RETRY_DELAY`, `MN_RESEARCH_TEMPERATURE`, `MN_RESEARCH_MAX_TOKENS`, `MN_TRANSLATE_MAX_TOKENS`
+- TTS (10): `MN_DEFAULT_VOICE`, `MN_TTS_PROVIDER`, `MN_TTS_CACHE_MAX_MB`, `MN_OPENAI_TTS_*`(3), `MN_MIMO_*`(4)
+
+**`job.yaml` (params) — 30 keys:** See [`job.example.yaml`](../examples/job.example.yaml)
+- Scene: `scene_threshold`, `scene_frame_skip`
+- Match: `match_min_score`, `match_speed_clamp_min/max`, `scene_merge_min_duration`, `embedding_model_name`
+- BGM: `bgm_gain_db`
+- TTS pacing: `tts_pause_ms`, `tts_max_concurrent`, `tts_audio_format`, `tts_audio_bitrate`
+- Translate: `translate_source_lang`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`
+- Research: `research_provider`
+- WhisperX: `whisperx_device/model/language`
+- Render: `render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout`
+- Async: `async_timeout`, `async_max_workers`
+- Video: `video_sizes`
 
 ### Provider env-var naming convention
 

--- a/examples/cli-usage.sh
+++ b/examples/cli-usage.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Movie Narrator — CLI 用法示例
+# 所有参数可选；不填则使用默认值或 YAML 配置
+# 优先级：CLI 参数 > job.yaml > 内联默认值
+
+# ============================================================
+# 基础用法
+# ============================================================
+
+# 最简调用 — 仅指定电影名
+mn create --movie "飞驰人生"
+
+# 指定解说风格和时长
+mn create --movie "飞驰人生" --style "热血搞笑" --duration 60
+
+# 指定音色和视频比例
+mn create --movie "飞驰人生" --voice "zh-CN-XiaoxiaoNeural" --format "9:16"
+
+# 保留 TTS 缓存（调试用）
+mn create --movie "飞驰人生" --keep-cache
+
+# ============================================================
+# 源视频 / 电影库
+# ============================================================
+
+# 直接指定源视频文件
+mn create --movie "飞驰人生" --video "/path/to/movie.mp4"
+
+# 从电影库目录模糊匹配
+mn create --movie "飞驰人生" --library-dir "/path/to/movie/library"
+
+# ============================================================
+# 调研 / BGM / 片段导出
+# ============================================================
+
+# 启用 LLM 剧情调研
+mn create --movie "飞驰人生" --research
+
+# 指定背景音乐
+mn create --movie "飞驰人生" --bgm "/path/to/bgm.mp3"
+
+# 禁用 BGM
+mn create --movie "飞驰人生" --no-bgm
+
+# 跳过场景片段导出（仅生成解说音频 + 字幕）
+mn create --movie "飞驰人生" --no-clips
+
+# 严格模式 — 软步骤失败时中止
+mn create --movie "飞驰人生" --strict
+
+# ============================================================
+# 多语言字幕
+# ============================================================
+
+# 翻译为英文字幕并叠加双语显示
+mn create --movie "Inception" --subtitle-lang en --subtitle-mode bilingual
+
+# 仅生成翻译字幕（画面仍用原版）
+mn create --movie "Inception" --subtitle-lang en
+
+# ============================================================
+# YAML 配置
+# ============================================================
+
+# 通过 YAML 文件驱动任务
+mn create --config examples/job.example.yaml
+
+# CLI 参数覆盖 YAML
+mn create --config examples/job.example.yaml --movie "其他电影" --no-clips
+
+# ============================================================
+# 完整参数列表
+# ============================================================
+# | 参数 | 说明 | 默认值 |
+# |------|------|--------|
+# | --movie, -m        | 电影名称（必填，除非 YAML 中指定） | - |
+# | --style, -s        | 解说风格 | 热血搞笑 |
+# | --duration, -d     | 目标时长（秒） | 60 |
+# | --voice, -v        | TTS 音色（按 provider 解释） | zh-CN-YunxiNeural |
+# | --format, -f       | 视频比例 (16:9 / 9:16) | 16:9 |
+# | --video, -V        | 源电影文件路径 | - |
+# | --library-dir      | 电影库目录 | - |
+# | --research         | 启用 LLM 剧情调研 | false |
+# | --no-research      | 禁用剧情调研 | - |
+# | --bgm              | 背景音乐文件路径 | - |
+# | --no-bgm           | 禁用 BGM | false |
+# | --no-clips         | 跳过场景片段导出 | false |
+# | --strict           | 软步骤失败时中止 | false |
+# | --keep-cache       | 保留 TTS 缓存 | false |
+# | --retry            | 硬步骤失败时交互重试 | false |
+# | --subtitle-lang    | 目标语言标签 (en/ja/zh-TW...)；空=关闭 | - |
+# | --subtitle-mode    | 字幕模式 (original/translated/bilingual) | original |
+# | --config           | YAML 配置文件路径 | 自动发现 |

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -34,7 +34,6 @@ def _read_example_env() -> str:
         "MN_LLM_API_KEY=ollama\n"
         "MN_LLM_MODEL=qwen2.5:7b\n"
         "MN_DEFAULT_VOICE=zh-CN-YunxiNeural\n"
-        "MN_DEFAULT_FORMAT=16:9\n"
     )
 
 


### PR DESCRIPTION
After PR #19 moved pipeline params from .env to job.yaml, 6 documents still described the old architecture.

## 9 fixes across 6 files

**README.md** (4): Remove \MN_DEFAULT_FORMAT\ from example; '60 env vars' -> '21'; '14 params' -> '30'; '33 hardcoded -> Settings (60)' -> strict boundary description.

**README.zh-CN.md** (4): Same 4 errors, Chinese version.

**CHANGELOG.md** (1): Add [Unreleased] section for breaking boundary refactor.

**docs/ARCHITECTURE.md** (2): Params whitelist 14 -> 30; add strict boundary note.

**docs/ROADMAP.md** (3): v0.4.7 section rewritten; env vars section replaced with env/yaml split.

**config.py** (1): Remove \MN_DEFAULT_FORMAT\ from fallback template.