### PR TITLE
ci: add test summary job for branch protection (v0.4.12 PR-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test-matrix:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -57,6 +57,23 @@ jobs:
           test -f output/CI-YAML-Test/metadata.json
           test -f output/CI-YAML-Test/subtitle.srt
           echo "YAML config smoke test passed"
+
+  # Summary job — name "test" matches branch protection required check.
+  # Matrix jobs generate "test-matrix (3.10)" etc. which don't match.
+  # This job depends on all matrix jobs and is a no-op gate.
+  test:
+    needs: [test-matrix]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix results
+        run: |
+          if [[ "${{ needs.test-matrix.result }}" == "success" ]]; then
+            echo "All matrix jobs passed"
+          else
+            echo "Matrix jobs failed: ${{ needs.test-matrix.result }}"
+            exit 1
+          fi
 
   media:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Branch protection requires a check named \	est\, but the matrix job generates \	est (3.10)\, \	est (3.11)\, etc. — they never match, so every PR needs \--admin\ to merge.

## Fix

- Rename matrix job \	est\ → \	est-matrix\
- Add \	est\ summary job (\
eeds: [test-matrix]\, \if: always()\) that exits 0 if all matrix jobs passed, 1 otherwise

## Why option A (summary job) over B (change branch protection rule)

- Versionable in the repo — no GitHub settings changes needed
- Survives repo transfers / new maintainers
- The summary job name exactly matches the required check name

## After merge

Future PRs should merge without \--admin\ once the \	est\ check appears in CI runs.

## Checklist

- [x] Matrix job renamed to \	est-matrix\
- [x] \	est\ summary job added with \if: always()\
- [x] Summary job fails if any matrix job fails