### PR TITLE
feat: WebUI refactor — FastAPI + React + WebSocket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ ml = [
     'whisperx>=3.0; python_version < "3.14"',
     'sentence-transformers>=3.0; python_version < "3.14"',
 ]
-web = ["gradio>=4.44,<7"]
+web = [
+    "fastapi>=0.104.0",
+    "uvicorn[standard]>=0.24.0",
+    "python-multipart>=0.0.6",
+]
 full = [
     "scenedetect>=0.6",
     'whisperx>=3.0; python_version < "3.14"',

--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -347,18 +347,10 @@ def version():
 
 @app.command()
 def web(
-    host: str = typer.Option("127.0.0.1", "--host", help="Bind host"),
-    port: int = typer.Option(7860, "--port", help="Bind port"),
-    share: bool = typer.Option(False, "--share", help="Create public Gradio link"),
+    host: str = typer.Option("127.0.0.1", "--host", "-h", help="Bind host"),
+    port: int = typer.Option(8760, "--port", "-p", help="Bind port"),
+    reload: bool = typer.Option(False, "--reload", help="Auto-reload on file changes"),
 ):
-    """Launch the browser UI (local Gradio app)."""
-    try:
-        from .web import launch_web
-    except ImportError:
-        typer.echo(
-            "Web UI requires the 'web' extra. Install with:\n"
-            "  pip install \"movie-narrator[web]\"",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    launch_web(host=host, port=port, share=share)
+    """Launch the Web UI (FastAPI + React)."""
+    from .web_api import launch_web_api
+    launch_web_api(host=host, port=port, reload=reload)

--- a/src/movie_narrator/web_api/__init__.py
+++ b/src/movie_narrator/web_api/__init__.py
@@ -1,0 +1,19 @@
+"""Web API — FastAPI + WebSocket backend for the React WebUI."""
+
+from __future__ import annotations
+
+__all__ = ["launch_web_api"]
+
+
+def launch_web_api(host: str = "127.0.0.1", port: int = 8760, reload: bool = False) -> None:
+    """Start the FastAPI web API server.
+
+    Imports are lazy so that ``mn web`` doesn't require fastapi/uvicorn
+    unless the user actually launches the web UI.
+    """
+    import uvicorn
+
+    from .server import create_app
+
+    app = create_app()
+    uvicorn.run(app, host=host, port=port, reload=reload)

--- a/src/movie_narrator/web_api/__main__.py
+++ b/src/movie_narrator/web_api/__main__.py
@@ -1,0 +1,6 @@
+"""python -m movie_narrator.web_api — launch the web API server."""
+
+from . import launch_web_api
+
+if __name__ == "__main__":
+    launch_web_api()

--- a/src/movie_narrator/web_api/console.py
+++ b/src/movie_narrator/web_api/console.py
@@ -1,0 +1,80 @@
+"""WebSocketConsole — buffered console for WebSocket UI consumption.
+
+Thread-safe: pipeline thread writes lines, WS endpoint polls snapshot().
+Identical protocol to GradioConsole — drop-in replacement.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import nullcontext
+from typing import Tuple
+
+from ..utils.console import BaseConsole
+
+
+class WebSocketConsole(BaseConsole):
+    """Buffered console for WebSocket UI consumption."""
+
+    def __init__(self) -> None:
+        self._lines: list[str] = []
+        self._version: int = 0
+        self._current_step: str = ""
+        self._lock = threading.Lock()
+
+    def _append(self, msg: str) -> None:
+        with self._lock:
+            self._lines.append(msg)
+            self._version += 1
+
+    def snapshot(self) -> Tuple[int, str, str]:
+        """Return ``(version, joined_text, current_step)`` atomically."""
+        with self._lock:
+            return self._version, "\n".join(self._lines), self._current_step
+
+    def clear(self) -> None:
+        with self._lock:
+            self._lines.clear()
+            self._version += 1
+            self._current_step = ""
+
+    # ── Console Protocol ──────────────────────────────────
+
+    def step(self, name: str) -> None:
+        with self._lock:
+            self._lines.append(f"▶ {name}...")
+            self._current_step = name
+            self._version += 1
+
+    def step_ok(self, name: str, elapsed: float) -> None:
+        self._append(f"✓ {name} ({elapsed:.1f}s)")
+
+    def step_skip(self, name: str, reason: str) -> None:
+        self._append(f"⏭ {name}: {reason}")
+
+    def step_warn(self, name: str, reason: str) -> None:
+        self._append(f"⚠ {name}: {reason}")
+
+    def step_err(self, name: str, exc: Exception, elapsed: float) -> None:
+        self._append(f"✗ {name}: {exc}")
+
+    def warn(self, msg: str) -> None:
+        self._append(f"⚠ {msg}")
+
+    def debug(self, msg: str) -> None:
+        pass  # WebSocket UI doesn't show debug-level messages
+
+    def inline_warn(self, msg: str) -> None:
+        self._append(f"⚠ {msg}")
+
+    def final(self, msg: str) -> None:
+        self._append(msg)
+
+    def done(self, elapsed: float) -> None:
+        self._append(f"Done in {elapsed:.1f}s")
+
+    def cancelled(self, msg: str) -> None:
+        self._append(f"⊘ Cancelled — {msg}")
+
+    def progress(self, *args, **kwargs):
+        return nullcontext()

--- a/src/movie_narrator/web_api/controller.py
+++ b/src/movie_narrator/web_api/controller.py
@@ -1,0 +1,28 @@
+"""Cooperative cancel controller for the Web API.
+
+Identical pattern to GradioController: threading.Event for cross-thread
+cancel signaling. Pipeline thread polls is_cancelled(), UI thread calls cancel().
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class TaskController:
+    """Thread-safe cooperative cancel flag."""
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+
+    def cancel(self) -> None:
+        """Request cancellation (called by REST DELETE or WS cancel)."""
+        self._event.set()
+
+    def is_cancelled(self) -> bool:
+        """Check if cancellation was requested (called by pipeline thread)."""
+        return self._event.is_set()
+
+    def reset(self) -> None:
+        """Clear the cancel flag for a new run."""
+        self._event.clear()

--- a/src/movie_narrator/web_api/form.py
+++ b/src/movie_narrator/web_api/form.py
@@ -1,0 +1,97 @@
+"""Form data model, validation, and conversion to build_context kwargs.
+
+The ``empty = no override`` rule (§5.3 of the spec) is critical:
+advanced params with ``None`` values are NOT injected into the
+``params`` dict, so Settings defaults take effect. This prevents the
+form from shadowing ``.env`` / ``MN_*`` configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class FormData:
+    """Parsed form data from the Web API."""
+
+    movie: str
+    style: str
+    duration: int
+    voice: str
+    format: str
+    video_path: Optional[str]
+    library_dir: str
+    research: bool
+    bgm_path: Optional[str]
+    no_bgm: bool
+    no_clips: bool
+    strict: bool
+    subtitle_lang: str
+    subtitle_mode: str
+    # Advanced params (None = no override, let Settings decide)
+    scene_threshold: Optional[float]
+    match_min_score: Optional[float]
+    translate_provider: str
+    translate_retries: Optional[int]
+
+
+def validate_form(data: FormData) -> List[str]:
+    """Return a list of validation error messages (empty = valid)."""
+    errors: List[str] = []
+    if not data.movie or not data.movie.strip():
+        errors.append("Movie name is required")
+    if data.duration < 5 or data.duration > 600:
+        errors.append("Duration must be 5-600 seconds")
+    if data.format not in ("16:9", "9:16"):
+        errors.append("Format must be 16:9 or 9:16")
+    if data.subtitle_mode not in ("original", "translated", "bilingual"):
+        errors.append("Subtitle mode must be original, translated, or bilingual")
+    if data.subtitle_mode in ("translated", "bilingual") and not data.subtitle_lang.strip():
+        errors.append("subtitle_lang is required when subtitle_mode is translated or bilingual")
+    if data.scene_threshold is not None and not (0 <= data.scene_threshold <= 100):
+        errors.append("Scene threshold must be 0-100")
+    if data.match_min_score is not None and not (0 <= data.match_min_score <= 1):
+        errors.append("Match min score must be 0-1")
+    if data.translate_retries is not None and not (0 <= data.translate_retries <= 10):
+        errors.append("Translate retries must be 0-10")
+    return errors
+
+
+def form_to_context_args(data: FormData) -> Dict[str, Any]:
+    """Convert :class:`FormData` to ``build_context`` kwargs.
+
+    Advanced params with ``None`` values are **not** injected into
+    ``params`` — this lets Settings (``.env`` / ``MN_*``) defaults
+    take effect. Only non-empty form values override Settings.
+    """
+    params: Dict[str, Any] = {}
+    if data.scene_threshold is not None:
+        params["scene_threshold"] = data.scene_threshold
+    if data.match_min_score is not None:
+        params["match_min_score"] = data.match_min_score
+    if data.translate_provider.strip():
+        params["translate_provider"] = data.translate_provider.strip()
+    if data.translate_retries is not None:
+        params["translate_retries"] = data.translate_retries
+
+    return dict(
+        movie=data.movie.strip(),
+        style=data.style,
+        duration=data.duration,
+        voice=data.voice.strip() or None,
+        format=data.format,
+        video=data.video_path,
+        library_dir=data.library_dir.strip() or None,
+        research=data.research,
+        bgm=data.bgm_path,
+        no_bgm=data.no_bgm,
+        no_clips=data.no_clips,
+        strict=data.strict,
+        workflow_steps=None,
+        params=params or None,
+        config_path=None,
+        subtitle_lang=data.subtitle_lang.strip() or None,
+        subtitle_mode=data.subtitle_mode,
+    )

--- a/src/movie_narrator/web_api/models.py
+++ b/src/movie_narrator/web_api/models.py
@@ -1,0 +1,77 @@
+"""Pydantic models for API request/response validation."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskCreateRequest(BaseModel):
+    """POST /api/tasks body — JSON form data.
+
+    File uploads (video, bgm) are sent as multipart/form-data alongside
+    this JSON in the same request.
+    """
+    movie: str = Field(..., description="Movie name")
+    style: str = Field("热血搞笑", description="Narration style")
+    duration: int = Field(60, ge=5, le=600, description="Target duration in seconds")
+    voice: str = Field("", description="TTS voice name (empty = Settings default)")
+    format: str = Field("16:9", pattern="^(16:9|9:16)$")
+    library_dir: str = Field("", description="Library directory for fuzzy video match")
+    research: bool = Field(False, description="Enable research step")
+    no_bgm: bool = Field(False, description="Disable BGM")
+    no_clips: bool = Field(False, description="Skip video clip matching")
+    strict: bool = Field(False, description="Strict mode — soft step failures abort")
+    subtitle_lang: str = Field("", description="Subtitle language code")
+    subtitle_mode: str = Field("original", pattern="^(original|translated|bilingual)$")
+    scene_threshold: Optional[float] = Field(None, ge=0, le=100)
+    match_min_score: Optional[float] = Field(None, ge=0, le=1)
+    translate_provider: str = Field("")
+    translate_retries: Optional[int] = Field(None, ge=0, le=10)
+
+    def to_form_data(self, video_path: Optional[str] = None, bgm_path: Optional[str] = None):
+        """Convert to FormData for validate_form() and form_to_context_args()."""
+        from .form import FormData
+
+        return FormData(
+            movie=self.movie,
+            style=self.style,
+            duration=self.duration,
+            voice=self.voice,
+            format=self.format,
+            video_path=video_path,
+            library_dir=self.library_dir,
+            research=self.research,
+            bgm_path=bgm_path,
+            no_bgm=self.no_bgm,
+            no_clips=self.no_clips,
+            strict=self.strict,
+            subtitle_lang=self.subtitle_lang,
+            subtitle_mode=self.subtitle_mode,
+            scene_threshold=self.scene_threshold,
+            match_min_score=self.match_min_score,
+            translate_provider=self.translate_provider,
+            translate_retries=self.translate_retries,
+        )
+
+
+class TaskCreateResponse(BaseModel):
+    """POST /api/tasks response."""
+    task_id: str
+    status: str = "running"
+
+
+class TaskStatusResponse(BaseModel):
+    """GET /api/tasks/{id} response."""
+    task_id: str
+    status: str  # running | done | failed | cancelled
+    current_step: str = ""
+    error: Optional[str] = None
+    artifacts: List[str] = []
+    video_path: Optional[str] = None
+
+
+class CancelResponse(BaseModel):
+    """DELETE /api/tasks/{id} response."""
+    cancelled: bool = True

--- a/src/movie_narrator/web_api/routes.py
+++ b/src/movie_narrator/web_api/routes.py
@@ -1,0 +1,100 @@
+"""REST API routes for task management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+from .models import CancelResponse, TaskCreateRequest, TaskCreateResponse, TaskStatusResponse
+from .tasks import TaskManager
+from .utils import save_upload, zip_artifacts
+
+
+def create_router(manager: TaskManager, upload_dir: Path) -> APIRouter:
+    """Create the REST API router with all endpoints."""
+    router = APIRouter(prefix="/api")
+
+    @router.post("/tasks", response_model=TaskCreateResponse)
+    async def create_task(
+        movie: str = Form(...),
+        style: str = Form("热血搞笑"),
+        duration: int = Form(60),
+        voice: str = Form(""),
+        format: str = Form("16:9"),
+        library_dir: str = Form(""),
+        research: bool = Form(False),
+        no_bgm: bool = Form(False),
+        no_clips: bool = Form(False),
+        strict: bool = Form(False),
+        subtitle_lang: str = Form(""),
+        subtitle_mode: str = Form("original"),
+        scene_threshold: Optional[float] = Form(None),
+        match_min_score: Optional[float] = Form(None),
+        translate_provider: str = Form(""),
+        translate_retries: Optional[int] = Form(None),
+        video: Optional[UploadFile] = File(None),
+        bgm: Optional[UploadFile] = File(None),
+    ):
+        # Save uploaded files
+        video_path = None
+        bgm_path = None
+        if video and video.filename:
+            video_path = save_upload(video, upload_dir, prefix="video_")
+        if bgm and bgm.filename:
+            bgm_path = save_upload(bgm, upload_dir, prefix="bgm_")
+
+        request = TaskCreateRequest(
+            movie=movie, style=style, duration=duration, voice=voice,
+            format=format, library_dir=library_dir, research=research,
+            no_bgm=no_bgm, no_clips=no_clips, strict=strict,
+            subtitle_lang=subtitle_lang, subtitle_mode=subtitle_mode,
+            scene_threshold=scene_threshold, match_min_score=match_min_score,
+            translate_provider=translate_provider, translate_retries=translate_retries,
+        )
+
+        try:
+            task_id = manager.create_task(request, video_path=video_path, bgm_path=bgm_path)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
+        return TaskCreateResponse(task_id=task_id, status="running")
+
+    @router.get("/tasks/{task_id}", response_model=TaskStatusResponse)
+    async def get_task(task_id: str):
+        info = manager.get_task(task_id)
+        if not info:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return TaskStatusResponse(**info.to_status_dict())
+
+    @router.delete("/tasks/{task_id}", response_model=CancelResponse)
+    async def cancel_task(task_id: str):
+        cancelled = manager.cancel_task(task_id)
+        if not cancelled:
+            raise HTTPException(status_code=409, detail="Task not running or not found")
+        return CancelResponse(cancelled=True)
+
+    @router.get("/artifacts/{task_id}")
+    async def download_artifacts(task_id: str):
+        info = manager.get_task(task_id)
+        if not info:
+            raise HTTPException(status_code=404, detail="Task not found")
+        if info.status == "running":
+            raise HTTPException(status_code=409, detail="Task still running")
+
+        artifacts = info.artifacts
+        if not artifacts:
+            raise HTTPException(status_code=404, detail="No artifacts available")
+
+        # If single artifact (video), return directly
+        if len(artifacts) == 1:
+            return FileResponse(artifacts[0], filename=Path(artifacts[0]).name)
+
+        # Multiple artifacts → zip
+        zip_path = info.output_dir / "artifacts.zip"
+        zip_artifacts(artifacts, zip_path)
+        return FileResponse(str(zip_path), filename="artifacts.zip")
+
+    return router

--- a/src/movie_narrator/web_api/server.py
+++ b/src/movie_narrator/web_api/server.py
@@ -1,0 +1,52 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+from .routes import create_router
+from .tasks import TaskManager
+from .ws import task_ws_endpoint
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(title="Movie Narrator Web API", version="0.1.0")
+
+    # CORS — dev only
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Task manager + upload dir
+    upload_dir = Path("output/_uploads")
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    manager = TaskManager()
+
+    # Routes
+    app.include_router(create_router(manager, upload_dir))
+
+    # WebSocket
+    @app.websocket("/ws/task/{task_id}")
+    async def ws_endpoint(websocket, task_id: str):
+        await task_ws_endpoint(websocket, task_id, manager)
+
+    # Health check
+    @app.get("/api/health")
+    async def health():
+        return {"status": "ok"}
+
+    # Serve built frontend (production)
+    dist_dir = Path(__file__).parent.parent.parent.parent / "webui" / "dist"
+    if dist_dir.exists():
+        app.mount("/", StaticFiles(directory=str(dist_dir), html=True), name="static")
+
+    return app

--- a/src/movie_narrator/web_api/tasks.py
+++ b/src/movie_narrator/web_api/tasks.py
@@ -1,0 +1,136 @@
+"""TaskManager — create/query/cancel pipeline tasks.
+
+Single-task at a time (ThreadPoolExecutor max_workers=1). Each task
+runs build_context + run_pipeline in a background thread, with a
+WebSocketConsole and TaskController for progress streaming and cancel.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict, Optional
+
+from ..utils.sanitize import sanitize_filename
+from .console import WebSocketConsole
+from .controller import TaskController
+from .form import form_to_context_args, validate_form
+from .models import TaskCreateRequest
+from .utils import collect_artifacts
+
+
+class TaskInfo:
+    """Runtime state for a single task."""
+
+    def __init__(self, task_id: str, output_dir: Path) -> None:
+        self.task_id = task_id
+        self.output_dir = output_dir
+        self.console = WebSocketConsole()
+        self.controller = TaskController()
+        self.status: str = "running"  # running | done | failed | cancelled
+        self.current_step: str = ""
+        self.error: Optional[str] = None
+        self.artifacts: list[str] = []
+        self.video_path: Optional[str] = None
+        self._lock = threading.Lock()
+
+    def set_terminal(self, status: str, error: Optional[str] = None) -> None:
+        with self._lock:
+            self.status = status
+            self.error = error
+
+    def to_status_dict(self) -> dict:
+        with self._lock:
+            return {
+                "task_id": self.task_id,
+                "status": self.status,
+                "current_step": self.current_step,
+                "error": self.error,
+                "artifacts": self.artifacts,
+                "video_path": self.video_path,
+            }
+
+
+class TaskManager:
+    """Manages pipeline tasks — single concurrent task."""
+
+    def __init__(self, base_output_dir: str = "output") -> None:
+        self._tasks: Dict[str, TaskInfo] = {}
+        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._base_output_dir = Path(base_output_dir)
+        self._lock = threading.Lock()
+
+    def create_task(
+        self,
+        request: TaskCreateRequest,
+        video_path: Optional[str] = None,
+        bgm_path: Optional[str] = None,
+    ) -> str:
+        """Create and start a new task. Returns task_id."""
+        # Validate form
+        form_data = request.to_form_data(video_path=video_path, bgm_path=bgm_path)
+        errors = validate_form(form_data)
+        if errors:
+            raise ValueError("; ".join(errors))
+
+        task_id = uuid.uuid4().hex[:12]
+        output_dir = self._base_output_dir / sanitize_filename(request.movie) / task_id
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        info = TaskInfo(task_id, output_dir)
+        with self._lock:
+            self._tasks[task_id] = info
+
+        # Submit to thread pool
+        self._executor.submit(self._run_task, task_id, form_data, output_dir)
+        return task_id
+
+    def _run_task(self, task_id: str, form_data, output_dir: Path) -> None:
+        """Run the pipeline in a background thread."""
+        info = self._tasks[task_id]
+        info.controller.reset()
+        info.console.clear()
+
+        try:
+            from ..pipeline.runner import build_context, run_pipeline
+
+            kwargs = form_to_context_args(form_data)
+            kwargs["output_dir"] = str(output_dir)
+            kwargs["services"] = None  # will be injected by build_context
+
+            ctx = build_context(**kwargs)
+            ctx.services.console = info.console
+
+            # Controller is passed to run_pipeline as a kwarg (matching the
+            # CLI / Gradio pattern in pipeline/runner.py). Context has no
+            # ``controller`` field, so it cannot be stored on ctx.
+            run_pipeline(ctx, controller=info.controller)
+
+            # Collect artifacts
+            info.artifacts = collect_artifacts(ctx, output_dir)
+            info.video_path = str(ctx.video_path) if ctx.video_path else None
+            info.set_terminal("done")
+
+        except Exception as e:
+            import traceback
+            info.set_terminal("failed", f"{e}\n{traceback.format_exc()}")
+
+    def get_task(self, task_id: str) -> Optional[TaskInfo]:
+        with self._lock:
+            return self._tasks.get(task_id)
+
+    def cancel_task(self, task_id: str) -> bool:
+        info = self.get_task(task_id)
+        if info and info.status == "running":
+            info.controller.cancel()
+            return True
+        return False
+
+    def update_step(self, task_id: str, step: str) -> None:
+        """Called by pipeline runner to update current step."""
+        info = self.get_task(task_id)
+        if info:
+            with info._lock:
+                info.current_step = step

--- a/src/movie_narrator/web_api/utils.py
+++ b/src/movie_narrator/web_api/utils.py
@@ -1,0 +1,53 @@
+"""Utility functions for the Web API — uploads, artifacts, zip."""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+from typing import List, Optional
+
+
+def save_upload(upload_file, destination_dir: Path, prefix: str = "") -> str:
+    """Save an uploaded file to destination_dir. Returns the path string."""
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{prefix}{upload_file.filename}" if prefix else upload_file.filename
+    dest = destination_dir / filename
+    with dest.open("wb") as f:
+        shutil.copyfileobj(upload_file.file, f)
+    return str(dest)
+
+
+def collect_artifacts(ctx, output_dir: Path) -> List[str]:
+    """Collect all output artifacts for a completed task."""
+    artifacts = []
+    # Video output
+    if ctx.video_path and Path(ctx.video_path).exists():
+        artifacts.append(str(ctx.video_path))
+    # SRT subtitle
+    srt_path = output_dir / "subtitle.srt"
+    if srt_path.exists():
+        artifacts.append(str(srt_path))
+    # Script JSON
+    script_path = output_dir / "script.json"
+    if script_path.exists():
+        artifacts.append(str(script_path))
+    # Narration audio
+    if ctx.audio_path and Path(ctx.audio_path).exists():
+        artifacts.append(ctx.audio_path)
+    # Metadata
+    meta_path = output_dir / "metadata.json"
+    if meta_path.exists():
+        artifacts.append(str(meta_path))
+    return artifacts
+
+
+def zip_artifacts(artifacts: List[str], zip_path: Path) -> str:
+    """Create a zip file containing all artifacts. Returns zip path."""
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for artifact in artifacts:
+            p = Path(artifact)
+            if p.exists():
+                zf.write(p, p.name)
+    return str(zip_path)

--- a/src/movie_narrator/web_api/ws.py
+++ b/src/movie_narrator/web_api/ws.py
@@ -1,0 +1,60 @@
+"""WebSocket endpoint for real-time progress streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from .tasks import TaskManager
+
+
+async def task_ws_endpoint(websocket: WebSocket, task_id: str, manager: TaskManager) -> None:
+    """WebSocket handler: push console snapshots to connected clients."""
+    await websocket.accept()
+
+    info = manager.get_task(task_id)
+    if not info:
+        await websocket.send_json({"type": "terminal", "status": "failed", "error": "Task not found"})
+        await websocket.close()
+        return
+
+    last_version = -1
+
+    try:
+        while True:
+            # Check for client messages (subscribe/cancel)
+            try:
+                msg = await asyncio.wait_for(websocket.receive_text(), timeout=0.2)
+                data = json.loads(msg)
+                if data.get("action") == "cancel":
+                    manager.cancel_task(task_id)
+            except asyncio.TimeoutError:
+                pass
+
+            # Push snapshot if version changed
+            version, text, step = info.console.snapshot()
+            if version != last_version:
+                last_version = version
+                await websocket.send_json({
+                    "type": "progress",
+                    "step": step,
+                    "version": version,
+                    "log": text,
+                })
+
+            # Check terminal state
+            if info.status in ("done", "failed", "cancelled"):
+                status_dict = info.to_status_dict()
+                await websocket.send_json({
+                    "type": "terminal",
+                    "status": info.status,
+                    "error": status_dict.get("error"),
+                    "artifacts": status_dict.get("artifacts", []),
+                    "video_path": status_dict.get("video_path"),
+                })
+                break
+
+    except WebSocketDisconnect:
+        pass

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+dist-ssr/
+
+# IDE
+*.local
+.vscode/
+.idea/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS
+.DS_Store
+*.tsbuildinfo

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Movie Narrator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/webui/postcss.config.js
+++ b/webui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/webui/public/favicon.svg
+++ b/webui/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#EC4899" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18"/>
+  <line x1="7" y1="2" x2="7" y2="22"/>
+  <line x1="17" y1="2" x2="17" y2="22"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <line x1="2" y1="7" x2="7" y2="7"/>
+  <line x1="2" y1="17" x2="7" y2="17"/>
+  <line x1="17" y1="17" x2="22" y2="17"/>
+  <line x1="17" y1="7" x2="22" y2="7"/>
+</svg>

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,0 +1,122 @@
+import {
+  createContext,
+  useState,
+  useCallback,
+} from "react"
+import { Header } from "@/components/Header"
+import { Footer } from "@/components/Footer"
+import { CreatePanel } from "@/components/CreatePanel"
+import { MonitorPanel } from "@/components/MonitorPanel"
+import { useWebSocket } from "@/hooks/useWebSocket"
+import { createTask, cancelTask as cancelTaskApi } from "@/lib/api"
+import type { FormSubmitData, TaskStatus, WsMessage } from "@/types"
+
+type AppStatus = "idle" | TaskStatus
+
+export interface TaskContextValue {
+  status: AppStatus
+  taskId: string | null
+  currentStep: string
+  logText: string
+  artifacts: string[]
+  error: string | null
+  videoPath: string | null
+  connected: boolean
+  startTask: (data: FormSubmitData, video?: File, bgm?: File) => Promise<void>
+  resetTask: () => void
+  cancelTask: () => void
+}
+
+export const TaskContext = createContext<TaskContextValue | null>(null)
+
+export function App() {
+  const [status, setStatus] = useState<AppStatus>("idle")
+  const [taskId, setTaskId] = useState<string | null>(null)
+  const [currentStep, setCurrentStep] = useState("")
+  const [logText, setLogText] = useState("")
+  const [artifacts, setArtifacts] = useState<string[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [videoPath, setVideoPath] = useState<string | null>(null)
+
+  // Stable onMessage callback — only depends on stable setState functions
+  const onMessage = useCallback((msg: WsMessage) => {
+    if (msg.type === "progress") {
+      if (msg.step) setCurrentStep(msg.step)
+      if (msg.log !== undefined) setLogText(msg.log)
+    } else if (msg.type === "terminal") {
+      if (msg.status) setStatus(msg.status)
+      if (msg.artifacts) setArtifacts(msg.artifacts)
+      if (msg.error !== undefined) setError(msg.error)
+      if (msg.video_path !== undefined) setVideoPath(msg.video_path)
+    }
+  }, [])
+
+  // Only keep WebSocket active while the task is running.
+  // When the task reaches a terminal state, pass null so the hook
+  // tears down the connection and stops initiating new ones.
+  const wsTaskId = status === "running" ? taskId : null
+  const { connected, sendCancel } = useWebSocket(wsTaskId, onMessage)
+
+  // Only surface the connected indicator while the task is running;
+  // prevents flicker from residual reconnection attempts after completion.
+  const displayConnected = status === "running" && connected
+
+  const startTask = useCallback(
+    async (data: FormSubmitData, video?: File, bgm?: File) => {
+      const res = await createTask(data, video, bgm)
+      setTaskId(res.task_id)
+      setStatus("running")
+      setCurrentStep("")
+      setLogText("")
+      setArtifacts([])
+      setError(null)
+      setVideoPath(null)
+    },
+    [],
+  )
+
+  const resetTask = useCallback(() => {
+    setStatus("idle")
+    setTaskId(null)
+    setCurrentStep("")
+    setLogText("")
+    setArtifacts([])
+    setError(null)
+    setVideoPath(null)
+  }, [])
+
+  const handleCancelTask = useCallback(() => {
+    if (taskId) {
+      sendCancel()
+      cancelTaskApi(taskId).catch(() => {})
+    }
+  }, [taskId, sendCancel])
+
+  const contextValue: TaskContextValue = {
+    status,
+    taskId,
+    currentStep,
+    logText,
+    artifacts,
+    error,
+    videoPath,
+    connected: displayConnected,
+    startTask,
+    resetTask,
+    cancelTask: handleCancelTask,
+  }
+
+  return (
+    <TaskContext.Provider value={contextValue}>
+      <div className="flex min-h-screen flex-col bg-background">
+        <Header />
+        <main className="flex-1">
+          {status === "idle" ? <CreatePanel /> : <MonitorPanel />}
+        </main>
+        <Footer />
+      </div>
+    </TaskContext.Provider>
+  )
+}
+
+export default App

--- a/webui/src/components/AdvancedSection.tsx
+++ b/webui/src/components/AdvancedSection.tsx
@@ -1,0 +1,140 @@
+import { Settings, Search, ShieldAlert, Scissors, Languages, Repeat, type LucideIcon } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+import type { FormSubmitData } from "@/types"
+
+interface AdvancedSectionProps {
+  data: FormSubmitData
+  onChange: (field: keyof FormSubmitData, value: string | number | boolean | undefined) => void
+}
+
+function SwitchRow({
+  icon: Icon,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  icon: LucideIcon
+  label: string
+  description: string
+  checked: boolean
+  onCheckedChange: (v: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-input border border-border bg-surface px-4 py-3">
+      <div className="flex items-center gap-2">
+        <Icon className="h-4 w-4 text-slate-400" strokeWidth={1.5} />
+        <div>
+          <Label className="cursor-pointer">{label}</Label>
+          <p className="text-xs text-slate-400">{description}</p>
+        </div>
+      </div>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  )
+}
+
+export function AdvancedSection({ data, onChange }: AdvancedSectionProps) {
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="advanced" className="border-b-0">
+        <AccordionTrigger>
+          <span className="flex items-center gap-2">
+            <Settings className="h-4 w-4 text-slate-400" strokeWidth={1.5} />
+            高级选项
+          </span>
+        </AccordionTrigger>
+        <AccordionContent className="space-y-5">
+          {/* Research */}
+          <SwitchRow
+            icon={Search}
+            label="启用剧情研究"
+            description="使用 LLM 研究电影剧情以提升文案质量"
+            checked={data.research}
+            onCheckedChange={(v) => onChange("research", v)}
+          />
+
+          {/* Strict mode */}
+          <SwitchRow
+            icon={ShieldAlert}
+            label="严格模式"
+            description="软步骤失败时中止流水线"
+            checked={data.strict}
+            onCheckedChange={(v) => onChange("strict", v)}
+          />
+
+          {/* No clips */}
+          <SwitchRow
+            icon={Scissors}
+            label="跳过片段匹配"
+            description="不进行视频片段匹配和导出"
+            checked={data.no_clips}
+            onCheckedChange={(v) => onChange("no_clips", v)}
+          />
+
+          {/* Numeric params */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>场景检测阈值</Label>
+              <Input
+                type="number"
+                value={data.scene_threshold ?? ""}
+                onChange={(e) =>
+                  onChange("scene_threshold", e.target.value ? Number(e.target.value) : undefined)
+                }
+                placeholder="0 - 100"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>匹配最低分数</Label>
+              <Input
+                type="number"
+                step="0.1"
+                value={data.match_min_score ?? ""}
+                onChange={(e) =>
+                  onChange("match_min_score", e.target.value ? Number(e.target.value) : undefined)
+                }
+                placeholder="0.0 - 1.0"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <Languages className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              翻译服务提供商
+            </Label>
+            <Input
+              value={data.translate_provider}
+              onChange={(e) => onChange("translate_provider", e.target.value)}
+              placeholder="llm（留空使用默认）"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <Repeat className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              翻译重试次数
+            </Label>
+            <Input
+              type="number"
+              value={data.translate_retries ?? ""}
+              onChange={(e) =>
+                onChange("translate_retries", e.target.value ? Number(e.target.value) : undefined)
+              }
+              placeholder="0 - 10"
+            />
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/webui/src/components/AssetsSection.tsx
+++ b/webui/src/components/AssetsSection.tsx
@@ -1,0 +1,157 @@
+import { useRef, useState } from "react"
+import { FolderOpen, Upload, Music, Music2 } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+import { cn } from "@/lib/utils"
+import type { FormSubmitData } from "@/types"
+
+interface AssetsSectionProps {
+  data: FormSubmitData
+  videoFile: File | null
+  bgmFile: File | null
+  onChange: (field: keyof FormSubmitData, value: string | number | boolean) => void
+  onVideoChange: (file: File | null) => void
+  onBgmChange: (file: File | null) => void
+}
+
+function FileDrop({
+  file,
+  accept,
+  placeholder,
+  onFileChange,
+}: {
+  file: File | null
+  accept: string
+  placeholder: string
+  onFileChange: (file: File | null) => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+
+  return (
+    <div
+      onClick={() => inputRef.current?.click()}
+      onDragOver={(e) => {
+        e.preventDefault()
+        setDragOver(true)
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault()
+        setDragOver(false)
+        const f = e.dataTransfer.files[0]
+        if (f) onFileChange(f)
+      }}
+      className={cn(
+        "flex cursor-pointer items-center gap-3 rounded-input border border-dashed px-4 py-3 transition-colors",
+        dragOver
+          ? "border-pink-500 bg-pink-500/5"
+          : "border-border bg-surface hover:border-slate-500"
+      )}
+    >
+      <Upload className="h-4 w-4 shrink-0 text-slate-400" strokeWidth={1.5} />
+      <span className="flex-1 truncate text-sm">
+        {file ? file.name : <span className="text-slate-400">{placeholder}</span>}
+      </span>
+      {file && (
+        <span className="text-xs text-slate-400">
+          {(file.size / 1024 / 1024).toFixed(1)} MB
+        </span>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0] ?? null
+          onFileChange(f)
+        }}
+      />
+    </div>
+  )
+}
+
+export function AssetsSection({
+  data,
+  videoFile,
+  bgmFile,
+  onChange,
+  onVideoChange,
+  onBgmChange,
+}: AssetsSectionProps) {
+  return (
+    <Accordion type="single" collapsible defaultValue="assets">
+      <AccordionItem value="assets" className="border-b-0">
+        <AccordionTrigger>素材资源</AccordionTrigger>
+        <AccordionContent className="space-y-5">
+          {/* Video upload */}
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <FolderOpen className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              视频文件（可选）
+            </Label>
+            <FileDrop
+              file={videoFile}
+              accept="video/*"
+              placeholder="拖拽或点击上传视频文件"
+              onFileChange={onVideoChange}
+            />
+            <p className="text-xs text-slate-400">
+              上传本地视频文件，或留空使用电影名称自动解析
+            </p>
+          </div>
+
+          {/* Library directory */}
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <FolderOpen className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              素材库目录（可选）
+            </Label>
+            <Input
+              value={data.library_dir}
+              onChange={(e) => onChange("library_dir", e.target.value)}
+              placeholder="视频素材库路径，用于模糊匹配片段"
+            />
+          </div>
+
+          {/* BGM upload */}
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <Music className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              背景音乐文件（可选）
+            </Label>
+            <FileDrop
+              file={bgmFile}
+              accept="audio/*"
+              placeholder="拖拽或点击上传背景音乐"
+              onFileChange={onBgmChange}
+            />
+          </div>
+
+          {/* No BGM switch */}
+          <div className="flex items-center justify-between rounded-input border border-border bg-surface px-4 py-3">
+            <div className="flex items-center gap-2">
+              <Music2 className="h-4 w-4 text-slate-400" strokeWidth={1.5} />
+              <div>
+                <Label className="cursor-pointer">禁用背景音乐</Label>
+                <p className="text-xs text-slate-400">不添加 BGM 到最终视频</p>
+              </div>
+            </div>
+            <Switch
+              checked={data.no_bgm}
+              onCheckedChange={(v) => onChange("no_bgm", v)}
+            />
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/webui/src/components/CreatePanel.tsx
+++ b/webui/src/components/CreatePanel.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react"
+import { Sparkles, Loader2 } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { MovieSection } from "@/components/MovieSection"
+import { VoiceSection } from "@/components/VoiceSection"
+import { AssetsSection } from "@/components/AssetsSection"
+import { SubtitlesSection } from "@/components/SubtitlesSection"
+import { AdvancedSection } from "@/components/AdvancedSection"
+import { useTask } from "@/hooks/useTask"
+import type { FormSubmitData } from "@/types"
+
+const DEFAULT_FORM: FormSubmitData = {
+  movie: "",
+  style: "热血搞笑",
+  duration: 60,
+  voice: "",
+  format: "16:9",
+  library_dir: "",
+  research: false,
+  no_bgm: false,
+  no_clips: false,
+  strict: false,
+  subtitle_lang: "",
+  subtitle_mode: "original",
+  translate_provider: "",
+}
+
+export function CreatePanel() {
+  const { startTask } = useTask()
+  const [formData, setFormData] = useState<FormSubmitData>(DEFAULT_FORM)
+  const [videoFile, setVideoFile] = useState<File | null>(null)
+  const [bgmFile, setBgmFile] = useState<File | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const handleChange = (field: keyof FormSubmitData, value: string | number | boolean | undefined) => {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSubmit = async () => {
+    if (!formData.movie.trim()) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await startTask(formData, videoFile ?? undefined, bgmFile ?? undefined)
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "创建任务失败")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const canSubmit = formData.movie.trim().length > 0 && !submitting
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>创建解说任务</CardTitle>
+          <CardDescription>
+            填写电影信息和解说参数，一键生成电影解说视频
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Movie section */}
+          <MovieSection data={formData} onChange={handleChange} />
+
+          <Separator />
+
+          {/* Voice section */}
+          <VoiceSection data={formData} onChange={handleChange} />
+
+          <Separator />
+
+          {/* Assets section (accordion) */}
+          <AssetsSection
+            data={formData}
+            videoFile={videoFile}
+            bgmFile={bgmFile}
+            onChange={handleChange}
+            onVideoChange={setVideoFile}
+            onBgmChange={setBgmFile}
+          />
+
+          <Separator />
+
+          {/* Subtitles section (accordion) */}
+          <SubtitlesSection data={formData} onChange={handleChange} />
+
+          <Separator />
+
+          {/* Advanced section (accordion) */}
+          <AdvancedSection data={formData} onChange={handleChange} />
+
+          {/* Error message */}
+          {submitError && (
+            <div className="rounded-input border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+              {submitError}
+            </div>
+          )}
+
+          {/* Submit button */}
+          <Button
+            size="lg"
+            className="w-full text-base"
+            disabled={!canSubmit}
+            onClick={handleSubmit}
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" strokeWidth={1.5} />
+                正在创建任务...
+              </>
+            ) : (
+              <>
+                <Sparkles className="mr-2 h-4 w-4" strokeWidth={1.5} />
+                生成解说视频
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/webui/src/components/Footer.tsx
+++ b/webui/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export function Footer() {
+  return (
+    <footer className="border-t border-border px-6 py-3 text-center text-xs text-slate-400">
+      Movie Narrator &copy; {new Date().getFullYear()} &middot; AI 驱动的电影解说视频生成工具
+    </footer>
+  )
+}

--- a/webui/src/components/Header.tsx
+++ b/webui/src/components/Header.tsx
@@ -1,0 +1,19 @@
+import { Film } from "lucide-react"
+
+export function Header() {
+  return (
+    <header className="flex items-center justify-between border-b border-border bg-surface/50 px-6 py-4 backdrop-blur-sm">
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-pink-500/10">
+          <Film className="h-5 w-5 text-pink-500" strokeWidth={1.5} />
+        </div>
+        <div className="flex items-baseline gap-2">
+          <h1 className="text-lg font-semibold text-slate-50">Movie Narrator</h1>
+          <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-xs font-medium text-slate-400">
+            v0.1.0
+          </span>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/webui/src/components/LogStream.tsx
+++ b/webui/src/components/LogStream.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react"
+import { Terminal } from "lucide-react"
+
+interface LogStreamProps {
+  logText: string
+}
+
+export function LogStream({ logText }: LogStreamProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const preRef = useRef<HTMLPreElement>(null)
+
+  // Auto-scroll to bottom when log updates
+  useEffect(() => {
+    if (preRef.current) {
+      preRef.current.scrollTop = preRef.current.scrollHeight
+    }
+  }, [logText])
+
+  return (
+    <div ref={containerRef} className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+        <Terminal className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+        <span className="text-sm font-medium text-slate-200">实时日志</span>
+      </div>
+      <pre
+        ref={preRef}
+        className="flex-1 overflow-auto bg-background p-4 font-mono text-xs leading-relaxed text-slate-300"
+        style={{ minHeight: "200px", maxHeight: "400px" }}
+      >
+        {logText || (
+          <span className="text-slate-500">等待日志输出...</span>
+        )}
+      </pre>
+    </div>
+  )
+}

--- a/webui/src/components/MonitorPanel.tsx
+++ b/webui/src/components/MonitorPanel.tsx
@@ -1,0 +1,74 @@
+import { X, Wifi, WifiOff } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { ProgressTimeline } from "@/components/ProgressTimeline"
+import { LogStream } from "@/components/LogStream"
+import { ResultPanel } from "@/components/ResultPanel"
+import { useTask } from "@/hooks/useTask"
+
+export function MonitorPanel() {
+  const { taskId, status, currentStep, logText, connected, cancelTask } = useTask()
+
+  const isRunning = status === "running"
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 px-4 py-8">
+      {/* Header card */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <CardTitle>任务监控</CardTitle>
+              {taskId && (
+                <span className="rounded-full border border-border bg-surface px-2 py-0.5 font-mono text-xs text-slate-400">
+                  {taskId}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-3">
+              {/* Connection indicator */}
+              <div className="flex items-center gap-1.5 text-xs">
+                {connected ? (
+                  <>
+                    <Wifi className="h-3.5 w-3.5 text-green-400" strokeWidth={1.5} />
+                    <span className="text-green-400">已连接</span>
+                  </>
+                ) : (
+                  <>
+                    <WifiOff className="h-3.5 w-3.5 text-slate-400" strokeWidth={1.5} />
+                    <span className="text-slate-400">未连接</span>
+                  </>
+                )}
+              </div>
+
+              {/* Cancel button */}
+              {isRunning && (
+                <Button variant="destructive" size="sm" onClick={cancelTask}>
+                  <X className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
+                  取消任务
+                </Button>
+              )}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Progress timeline */}
+          <ProgressTimeline currentStep={currentStep} status={status} />
+
+          <Separator />
+
+          {/* Log stream */}
+          <div className="overflow-hidden rounded-card border border-border">
+            <LogStream logText={logText} />
+          </div>
+
+          <Separator />
+
+          {/* Result panel */}
+          <ResultPanel />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/webui/src/components/MovieSection.tsx
+++ b/webui/src/components/MovieSection.tsx
@@ -1,0 +1,92 @@
+import { Clapperboard, Palette, Clock, Monitor } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Slider } from "@/components/ui/slider"
+import type { FormSubmitData } from "@/types"
+
+interface MovieSectionProps {
+  data: FormSubmitData
+  onChange: (field: keyof FormSubmitData, value: string | number | boolean) => void
+}
+
+export function MovieSection({ data, onChange }: MovieSectionProps) {
+  return (
+    <div className="space-y-5">
+      {/* Movie name */}
+      <div className="space-y-2">
+        <Label className="flex items-center gap-1.5 text-slate-200">
+          <Clapperboard className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+          电影名称 <span className="text-pink-500">*</span>
+        </Label>
+        <Input
+          value={data.movie}
+          onChange={(e) => onChange("movie", e.target.value)}
+          placeholder="输入电影名称，如：肖申克的救赎"
+          className="h-12 text-base"
+        />
+      </div>
+
+      {/* Style */}
+      <div className="space-y-2">
+        <Label className="flex items-center gap-1.5 text-slate-200">
+          <Palette className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+          解说风格
+        </Label>
+        <Input
+          value={data.style}
+          onChange={(e) => onChange("style", e.target.value)}
+          placeholder="热血搞笑"
+        />
+      </div>
+
+      {/* Duration */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="flex items-center gap-1.5 text-slate-200">
+            <Clock className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+            目标时长
+          </Label>
+          <span className="text-sm font-medium text-pink-400">
+            {Math.floor(data.duration / 60)}:{String(data.duration % 60).padStart(2, "0")}
+          </span>
+        </div>
+        <Slider
+          value={data.duration}
+          min={30}
+          max={300}
+          step={5}
+          onValueChange={(v) => onChange("duration", v)}
+        />
+        <div className="flex justify-between text-xs text-slate-400">
+          <span>30s</span>
+          <span>300s</span>
+        </div>
+      </div>
+
+      {/* Format */}
+      <div className="space-y-2">
+        <Label className="flex items-center gap-1.5 text-slate-200">
+          <Monitor className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+          视频比例
+        </Label>
+        <div className="flex gap-2">
+          {(["16:9", "9:16"] as const).map((fmt) => (
+            <button
+              key={fmt}
+              type="button"
+              onClick={() => onChange("format", fmt)}
+              className={`flex flex-1 items-center justify-center gap-2 rounded-input border px-4 py-2.5 text-sm font-medium transition-colors ${
+                data.format === fmt
+                  ? "border-pink-500 bg-pink-500/10 text-pink-400"
+                  : "border-border bg-surface text-slate-300 hover:bg-slate-700/50"
+              }`}
+            >
+              <span className="font-mono">{fmt}</span>
+              {fmt === "16:9" ? "横屏" : "竖屏"}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/webui/src/components/ProgressTimeline.tsx
+++ b/webui/src/components/ProgressTimeline.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react"
+import { Check, X, Loader2, Minus } from "lucide-react"
+import { Progress } from "@/components/ui/progress"
+import { PIPELINE_STEPS } from "@/types"
+import { cn } from "@/lib/utils"
+
+const STEP_LABELS: Record<string, string> = {
+  resolve_video: "解析视频",
+  generate_script: "生成文案",
+  synthesize_tts: "语音合成",
+  detect_scenes: "场景检测",
+  match_clips: "片段匹配",
+  align_audio: "音频对齐",
+  generate_subtitle: "生成字幕",
+  translate_subtitles: "翻译字幕",
+  export_clips: "导出片段",
+  render_video: "渲染输出",
+}
+
+type StepState = "pending" | "active" | "done" | "failed" | "skipped"
+
+function getStepStates(
+  currentStep: string,
+  status: string
+): StepState[] {
+  const currentIdx = PIPELINE_STEPS.indexOf(currentStep as (typeof PIPELINE_STEPS)[number])
+
+  return PIPELINE_STEPS.map((_step, idx) => {
+    // Step not found in list — all pending
+    if (currentIdx === -1) {
+      if (status === "done") return "done"
+      return "pending"
+    }
+
+    if (status === "done") return "done"
+
+    if (idx < currentIdx) return "done"
+
+    if (idx === currentIdx) {
+      if (status === "failed") return "failed"
+      if (status === "cancelled") return "skipped"
+      return "active"
+    }
+
+    // idx > currentIdx
+    if (status === "failed" || status === "cancelled") return "skipped"
+    return "pending"
+  })
+}
+
+function getProgressPercent(states: StepState[]): number {
+  const done = states.filter((s) => s === "done").length
+  return Math.round((done / states.length) * 100)
+}
+
+const STATE_STYLES: Record<StepState, { dot: string; label: string; icon: ReactNode }> = {
+  pending: {
+    dot: "border-slate-600 bg-slate-700",
+    label: "text-slate-500",
+    icon: <Minus className="h-3 w-3 text-slate-500" strokeWidth={2} />,
+  },
+  active: {
+    dot: "border-pink-500 bg-pink-500",
+    label: "text-pink-400",
+    icon: <Loader2 className="h-3 w-3 text-white animate-spin" strokeWidth={2} />,
+  },
+  done: {
+    dot: "border-green-500 bg-green-500",
+    label: "text-green-400",
+    icon: <Check className="h-3 w-3 text-white" strokeWidth={2.5} />,
+  },
+  failed: {
+    dot: "border-red-500 bg-red-500",
+    label: "text-red-400",
+    icon: <X className="h-3 w-3 text-white" strokeWidth={2.5} />,
+  },
+  skipped: {
+    dot: "border-slate-600 bg-slate-700",
+    label: "text-slate-500",
+    icon: <span className="text-[10px] leading-none text-slate-500">...</span>,
+  },
+}
+
+interface ProgressTimelineProps {
+  currentStep: string
+  status: string
+}
+
+export function ProgressTimeline({ currentStep, status }: ProgressTimelineProps) {
+  const states = getStepStates(currentStep, status)
+  const percent = getProgressPercent(states)
+
+  return (
+    <div className="space-y-4">
+      {/* Progress bar */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-slate-200">流水线进度</span>
+          <span className="font-mono text-pink-400">{percent}%</span>
+        </div>
+        <Progress value={percent} />
+      </div>
+
+      {/* Step dots */}
+      <div className="flex flex-wrap gap-3">
+        {PIPELINE_STEPS.map((step, idx) => {
+          const state = states[idx]
+          const style = STATE_STYLES[state]
+          const isActive = state === "active"
+
+          return (
+            <div
+              key={step}
+              className="flex flex-col items-center gap-1.5"
+              style={{ minWidth: "72px" }}
+            >
+              <div
+                className={cn(
+                  "flex h-7 w-7 items-center justify-center rounded-full border-2 transition-all",
+                  style.dot,
+                  isActive && "animate-step-pulse ring-4 ring-pink-500/20"
+                )}
+              >
+                {style.icon}
+              </div>
+              <span
+                className={cn(
+                  "text-center text-xs font-medium leading-tight",
+                  style.label
+                )}
+              >
+                {STEP_LABELS[step] ?? step}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/webui/src/components/ResultPanel.tsx
+++ b/webui/src/components/ResultPanel.tsx
@@ -1,0 +1,159 @@
+import {
+  CheckCircle2,
+  XCircle,
+  Ban,
+  Download,
+  PlusCircle,
+  PlayCircle,
+  FileArchive,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useTask } from "@/hooks/useTask"
+import { getArtifactUrl } from "@/lib/api"
+
+export function ResultPanel() {
+  const { taskId, status, artifacts, error, resetTask } = useTask()
+
+  if (!taskId) return null
+
+  const artifactUrl = getArtifactUrl(taskId)
+  const hasArtifacts = artifacts && artifacts.length > 0
+
+  // Done
+  if (status === "done") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 text-green-400">
+          <CheckCircle2 className="h-5 w-5" strokeWidth={1.5} />
+          <span className="text-lg font-semibold">任务完成</span>
+        </div>
+
+        {/* Video player */}
+        <div className="overflow-hidden rounded-card border border-border bg-black">
+          <video
+            controls
+            className="mx-auto max-h-[480px] w-full"
+            src={artifactUrl}
+          >
+            您的浏览器不支持视频播放。
+          </video>
+        </div>
+
+        {/* Artifacts download */}
+        {hasArtifacts && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-slate-200">下载制品</h3>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <a href={artifactUrl} download>
+                  <Download className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
+                  下载全部制品 ({artifacts!.length} 个文件)
+                </a>
+              </Button>
+              {artifacts!.map((path, idx) => (
+                <Button key={idx} variant="ghost" size="sm" asChild>
+                  <a href={artifactUrl} download>
+                    <FileArchive className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
+                    {path.split(/[\\/]/).pop() || `制品 ${idx + 1}`}
+                  </a>
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <Button variant="default" size="lg" className="w-full" onClick={resetTask}>
+          <PlusCircle className="mr-2 h-4 w-4" strokeWidth={1.5} />
+          新建任务
+        </Button>
+      </div>
+    )
+  }
+
+  // Failed
+  if (status === "failed") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 text-red-400">
+          <XCircle className="h-5 w-5" strokeWidth={1.5} />
+          <span className="text-lg font-semibold">任务失败</span>
+        </div>
+
+        {error && (
+          <div className="rounded-card border border-red-500/30 bg-red-500/10 p-4">
+            <p className="text-xs leading-relaxed text-red-300">
+              <span className="font-semibold">错误信息：</span>
+            </p>
+            <pre className="mt-2 overflow-auto whitespace-pre-wrap font-mono text-xs text-red-300">
+              {error}
+            </pre>
+          </div>
+        )}
+
+        {/* Partial artifacts */}
+        {hasArtifacts && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-slate-200">部分制品下载</h3>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <a href={artifactUrl} download>
+                  <Download className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
+                  下载制品 ({artifacts!.length} 个文件)
+                </a>
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <Button variant="default" size="lg" className="w-full" onClick={resetTask}>
+          <PlusCircle className="mr-2 h-4 w-4" strokeWidth={1.5} />
+          新建任务
+        </Button>
+      </div>
+    )
+  }
+
+  // Cancelled
+  if (status === "cancelled") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 text-slate-400">
+          <Ban className="h-5 w-5" strokeWidth={1.5} />
+          <span className="text-lg font-semibold">任务已取消</span>
+        </div>
+
+        <p className="text-sm text-slate-400">
+          任务已取消执行。您可以查看下方日志了解执行进度。
+        </p>
+
+        {/* Partial artifacts */}
+        {hasArtifacts && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-slate-200">部分制品下载</h3>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <a href={artifactUrl} download>
+                  <Download className="mr-1.5 h-4 w-4" strokeWidth={1.5} />
+                  下载制品 ({artifacts!.length} 个文件)
+                </a>
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <Button variant="default" size="lg" className="w-full" onClick={resetTask}>
+          <PlusCircle className="mr-2 h-4 w-4" strokeWidth={1.5} />
+          新建任务
+        </Button>
+      </div>
+    )
+  }
+
+  // Running — show a placeholder (MonitorPanel handles the running state)
+  return (
+    <div className="flex items-center justify-center py-8 text-slate-400">
+      <PlayCircle className="mr-2 h-5 w-5 animate-pulse" strokeWidth={1.5} />
+      <span>任务执行中...</span>
+    </div>
+  )
+}

--- a/webui/src/components/SubtitlesSection.tsx
+++ b/webui/src/components/SubtitlesSection.tsx
@@ -1,0 +1,70 @@
+import { Captions, Languages } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+import type { FormSubmitData } from "@/types"
+
+interface SubtitlesSectionProps {
+  data: FormSubmitData
+  onChange: (field: keyof FormSubmitData, value: string | number | boolean) => void
+}
+
+export function SubtitlesSection({ data, onChange }: SubtitlesSectionProps) {
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="subtitles" className="border-b-0">
+        <AccordionTrigger>字幕设置</AccordionTrigger>
+        <AccordionContent className="space-y-5">
+          {/* Subtitle language */}
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <Languages className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              字幕语言代码
+            </Label>
+            <Input
+              value={data.subtitle_lang}
+              onChange={(e) => onChange("subtitle_lang", e.target.value)}
+              placeholder="如 zh、en（留空则不启用多语言字幕）"
+            />
+            <p className="text-xs text-slate-400">
+              设置后启用翻译字幕功能，将自动翻译字幕到指定语言
+            </p>
+          </div>
+
+          {/* Subtitle mode */}
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5 text-slate-200">
+              <Captions className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+              字幕模式
+            </Label>
+            <div className="flex gap-2">
+              {([
+                { value: "original", label: "仅原文" },
+                { value: "translated", label: "仅译文" },
+                { value: "bilingual", label: "双语" },
+              ] as const).map((mode) => (
+                <button
+                  key={mode.value}
+                  type="button"
+                  onClick={() => onChange("subtitle_mode", mode.value)}
+                  className={`flex-1 rounded-input border px-3 py-2 text-sm font-medium transition-colors ${
+                    data.subtitle_mode === mode.value
+                      ? "border-pink-500 bg-pink-500/10 text-pink-400"
+                      : "border-border bg-surface text-slate-300 hover:bg-slate-700/50"
+                  }`}
+                >
+                  {mode.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/webui/src/components/VoiceSection.tsx
+++ b/webui/src/components/VoiceSection.tsx
@@ -1,0 +1,28 @@
+import { Mic } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { FormSubmitData } from "@/types"
+
+interface VoiceSectionProps {
+  data: FormSubmitData
+  onChange: (field: keyof FormSubmitData, value: string | number | boolean) => void
+}
+
+export function VoiceSection({ data, onChange }: VoiceSectionProps) {
+  return (
+    <div className="space-y-2">
+      <Label className="flex items-center gap-1.5 text-slate-200">
+        <Mic className="h-4 w-4 text-pink-500" strokeWidth={1.5} />
+        语音名称
+      </Label>
+      <Input
+        value={data.voice}
+        onChange={(e) => onChange("voice", e.target.value)}
+        placeholder="zh-CN-YunxiNeural（留空使用默认语音）"
+      />
+      <p className="text-xs text-slate-400">
+        使用 Edge TTS 语音名称，如 zh-CN-YunxiNeural、zh-CN-XiaoxiaoNeural 等
+      </p>
+    </div>
+  )
+}

--- a/webui/src/components/ui/accordion.tsx
+++ b/webui/src/components/ui/accordion.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b border-border", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:text-pink-400 [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown
+        className="h-4 w-4 shrink-0 transition-transform duration-200 text-slate-400"
+        strokeWidth={1.5}
+      />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/webui/src/components/ui/button.tsx
+++ b/webui/src/components/ui/button.tsx
@@ -1,0 +1,54 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-button text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-pink-600",
+        destructive: "bg-red-600 text-white hover:bg-red-700",
+        outline:
+          "border border-border bg-transparent hover:bg-surface hover:text-slate-50",
+        secondary: "bg-surface text-slate-50 hover:bg-slate-700",
+        ghost: "hover:bg-surface hover:text-slate-50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-button px-3",
+        lg: "h-11 rounded-button px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/webui/src/components/ui/card.tsx
+++ b/webui/src/components/ui/card.tsx
@@ -1,0 +1,83 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-card border border-border bg-surface text-slate-50 shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-slate-400", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+}

--- a/webui/src/components/ui/input.tsx
+++ b/webui/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-input border border-border bg-surface px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/webui/src/components/ui/label.tsx
+++ b/webui/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/webui/src/components/ui/progress.tsx
+++ b/webui/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-slate-700",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-pink-500 transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/webui/src/components/ui/separator.tsx
+++ b/webui/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/webui/src/components/ui/slider.tsx
+++ b/webui/src/components/ui/slider.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface SliderProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "type"> {
+  value: number
+  min?: number
+  max?: number
+  step?: number
+  onValueChange?: (value: number) => void
+}
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  ({ className, value, min = 0, max = 100, step = 1, onValueChange, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onValueChange?.(Number(e.target.value))}
+        className={cn(
+          "h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-700 outline-none",
+          // Webkit thumb
+          "[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-pink-500 [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow-lg [&::-webkit-slider-thumb]:transition-colors hover:[&::-webkit-slider-thumb]:bg-pink-400",
+          // Firefox thumb
+          "[&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:bg-pink-500 [&::-moz-range-thumb]:cursor-pointer",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Slider.displayName = "Slider"
+
+export { Slider }

--- a/webui/src/components/ui/switch.tsx
+++ b/webui/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-pink-500 data-[state=unchecked]:bg-slate-600",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/webui/src/hooks/useTask.ts
+++ b/webui/src/hooks/useTask.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react"
+import { TaskContext } from "@/App"
+
+export function useTask() {
+  const ctx = useContext(TaskContext)
+  if (!ctx) throw new Error("useTask must be used within TaskProvider")
+  return ctx
+}

--- a/webui/src/hooks/useWebSocket.ts
+++ b/webui/src/hooks/useWebSocket.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useCallback, useState } from "react"
+import type { WsMessage } from "@/types"
+import { getWsUrl } from "@/lib/api"
+
+export function useWebSocket(taskId: string | null, onMessage: (msg: WsMessage) => void) {
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectCount = useRef(0)
+  const [connected, setConnected] = useState(false)
+
+  const connect = useCallback(() => {
+    if (!taskId) return
+    const ws = new WebSocket(getWsUrl(taskId))
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setConnected(true)
+      reconnectCount.current = 0
+      ws.send(JSON.stringify({ action: "subscribe" }))
+    }
+
+    ws.onmessage = (e) => {
+      try {
+        const msg: WsMessage = JSON.parse(e.data)
+        onMessage(msg)
+      } catch {}
+    }
+
+    ws.onclose = () => {
+      setConnected(false)
+      if (reconnectCount.current < 3) {
+        reconnectCount.current++
+        setTimeout(connect, 2000)
+      }
+    }
+
+    ws.onerror = () => ws.close()
+  }, [taskId, onMessage])
+
+  useEffect(() => {
+    connect()
+    return () => {
+      wsRef.current?.close()
+      wsRef.current = null
+    }
+  }, [connect])
+
+  const sendCancel = useCallback(() => {
+    wsRef.current?.send(JSON.stringify({ action: "cancel" }))
+  }, [])
+
+  return { connected, sendCancel }
+}

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -1,0 +1,53 @@
+import type { FormSubmitData, TaskCreateResponse, TaskStatusResponse } from "@/types"
+
+const API_BASE = ""
+
+export async function createTask(
+  data: FormSubmitData,
+  video?: File,
+  bgm?: File,
+): Promise<TaskCreateResponse> {
+  const formData = new FormData()
+
+  // Append form fields
+  Object.entries(data).forEach(([key, value]) => {
+    if (typeof value === "boolean") {
+      formData.append(key, value ? "true" : "false")
+    } else if (value !== undefined && value !== null) {
+      formData.append(key, String(value))
+    }
+  })
+
+  // Append files
+  if (video) formData.append("video", video)
+  if (bgm) formData.append("bgm", bgm)
+
+  const res = await fetch(`${API_BASE}/api/tasks`, {
+    method: "POST",
+    body: formData,
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    throw new Error(err.detail || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function getTask(taskId: string): Promise<TaskStatusResponse> {
+  const res = await fetch(`${API_BASE}/api/tasks/${taskId}`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+export async function cancelTask(taskId: string): Promise<void> {
+  await fetch(`${API_BASE}/api/tasks/${taskId}`, { method: "DELETE" })
+}
+
+export function getArtifactUrl(taskId: string): string {
+  return `${API_BASE}/api/artifacts/${taskId}`
+}
+
+export function getWsUrl(taskId: string): string {
+  const proto = location.protocol === "https:" ? "wss:" : "ws:"
+  return `${proto}//${location.host}/ws/task/${taskId}`
+}

--- a/webui/src/lib/utils.ts
+++ b/webui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import ReactDOM from "react-dom/client"
+import App from "./App"
+import "./styles/globals.css"
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  * { border-color: rgba(255,255,255,0.08); }
+  body {
+    background-color: #0F172A;
+    color: #F8FAFC;
+    font-family: Inter, system-ui, sans-serif;
+  }
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: #0F172A; }
+::-webkit-scrollbar-thumb { background: #334155; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #475569; }
+
+/* Pulse animation for active step */
+@keyframes step-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.animate-step-pulse { animation: step-pulse 1.5s ease-in-out infinite; }

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -1,0 +1,61 @@
+export interface FormSubmitData {
+  movie: string;
+  style: string;
+  duration: number;
+  voice: string;
+  format: "16:9" | "9:16";
+  library_dir: string;
+  research: boolean;
+  no_bgm: boolean;
+  no_clips: boolean;
+  strict: boolean;
+  subtitle_lang: string;
+  subtitle_mode: "original" | "translated" | "bilingual";
+  scene_threshold?: number;
+  match_min_score?: number;
+  translate_provider: string;
+  translate_retries?: number;
+}
+
+export type TaskStatus = "running" | "done" | "failed" | "cancelled";
+
+export interface TaskCreateResponse {
+  task_id: string;
+  status: string;
+}
+
+export interface TaskStatusResponse {
+  task_id: string;
+  status: TaskStatus;
+  current_step?: string;
+  error?: string;
+  artifacts?: string[];
+  video_path?: string;
+}
+
+export interface WsMessage {
+  type: "progress" | "terminal";
+  step?: string;
+  version?: number;
+  log?: string;
+  status?: TaskStatus;
+  error?: string;
+  artifacts?: string[];
+  video_path?: string;
+}
+
+// Pipeline steps for progress timeline
+export const PIPELINE_STEPS = [
+  "resolve_video",
+  "generate_script",
+  "synthesize_tts",
+  "detect_scenes",
+  "match_clips",
+  "align_audio",
+  "generate_subtitle",
+  "translate_subtitles",
+  "export_clips",
+  "render_video",
+] as const;
+
+export type PipelineStep = typeof PIPELINE_STEPS[number];

--- a/webui/tailwind.config.ts
+++ b/webui/tailwind.config.ts
@@ -1,0 +1,36 @@
+import type { Config } from "tailwindcss"
+import tailwindcssAnimate from "tailwindcss-animate"
+
+export default {
+  darkMode: ["class"],
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        background: "#0F172A",
+        surface: "#1E293B",
+        primary: { DEFAULT: "#EC4899", foreground: "#F8FAFC" },
+        accent: { DEFAULT: "#2563EB", foreground: "#F8FAFC" },
+        border: "rgba(255,255,255,0.08)",
+        muted: { DEFAULT: "#1E293B", foreground: "#94A3B8" },
+      },
+      fontFamily: { sans: ["Inter", "system-ui", "sans-serif"] },
+      borderRadius: { card: "12px", button: "8px", input: "8px" },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [tailwindcssAnimate],
+} satisfies Config

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import path from "path"
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+  server: {
+    proxy: {
+      "/api": "http://127.0.0.1:8760",
+      "/ws": { target: "ws://127.0.0.1:8760", ws: true },
+    },
+  },
+})


### PR DESCRIPTION
## WebUI Refactor — FastAPI + React + WebSocket

Replace Gradio UI with FastAPI backend + React SPA frontend.

### Backend (`src/movie_narrator/web_api/`)

| File | Role |
|------|------|
| `__init__.py` | `launch_web_api()` entry point (lazy fastapi import) |
| `console.py` | `WebSocketConsole` — thread-safe buffered console |
| `controller.py` | `TaskController` — cooperative cancel flag |
| `form.py` | Copied from `web/form.py` (FormData, validate_form) |
| `models.py` | Pydantic request/response schemas |
| `tasks.py` | `TaskManager` — single-task ThreadPoolExecutor |
| `utils.py` | Upload handling, artifact collection, zip |
| `ws.py` | WebSocket endpoint for progress streaming |
| `routes.py` | REST: POST/GET/DELETE /api/tasks, GET /api/artifacts |
| `server.py` | FastAPI app factory (CORS, WS, static files) |

**Pipeline zero-modification**: `build_context` + `run_pipeline` called as-is.

### Frontend (`webui/`)

- React 18 + Vite 5 + TypeScript (strict mode, 0 errors)
- shadcn/ui components (Button, Input, Accordion, Switch, Progress, etc.)
- Tailwind CSS dark theme (pink-500 primary, slate-900 background)
- 10-step progress timeline with real-time status (pending/active/done/failed)
- Log stream with auto-scroll
- Video player + artifact downloads on completion
- WebSocket hook with auto-reconnect (3 retries)
- Form sections: Movie, Voice, Assets, Subtitles, Advanced
- All UI text in Chinese

### Build verification

- TypeScript: 0 errors (strict mode)
- Vite build: 1560 modules, 226KB JS (71KB gzipped)
- Backend import: OK (lazy fastapi import)
- Existing tests: 286 passed, 0 regressions

### Fixes applied during implementation

- `tasks.py`: use `run_pipeline(ctx, controller=...)` not `ctx.controller` (Context has no `controller` field)
- `tasks.py`: use `ctx.video_path` not `ctx.output_path` (output_path is a directory)
- `sanitize_filename`: imported from `utils/sanitize.py` (not duplicated)
- `collect_artifacts`: defined once in `utils.py` (not duplicated)
- `tailwind.config.ts`: ESM import (not `require()`)

### Install

```bash
pip install 'movie-narrator[web]'    # fastapi + uvicorn + python-multipart
cd webui && npm install              # frontend deps
cd webui && npm run build            # production build → dist/
mn web                               # launch (serves built frontend + API)
```

### Dev mode

```bash
mn web                               # backend on :8760
cd webui && npm run dev              # Vite dev server on :5173 (proxies API)
```
