### PR TITLE
fix: WS JSONDecodeError, path traversal, dead code cleanup

### DIFF
--- a/src/movie_narrator/web_api/tasks.py
+++ b/src/movie_narrator/web_api/tasks.py
@@ -31,7 +31,6 @@ class TaskInfo:
         self.console = WebSocketConsole()
         self.controller = TaskController()
         self.status: str = "running"  # running | done | failed | cancelled
-        self.current_step: str = ""
         self.error: Optional[str] = None
         self.artifacts: list[str] = []
         self.video_path: Optional[str] = None
@@ -134,10 +133,3 @@ class TaskManager:
             info.controller.cancel()
             return True
         return False
-
-    def update_step(self, task_id: str, step: str) -> None:
-        """Called by pipeline runner to update current step."""
-        info = self.get_task(task_id)
-        if info:
-            with info._lock:
-                info.current_step = step

--- a/src/movie_narrator/web_api/utils.py
+++ b/src/movie_narrator/web_api/utils.py
@@ -9,9 +9,15 @@ from typing import List, Optional
 
 
 def save_upload(upload_file, destination_dir: Path, prefix: str = "") -> str:
-    """Save an uploaded file to destination_dir. Returns the path string."""
+    """Save an uploaded file to destination_dir. Returns the path string.
+
+    Strips any directory components from the filename to prevent
+    path traversal (e.g. ``../../etc/passwd``).
+    """
     destination_dir.mkdir(parents=True, exist_ok=True)
-    filename = f"{prefix}{upload_file.filename}" if prefix else upload_file.filename
+    # Strip directory components — only keep the basename
+    raw_name = Path(upload_file.filename).name if upload_file.filename else "upload"
+    filename = f"{prefix}{raw_name}" if prefix else raw_name
     dest = destination_dir / filename
     with dest.open("wb") as f:
         shutil.copyfileobj(upload_file.file, f)

--- a/src/movie_narrator/web_api/ws.py
+++ b/src/movie_narrator/web_api/ws.py
@@ -27,9 +27,12 @@ async def task_ws_endpoint(websocket: WebSocket, task_id: str, manager: TaskMana
             # Check for client messages (subscribe/cancel)
             try:
                 msg = await asyncio.wait_for(websocket.receive_text(), timeout=0.2)
-                data = json.loads(msg)
-                if data.get("action") == "cancel":
-                    manager.cancel_task(task_id)
+                try:
+                    data = json.loads(msg)
+                    if data.get("action") == "cancel":
+                        manager.cancel_task(task_id)
+                except (json.JSONDecodeError, TypeError):
+                    pass  # ignore malformed client messages
             except asyncio.TimeoutError:
                 pass
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -365,3 +365,66 @@ def test_zip_artifacts(tmp_path):
         assert "b.txt" in names
         assert zf.read("a.txt").decode() == "hello"
         assert zf.read("b.txt").decode() == "world"
+
+
+# ── 7. Utils — path traversal protection ──────────────────
+
+
+def test_save_upload_strips_path_traversal(tmp_path):
+    """save_upload must strip directory components from filename."""
+    from movie_narrator.web_api.utils import save_upload
+    from io import BytesIO
+
+    class FakeUpload:
+        filename = "../../../etc/passwd"
+        file = BytesIO(b"malicious")
+
+    dest_dir = tmp_path / "uploads"
+    result = save_upload(FakeUpload(), dest_dir)
+
+    # File should be in dest_dir, not in /etc/passwd
+    assert str(dest_dir) in result
+    assert ".." not in result
+    assert (dest_dir / "passwd").exists()
+    # Ensure no directory traversal occurred
+    assert not (tmp_path.parent.parent.parent / "etc" / "passwd").exists()
+
+
+def test_save_upload_normal_filename(tmp_path):
+    """save_upload works correctly with a normal filename."""
+    from movie_narrator.web_api.utils import save_upload
+    from io import BytesIO
+
+    class FakeUpload:
+        filename = "video.mp4"
+        file = BytesIO(b"video data")
+
+    dest_dir = tmp_path / "uploads"
+    result = save_upload(FakeUpload(), dest_dir, prefix="prefix_")
+
+    assert (dest_dir / "prefix_video.mp4").exists()
+    assert "prefix_video.mp4" in result
+
+
+# ── 8. TaskInfo — no dead code ─────────────────────────────
+
+
+def test_task_info_no_current_step_field():
+    """TaskInfo should not have a current_step field (dead code removed).
+
+    current_step is now extracted from console.snapshot() in
+    to_status_dict(), so the field is unnecessary.
+    """
+    import inspect
+    from movie_narrator.web_api.tasks import TaskInfo
+
+    src = inspect.getsource(TaskInfo.__init__)
+    assert "current_step" not in src, "TaskInfo.__init__ should not set current_step"
+
+
+def test_task_manager_no_update_step():
+    """TaskManager should not have update_step method (dead code removed)."""
+    from movie_narrator.web_api.tasks import TaskManager
+
+    assert not hasattr(TaskManager, "update_step"), \
+        "TaskManager.update_step was dead code and should be removed"


### PR DESCRIPTION
## Full code review — 3 issues found and fixed

### 1. ws.py: JSONDecodeError crashes WS handler (HIGH)
\json.loads(msg)\ inside the inner try-except only caught \syncio.TimeoutError\. Invalid JSON from client would throw \JSONDecodeError\, propagate past the outer \WebSocketDisconnect\ handler, and silently kill the WS connection.

**Fix**: Added inner try-except for \JSONDecodeError\/\TypeError\.

### 2. utils.py: Path traversal in save_upload (MEDIUM)
\save_upload()\ used \upload_file.filename\ directly in path construction. A filename like \../../etc/passwd\ would write outside \destination_dir\.

**Fix**: Strip to basename via \Path(filename).name\.

### 3. tasks.py: Dead code cleanup (LOW)
\TaskInfo.current_step\ field and \TaskManager.update_step()\ were dead code — \current_step\ is now extracted from \console.snapshot()\ in \	o_status_dict()\. Removed both.

### Tests added (4)
- \	est_save_upload_strips_path_traversal\ — verifies \../../etc/passwd\ → \passwd\
- \	est_save_upload_normal_filename\ — normal filename with prefix
- \	est_task_info_no_current_step_field\ — dead code removed
- \	est_task_manager_no_update_step\ — dead code removed

All 26 web_api tests pass.