### PR TITLE
docs: remove inline version annotations from README and ARCHITECTURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ mn create --movie "飞驰人生" --style "热血搞笑" --duration 60
 
 All 18 CLI flags are documented in [`examples/cli-usage.sh`](examples/cli-usage.sh) with usage examples for every scenario: basic, video/library, research/BGM/clips, multi-language subtitles, and YAML config. Key flags: `--movie/-m`, `--style/-s`, `--duration/-d`, `--voice/-v`, `--format/-f`, `--video/-V`, `--library-dir`, `--research`, `--bgm`, `--no-bgm`, `--no-clips`, `--strict`, `--keep-cache`, `--retry`, `--subtitle-lang`, `--subtitle-mode`, `--config`.
 
-### Job YAML config (v0.3)
+### Job YAML config
 
 ```bash
 # Drive a job from YAML (movie may live only in the file)
@@ -189,7 +189,7 @@ When `--subtitle-lang` is set, `generate_subtitle` always writes three SRT files
 
 Setting `subtitle_mode=translated|bilingual` without `subtitle_lang` raises `JobConfigError` at merge time. Failure policy: LLM retries `MN_TRANSLATE_RETRIES` times, then soft-degrades to filling the translation track with the original text and surfacing a warning.
 
-### Web UI (v0.3.5)
+### Web UI
 
 ```bash
 # Install with web extra
@@ -368,7 +368,7 @@ movie-narrator/
 │   │   ├── load.py          # YAML loader + validation
 │   │   ├── merge.py         # CLI > YAML > Settings merge
 │   │   └── errors.py        # JobConfigError
-│   ├── tts/                     # TTS abstraction layer (v0.4)
+│   ├── tts/                     # TTS abstraction layer
 │   │   ├── __init__.py          # re-exports public API
 │   │   ├── protocol.py          # TTSProvider ABC
 │   │   ├── base.py              # BaseTTSProvider (CI silent fallback), is_ci()
@@ -390,7 +390,7 @@ movie-narrator/
 │   │   ├── optional_deps.py # Optional dependency probing
 │   │   ├── prompts.py       # Prompt templates
 │   │   └── retention.py     # Log file retention
-│   └── web/                     # Gradio browser UI (v0.3.5; requires [web] extra)
+│   └── web/                     # Gradio browser UI (requires [web] extra)
 │       ├── __init__.py          # lazy launch_web export
 │       ├── __main__.py          # python -m movie_narrator.web
 │       ├── app.py               # Gradio Blocks layout + event handlers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,7 @@ class PipelineStatus(BaseModel):
 via `steps.translate=false` or unknown provider" (see
 `docs/superpowers/specs/2026-07-13-multi-language-subtitle-design.md` §4.1).
 
-## Job config merge layer (v0.3)
+## Job config merge layer
 
 Optional declarative job YAML sits **in front of** `run_pipeline`:
 
@@ -57,11 +57,11 @@ run_pipeline(...) # STEPS order unchanged
 - Params whitelist (30 keys: scene_threshold, scene_frame_skip, match_min_score, match_speed_clamp_min/max, scene_merge_min_duration, embedding_model_name, bgm_gain_db, tts_pause_ms, tts_max_concurrent, tts_audio_format, tts_audio_bitrate, translate_source_lang, translate_provider, translate_retries, translate_chunk_chars, translate_chunk_size, research_provider, whisperx_device/model/language, render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout, async_timeout, async_max_workers, video_sizes) land in `ctx.metadata` via `build_context` copy loop
 - Multi-language subtitle top-level keys: `subtitle_lang`, `subtitle_mode` (validated in `JobConfig` — `subtitle_mode ∈ {translated, bilingual}` without `subtitle_lang` raises `JobConfigError` at merge time)
 - `STEPS` remains the single source of step order; no DAG / plugins in v0.3
-- YAML auto-discovery (v0.4.7): `--config` not passed → `cwd/job.yaml` → packaged `examples/job.example.yaml` → none
+- YAML auto-discovery: `--config` not passed → `cwd/job.yaml` → packaged `examples/job.example.yaml` → none
 - `.env.example` is the single source of truth for first-run config (read by `ensure_user_config()`, not a divergent inline template)
 - Strict env/yaml boundary: `.env` (Settings) = 21 LLM + TTS infrastructure fields only; `job.yaml` (params) = 30 pipeline behavior keys; no code constants module — inline literals match example files
 
-## Web UI Layer (v0.3.5)
+## Web UI Layer
 
 The Gradio-based Web UI is a thin shell over the same pipeline entry points:
 
@@ -97,7 +97,7 @@ bridge polls GradioConsole.snapshot() every 200ms → yields to Gradio
 | `web/models.py` | `RunStatus` enum, `WebRun` per-session state |
 | `web/utils.py` | Upload handling, `collect_artifacts()`, filename sanitization |
 
-## TTS Abstraction Layer (v0.4)
+## TTS Abstraction Layer
 
 The `tts/` package decouples TTS backend selection from pipeline orchestration:
 


### PR DESCRIPTION
Removed version tags like (v0.3), (v0.3.5), (v0.4), (v0.4.7) from section headers and inline descriptions. These belong in CHANGELOG and ROADMAP, not in user-facing docs.

**README.md** (4 removals):
- \### Job YAML config (v0.3)\ -> \### Job YAML config\
- \### Web UI (v0.3.5)\ -> \### Web UI\
- \# TTS abstraction layer (v0.4)\ -> \# TTS abstraction layer\
- \# Gradio browser UI (v0.3.5; requires [web] extra)\ -> \# Gradio browser UI (requires [web] extra)\

**docs/ARCHITECTURE.md** (4 removals):
- \## Job config merge layer (v0.3)\ -> \## Job config merge layer\
- \YAML auto-discovery (v0.4.7):\ -> \YAML auto-discovery:\
- \## Web UI Layer (v0.3.5)\ -> \## Web UI Layer\
- \## TTS Abstraction Layer (v0.4)\ -> \## TTS Abstraction Layer\

Roadmap section version headers (v0.1.x, v0.2.x, ...) retained — that is the standard roadmap structure, not inline annotations.