### PR TITLE
refactor: code audit optimizations (5 fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **align.py**: WhisperX alignment switched from index-based (1:1) to time-overlap matching. Index-based caused drift on long videos when WhisperX produced a different number of segments than the script (silence/music sections).
 - **render.py**: `VideoFileClip` open failure upgraded from `debug` to `inline_warn` with clear message: "Falling back to text-only video — no footage will be shown."
 
+### Refactored (code audit optimizations)
+- **utils/sanitize.py**: Extracted `sanitize_filename()` to shared module (was duplicated in `cli.py` and `web/utils.py`).
+- **runner.py**: Added module-level assertion enforcing `SOFT_STATUS_STEPS` ↔ `STATUS_FIELD_FOR_STEP` key consistency.
+- **match.py**: `SentenceTransformer` model loading cached via `lru_cache` (was reloaded twice per `match_clips` call, saving 1-3 seconds).
+- **subtitle.py**: SRT files now written with UTF-8 BOM (`utf-8-sig`) — prevents CJK mojibake on older players that default to system ANSI.
+- **resolve.py**: Added `elif` + comments to make `--video` vs `--library-dir` fallthrough explicit.
+
 ## [0.4.8] - 2026-07-16
 
 ### Fixed

--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -53,21 +53,7 @@ class InteractiveCLIController:
             return StepAction.SKIP
         return StepAction.ABORT
 
-_RESERVED_NAMES = {
-    "CON", "PRN", "AUX", "NUL",
-    *(f"COM{i}" for i in range(1, 10)),
-    *(f"LPT{i}" for i in range(1, 10)),
-}
-
-
-def _sanitize_filename(name: str) -> str:
-    name = re.sub(r'[<>:"/\\|?*]', "_", name)
-    name = name.strip().rstrip(".")
-    if not name:
-        name = "movie"
-    if name.upper() in _RESERVED_NAMES:
-        name = f"_{name}"
-    return name
+from .utils.sanitize import sanitize_filename as _sanitize_filename
 
 
 @app.command()

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -118,15 +118,29 @@ def _build_scene_label(scene_index: int, start: float, end: float) -> str:
     return f"scene {scene_index} from {start:.1f}s to {end:.1f}s"
 
 
+import functools
+
+
+@functools.lru_cache(maxsize=2)
+def _load_embedding_model(model_name: str):
+    """Load and cache a SentenceTransformer model.
+
+    Loading takes 1-3 seconds and ~200MB; caching avoids re-loading
+    when _embed_texts is called twice per match_clips run (scene labels
+    + narration texts).
+    """
+    from sentence_transformers import SentenceTransformer
+
+    return SentenceTransformer(model_name)
+
+
 def _embed_texts(texts: List[str], model_name: str = _EMBEDDING_MODEL_NAME):
     """Encode a list of strings to L2-normalized vectors.
 
     Returns ``None`` when sentence-transformers is unavailable or fails at
     runtime, so the caller can fall back to the heuristic shape.
     """
-    from sentence_transformers import SentenceTransformer
-
-    model = SentenceTransformer(model_name)
+    model = _load_embedding_model(model_name)
     vectors = model.encode(texts)
     import numpy as np
 

--- a/src/movie_narrator/pipeline/resolve.py
+++ b/src/movie_narrator/pipeline/resolve.py
@@ -46,12 +46,14 @@ def resolve_video(ctx: Context) -> Context:
             raise FileNotFoundError(f"video not found: {video_arg}")
         ctx.source_video_path = str(p.resolve())
         return ctx
-    if ctx.library_dir:
+    elif ctx.library_dir:
+        # No --video flag; try fuzzy match in library
         hit = find_in_library(ctx.movie_name, ctx.library_dir)
         if hit:
             if ctx.services:
                 ctx.services.console.debug(f"library match: {hit}")
             ctx.source_video_path = hit
             return ctx
+    # No video source found — pipeline continues without footage
     ctx.source_video_path = None
     return ctx

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -50,6 +50,12 @@ STATUS_FIELD_FOR_STEP: Dict[str, str] = {
     "translate_subtitles": "translate",
 }
 
+# Safety: every soft step must have a status field mapping.
+# A typo in either dict would silently break status tracking.
+assert SOFT_STATUS_STEPS == set(STATUS_FIELD_FOR_STEP), (
+    "SOFT_STATUS_STEPS and STATUS_FIELD_FOR_STEP keys must match"
+)
+
 # Short alias mapping for workflow_steps keys (spec §9 back-compat).
 # Allows users to write `{"translate": False}` in addition to the
 # function-name key `{"translate_subtitles": False}`.

--- a/src/movie_narrator/pipeline/subtitle.py
+++ b/src/movie_narrator/pipeline/subtitle.py
@@ -20,7 +20,7 @@ def _write_srt(path: Path, cues: list[tuple[int, str, str, str]]) -> None:
     File is opened with `newline=""` so Python does not translate the
     LF bytes we wrote on Windows.
     """
-    with open(path, "w", encoding="utf-8", newline="") as f:
+    with open(path, "w", encoding="utf-8-sig", newline="") as f:
         for idx, start, end, body in cues:
             f.write(f"{idx}\n")
             f.write(f"{start} --> {end}\n")

--- a/src/movie_narrator/utils/sanitize.py
+++ b/src/movie_narrator/utils/sanitize.py
@@ -1,0 +1,31 @@
+"""Shared filename sanitization utility.
+
+Used by both CLI and Web UI to ensure consistent directory/file naming
+across the application. Single source of truth — both callers import
+from here.
+"""
+
+import re
+
+_RESERVED_NAMES = {
+    "CON", "PRN", "AUX", "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def sanitize_filename(name: str) -> str:
+    """Make a string safe for use as a directory or file name.
+
+    - Replaces invalid characters (< > : " / \\ | ? *) with underscore
+    - Strips leading/trailing whitespace and trailing dots
+    - Falls back to "movie" if the result is empty
+    - Prefixes Windows reserved names (CON, PRN, AUX, ...) with underscore
+    """
+    name = re.sub(r'[<>:"/\\|?*]', "_", name)
+    name = name.strip().rstrip(".")
+    if not name:
+        name = "movie"
+    if name.upper() in _RESERVED_NAMES:
+        name = f"_{name}"
+    return name

--- a/src/movie_narrator/web/utils.py
+++ b/src/movie_narrator/web/utils.py
@@ -8,27 +8,11 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
+from ..utils.sanitize import sanitize_filename
 from ..models import Context
 
 # Temp dirs created by save_upload — tracked for cleanup
 _tempdirs: List[Path] = []
-
-_RESERVED_NAMES = {
-    "CON", "PRN", "AUX", "NUL",
-    *(f"COM{i}" for i in range(1, 10)),
-    *(f"LPT{i}" for i in range(1, 10)),
-}
-
-
-def sanitize_filename(name: str) -> str:
-    """Make a string safe for use as a directory name."""
-    name = re.sub(r'[<>:"/\\|?*]', "_", name)
-    name = name.strip().rstrip(".")
-    if not name:
-        name = "movie"
-    if name.upper() in _RESERVED_NAMES:
-        name = f"_{name}"
-    return name
 
 
 def save_upload(gradio_file) -> Optional[str]:

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -12,6 +12,14 @@ from movie_narrator.pipeline import match as match_module
 from movie_narrator.pipeline.match import match_clips
 
 
+@pytest.fixture(autouse=True)
+def _clear_embedding_cache():
+    """Clear lru_cache between tests so mock SentenceTransformer doesn't leak."""
+    match_module._load_embedding_model.cache_clear()
+    yield
+    match_module._load_embedding_model.cache_clear()
+
+
 def _make_ctx(tmp_path, source_video="video.mp4"):
     ctx = Context(
         movie_name="m",


### PR DESCRIPTION
## Code audit optimizations (5 fixes)

From the v0.4.7 code analysis report. Each item independently evaluated — 5 fixed, 5 skipped.

### Fixed

1. **sanitize_filename dedup** (Medium) — Extracted to `utils/sanitize.py`. Was duplicated verbatim in `cli.py` and `web/utils.py`.

2. **SOFT_STATUS_STEPS consistency assert** (Medium) — Added `assert SOFT_STATUS_STEPS == set(STATUS_FIELD_FOR_STEP)` at module level. Catches typos at import time.

3. **SentenceTransformer lru_cache** (Low) — Model was reloaded twice per `match_clips` call. `@lru_cache(maxsize=2)` saves 1-3 seconds per run.

4. **SRT UTF-8 BOM** (High) — Changed `utf-8` to `utf-8-sig`. Chinese subtitles on older players (WMP, some Smart TVs) default to system ANSI without BOM, causing mojibake.

5. **resolve_video elif** (Low) — Added `elif` + comments to make `--video` vs `--library-dir` fallthrough explicit.

### Skipped (with reasoning)

- **#2 _ALLOWED_TOP redundant** — Manual check provides friendlier error messages (lists allowed keys). Removing it would degrade UX.
- **#6 TTS LRU O(n log n)** — Premature optimization. Default behavior deletes cache each run; scan only runs with `--keep-cache`.
- **#7 CLI top-level imports** — Low impact. Users run `mn create` (needs all imports) far more than `mn --help`.
- **#8 retry loop** — No bug. Audit itself says "this is the intended fail-fast behavior."
- **#9 ScriptSegment single field** — YAGNI. Add fields when LLM prompt actually needs them.
