### PR TITLE
feat: Web upload hardening — size limits + extension whitelist + cleanup (v0.4.12 PR-2)

### DIFF
--- a/src/movie_narrator/web_api/routes.py
+++ b/src/movie_narrator/web_api/routes.py
@@ -10,7 +10,15 @@ from fastapi.responses import FileResponse
 
 from .models import CancelResponse, TaskCreateRequest, TaskCreateResponse, TaskStatusResponse
 from .tasks import TaskManager
-from .utils import save_upload, zip_artifacts
+from .utils import (
+    BGM_EXTENSIONS,
+    MAX_BGM_SIZE,
+    MAX_VIDEO_SIZE,
+    VIDEO_EXTENSIONS,
+    UploadError,
+    save_upload,
+    zip_artifacts,
+)
 
 
 def create_router(manager: TaskManager, upload_dir: Path) -> APIRouter:
@@ -38,13 +46,24 @@ def create_router(manager: TaskManager, upload_dir: Path) -> APIRouter:
         video: Optional[UploadFile] = File(None),
         bgm: Optional[UploadFile] = File(None),
     ):
-        # Save uploaded files
+        # Save uploaded files with size + extension validation
         video_path = None
         bgm_path = None
-        if video and video.filename:
-            video_path = save_upload(video, upload_dir, prefix="video_")
-        if bgm and bgm.filename:
-            bgm_path = save_upload(bgm, upload_dir, prefix="bgm_")
+        try:
+            if video and video.filename:
+                video_path = save_upload(
+                    video, upload_dir, prefix="video_",
+                    max_size=MAX_VIDEO_SIZE,
+                    allowed_extensions=VIDEO_EXTENSIONS,
+                )
+            if bgm and bgm.filename:
+                bgm_path = save_upload(
+                    bgm, upload_dir, prefix="bgm_",
+                    max_size=MAX_BGM_SIZE,
+                    allowed_extensions=BGM_EXTENSIONS,
+                )
+        except UploadError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.message)
 
         request = TaskCreateRequest(
             movie=movie, style=style, duration=duration, voice=voice,

--- a/src/movie_narrator/web_api/tasks.py
+++ b/src/movie_narrator/web_api/tasks.py
@@ -34,6 +34,7 @@ class TaskInfo:
         self.error: Optional[str] = None
         self.artifacts: list[str] = []
         self.video_path: Optional[str] = None
+        self.upload_paths: list[str] = []  # files to clean up after completion
         self._lock = threading.Lock()
 
     def set_terminal(self, status: str, error: Optional[str] = None) -> None:
@@ -83,6 +84,11 @@ class TaskManager:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         info = TaskInfo(task_id, output_dir)
+        # Track upload paths for best-effort cleanup after task completion
+        if video_path:
+            info.upload_paths.append(video_path)
+        if bgm_path:
+            info.upload_paths.append(bgm_path)
         with self._lock:
             self._tasks[task_id] = info
 
@@ -122,6 +128,14 @@ class TaskManager:
         except Exception as e:
             import traceback
             info.set_terminal("failed", f"{e}\n{traceback.format_exc()}")
+
+        finally:
+            # Best-effort cleanup of uploaded source files
+            for p in info.upload_paths:
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except Exception:
+                    pass
 
     def get_task(self, task_id: str) -> Optional[TaskInfo]:
         with self._lock:

--- a/src/movie_narrator/web_api/utils.py
+++ b/src/movie_narrator/web_api/utils.py
@@ -7,21 +7,94 @@ import zipfile
 from pathlib import Path
 from typing import List, Optional
 
+# Upload limits
+MAX_VIDEO_SIZE = 2 * 1024 * 1024 * 1024  # 2 GB
+MAX_BGM_SIZE = 50 * 1024 * 1024  # 50 MB
+CHUNK_SIZE = 1024 * 1024  # 1 MB streaming chunks
 
-def save_upload(upload_file, destination_dir: Path, prefix: str = "") -> str:
+# Extension whitelists (lowercase, no dot)
+VIDEO_EXTENSIONS = {"mp4", "mkv", "mov", "webm", "avi"}
+BGM_EXTENSIONS = {"mp3", "wav", "m4a", "flac", "ogg"}
+
+
+class UploadError(Exception):
+    """Raised when an upload fails validation (size, extension)."""
+
+    def __init__(self, message: str, status_code: int = 422) -> None:
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def save_upload(
+    upload_file,
+    destination_dir: Path,
+    prefix: str = "",
+    max_size: int = MAX_VIDEO_SIZE,
+    allowed_extensions: Optional[set[str]] = None,
+) -> str:
     """Save an uploaded file to destination_dir. Returns the path string.
 
-    Strips any directory components from the filename to prevent
-    path traversal (e.g. ``../../etc/passwd``).
+    - Strips directory components from filename (path traversal protection)
+    - Validates file extension against whitelist
+    - Streams file in chunks, rejects if size exceeds max_size
+    - Deletes partial file on size violation
     """
     destination_dir.mkdir(parents=True, exist_ok=True)
+
     # Strip directory components — only keep the basename
     raw_name = Path(upload_file.filename).name if upload_file.filename else "upload"
     filename = f"{prefix}{raw_name}" if prefix else raw_name
+
+    # Extension whitelist check
+    if allowed_extensions is not None:
+        ext = Path(raw_name).suffix.lower().lstrip(".")
+        if ext not in allowed_extensions:
+            raise UploadError(
+                f"File extension '.{ext}' not allowed. Allowed: {sorted(allowed_extensions)}",
+                status_code=415,
+            )
+
     dest = destination_dir / filename
-    with dest.open("wb") as f:
-        shutil.copyfileobj(upload_file.file, f)
+
+    # Stream-read in chunks, enforce size limit
+    total = 0
+    try:
+        with dest.open("wb") as f:
+            while True:
+                chunk = upload_file.file.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_size:
+                    f.close()
+                    dest.unlink(missing_ok=True)
+                    raise UploadError(
+                        f"File too large: {total} bytes exceeds limit {max_size} bytes",
+                        status_code=413,
+                    )
+                f.write(chunk)
+    except UploadError:
+        raise
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
+
     return str(dest)
+
+
+def cleanup_uploads(upload_dir: Path, task_id: str) -> None:
+    """Best-effort cleanup of uploaded files for a completed task.
+
+    Removes files prefixed with 'video_' or 'bgm_' that were saved
+    for this task. Non-fatal if files are missing or deletion fails.
+    """
+    try:
+        for p in upload_dir.glob("*"):
+            if p.is_file() and task_id in p.name:
+                p.unlink(missing_ok=True)
+    except Exception:
+        pass  # best-effort, never fail the task
 
 
 def collect_artifacts(ctx, output_dir: Path) -> List[str]:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -428,3 +428,126 @@ def test_task_manager_no_update_step():
 
     assert not hasattr(TaskManager, "update_step"), \
         "TaskManager.update_step was dead code and should be removed"
+
+
+# ── 9. Upload hardening — size limits + extension whitelist ──
+
+
+def test_save_upload_rejects_bad_extension(tmp_path):
+    """save_upload rejects files with non-whitelisted extensions."""
+    from movie_narrator.web_api.utils import save_upload, UploadError, VIDEO_EXTENSIONS
+    from io import BytesIO
+
+    class FakeUpload:
+        filename = "malware.exe"
+        file = BytesIO(b"payload")
+
+    with pytest.raises(UploadError, match="not allowed"):
+        save_upload(FakeUpload(), tmp_path, allowed_extensions=VIDEO_EXTENSIONS)
+
+    # File should not exist on disk
+    assert not (tmp_path / "malware.exe").exists()
+
+
+def test_save_upload_accepts_whitelisted_extension(tmp_path):
+    """save_upload accepts files with whitelisted extensions."""
+    from movie_narrator.web_api.utils import save_upload, VIDEO_EXTENSIONS
+    from io import BytesIO
+
+    class FakeUpload:
+        filename = "clip.mkv"
+        file = BytesIO(b"video")
+
+    result = save_upload(FakeUpload(), tmp_path, allowed_extensions=VIDEO_EXTENSIONS)
+    assert (tmp_path / "clip.mkv").exists()
+    assert "clip.mkv" in result
+
+
+def test_save_upload_rejects_oversized_file(tmp_path):
+    """save_upload rejects files exceeding max_size and deletes partial."""
+    from movie_narrator.web_api.utils import save_upload, UploadError
+    from io import BytesIO
+
+    # Create 5MB of data, limit to 1MB
+    data = b"x" * (5 * 1024 * 1024)
+
+    class FakeUpload:
+        filename = "big.mp4"
+        file = BytesIO(data)
+
+    with pytest.raises(UploadError, match="too large"):
+        save_upload(FakeUpload(), tmp_path, max_size=1024 * 1024)
+
+    # Partial file must be deleted
+    assert not (tmp_path / "big.mp4").exists()
+
+
+def test_save_upload_streaming_under_limit(tmp_path):
+    """save_upload succeeds when file is under the size limit."""
+    from movie_narrator.web_api.utils import save_upload
+    from io import BytesIO
+
+    # 512KB data, 1MB limit
+    data = b"y" * (512 * 1024)
+
+    class FakeUpload:
+        filename = "ok.webm"
+        file = BytesIO(data)
+
+    result = save_upload(
+        FakeUpload(), tmp_path,
+        max_size=1024 * 1024,
+        allowed_extensions={"webm"},
+    )
+    assert (tmp_path / "ok.webm").exists()
+    assert (tmp_path / "ok.webm").stat().st_size == 512 * 1024
+
+
+def test_save_upload_extension_case_insensitive(tmp_path):
+    """Extension check is case-insensitive."""
+    from movie_narrator.web_api.utils import save_upload, VIDEO_EXTENSIONS
+    from io import BytesIO
+
+    class FakeUpload:
+        filename = "clip.MP4"
+        file = BytesIO(b"data")
+
+    result = save_upload(FakeUpload(), tmp_path, allowed_extensions=VIDEO_EXTENSIONS)
+    assert (tmp_path / "clip.MP4").exists()
+
+
+def test_cleanup_uploads_best_effort(tmp_path):
+    """cleanup_uploads removes matching files, ignores missing."""
+    from movie_narrator.web_api.utils import cleanup_uploads
+
+    # Create some files
+    (tmp_path / "video_test123.mp4").write_bytes(b"v")
+    (tmp_path / "bgm_test123.mp3").write_bytes(b"b")
+    (tmp_path / "video_other.mp4").write_bytes(b"other")
+    (tmp_path / "not_related.txt").write_bytes(b"x")
+
+    cleanup_uploads(tmp_path, "test123")
+
+    # Files with task_id should be deleted
+    assert not (tmp_path / "video_test123.mp4").exists()
+    assert not (tmp_path / "bgm_test123.mp3").exists()
+    # Other files remain
+    assert (tmp_path / "video_other.mp4").exists()
+    assert (tmp_path / "not_related.txt").exists()
+
+
+def test_cleanup_uploads_empty_dir(tmp_path):
+    """cleanup_uploads on empty directory doesn't raise."""
+    from movie_narrator.web_api.utils import cleanup_uploads
+    cleanup_uploads(tmp_path, "nonexistent")  # should not raise
+
+
+def test_upload_error_status_codes():
+    """UploadError carries correct HTTP status codes."""
+    from movie_narrator.web_api.utils import UploadError
+
+    size_err = UploadError("too large", status_code=413)
+    assert size_err.status_code == 413
+
+    ext_err = UploadError("bad ext", status_code=415)
+    assert ext_err.status_code == 415


### PR DESCRIPTION
## Web upload hardening — v0.4.12 PR-2

Three upload security improvements for the Web API.

### 1. File size limits with streaming enforcement
- Video: 2 GB max, BGM: 50 MB max
- `save_upload` reads in 1MB chunks, rejects (HTTP 413) if exceeded
- Partial file deleted on size violation

### 2. Extension whitelist
- Video: `mp4`, `mkv`, `mov`, `webm`, `avi`
- BGM: `mp3`, `wav`, `m4a`, `flac`, `ogg`
- Case-insensitive, rejects (HTTP 415) non-whitelisted extensions
- Pairs with existing path traversal protection (PR #29)

### 3. Best-effort upload cleanup after task completion
- `TaskInfo.upload_paths` tracks saved file paths
- `finally` block in `_run_task` deletes them (`missing_ok=True`)
- Non-fatal: cleanup errors never affect task status

### New `UploadError` exception
Carries HTTP status code (413/415/422) for proper REST error responses.

### Tests (9 new)
- Rejects bad extension (`.exe` rejected, `.mkv` accepted)
- Rejects oversized file (5MB > 1MB limit, partial deleted)
- Streaming under limit (512KB < 1MB, correct size on disk)
- Case-insensitive extension (`.MP4` accepted)
- `cleanup_uploads` utility (matching files deleted, others kept)
- `UploadError` status codes (413, 415)

### Verification
- 305 passed, 2 failed (pre-existing TTS config), 11 skipped
