### PR TITLE
feat: core engine production quality (v0.4.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed (Production defaults tightened without config)
 - **Match defaults**: `match_speed_clamp_min` 0.5 → 0.85, `match_speed_clamp_max` 3.0 → 1.25, `scene_merge_min_duration` 0.0 → 2.0 — keeps pacing publishable. Scenes shorter than `match_drop_scene_min_duration` (default 0.4s) are dropped after merge with re-indexing (last-resort keeps all if every scene would be dropped).
 - **Render encode**: CRF 18, preset `slow`, `+faststart` movflag by default for VOD-friendly output.
+- **QA duration tolerance**: `qa_max_duration_ratio` default 1.15 → 1.25 — TTS natural output routinely exceeds the target duration by 10-20%; the tighter 1.15 threshold falsely rejected valid renders in hand-testing.
 - Pipeline is now **15 steps** (was 14): `validate_deliverable` inserted between `render_video` and `export_clips`. Frontend `PIPELINE_STEPS` and `STEP_LABELS` synced (`成片质检`).
+
+### Fixed (Hand-test P0 bugs on Windows + Python 3.14)
+- **Two-stage render** (`render.py`): MoviePy 2.x `write_videofile` on Windows + Python 3.14 raises `OSError [Errno 22] Invalid argument` partway through the rawvideo stdin pipe when encoding video+audio together, leaving `final.mp4` with a corrupted ftyp/mdat layout (no moov atom — ffprobe returns empty, file unplayable). Split into stage 1 (MoviePy writes video-only mp4, stable in isolation) + stage 2 (ffmpeg muxes audio with `-c:v copy` + applies `+faststart` atomically). Eliminates the stdin pipe failure mode entirely.
+- **UTF-8 subprocess decoding** (`deliverable_qa.py`): `subprocess.run` with `text=True` alone uses the system locale (GBK on Chinese Windows), which crashed when ffprobe/ffmpeg emitted non-GBK bytes and left stdout/stderr empty — causing `validate_deliverable` to fail every render with false `silent_audio` / `no_audio_stream`. Added `_run()` helper forcing `encoding="utf-8", errors="replace"` so probe parsing always sees real text.
+- **`load.py` param whitelist**: 12 production-quality knobs (`render_fit_mode`, `render_crf`, `render_preset`, `render_faststart`, `render_subtitle_position`, `render_subtitle_max_width_ratio`, `render_subtitle_bottom_margin_ratio`, `qa_enabled`, `qa_max_silence_db`, `qa_min_duration_ratio`, `qa_max_duration_ratio`, `match_drop_scene_min_duration`, `bgm_duck_db`, `bgm_normalize`, `audio_target_dbfs`) were missing from `_ALLOWED_PARAMS` — job configs setting these were silently rejected at load time.
 
 ## [0.4.12] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.13] - 2026-07-17
+
+### Added (Core engine production quality)
+- **Post-render deliverable QA step** (`validate_deliverable`): new hard pipeline step inserted after `render_video`. Probes the final `final.mp4` with ffprobe (falling back to `ffmpeg -i` when ffprobe is absent) and fails the pipeline on missing/silent audio, missing video stream, duration mismatch, or tiny output. CI runs skip QA by default (fast smoke); local runs enable it by default. Configurable via `qa_enabled` / `qa_max_silence_db` / `qa_min_duration_ratio` / `qa_max_duration_ratio`.
+- **Audio normalize + BGM ducking** (`utils/audio_mix.py`): `normalize_peak()` targets a loudness floor; `duck_bgm()` attenuates BGM under narration with windowed envelope + linear attack/release smoothing. The `mix_bgm` skip path now normalizes narration for loudness consistency; the success path ducks then normalizes. MP3 export falls back to WAV when the bundled ffmpeg lacks libmp3lame.
+- **Video cover/contain layout** (`utils/video_layout.py`): `compute_fit_box()` returns crop+resize geometry so source footage fills the canvas (cover) or letterboxes (contain). Render applies `cover` by default.
+- **Bottom-safe subtitle layout**: `text_image.create_text_image` gains `position="bottom"`, `max_width_ratio`, `bottom_margin_ratio`, `max_lines` with CJK-aware wrapping and ellipsis truncation. Render now always draws subtitle overlays for all segments (including footage-covered ones) using the bottom position by default.
+- **Deliverable QA probes** (`utils/deliverable_qa.py`): `probe_media()` + `evaluate_deliverable()` with structured `QAReport` / `QAIssue` output.
+- 15 new `JobParams` fields plumbed through schema → merge → runner metadata for render fit/encode/subtitle, BGM duck/normalize, QA, and match drop.
+- 44 new unit tests across `test_video_layout`, `test_text_image`, `test_audio_mix`, `test_deliverable_qa`, `test_qa`, extended `test_match` (tiny-scene drop + merge defaults) and `test_bgm` (ducking/normalize + WAV fallback).
+
+### Changed (Production defaults tightened without config)
+- **Match defaults**: `match_speed_clamp_min` 0.5 → 0.85, `match_speed_clamp_max` 3.0 → 1.25, `scene_merge_min_duration` 0.0 → 2.0 — keeps pacing publishable. Scenes shorter than `match_drop_scene_min_duration` (default 0.4s) are dropped after merge with re-indexing (last-resort keeps all if every scene would be dropped).
+- **Render encode**: CRF 18, preset `slow`, `+faststart` movflag by default for VOD-friendly output.
+- Pipeline is now **15 steps** (was 14): `validate_deliverable` inserted between `render_video` and `export_clips`. Frontend `PIPELINE_STEPS` and `STEP_LABELS` synced (`成片质检`).
+
 ## [0.4.12] - 2026-07-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ output/
 
 ## Pipeline
 
-14-step sequential pipeline (see [Architecture](docs/ARCHITECTURE.md)):
+15-step sequential pipeline (see [Architecture](docs/ARCHITECTURE.md)):
 
 ```text
 resolve_video → prepare_assets → research_plot → generate_script →
 export_script_md → generate_voice → align_audio → detect_scenes →
 match_clips → mix_bgm → translate_subtitles → generate_subtitle →
-render_video → export_clips
+render_video → validate_deliverable → export_clips
 ```
 
 **Soft steps** (research, align, scene detect, scene match, BGM, translate, clip export) gracefully skip or soft-degrade when optional dependencies are missing or upstream data is unavailable. Use `--strict` to abort instead.
@@ -351,7 +351,7 @@ movie-narrator/
 │   ├── config.py            # Pydantic settings
 │   ├── models.py            # Data models (Context, Status, etc.)
 │   ├── pipeline/
-│   │   ├── runner.py        # 14-step pipeline orchestrator
+│   │   ├── runner.py        # 15-step pipeline orchestrator
 │   │   ├── resolve.py       # Source video resolution
 │   │   ├── assets.py        # Asset validation
 │   │   ├── research.py      # LLM movie research
@@ -365,6 +365,7 @@ movie-narrator/
 │   │   ├── translate.py     # Multi-language subtitle translation (LLM)
 │   │   ├── subtitle.py      # SRT generation (single / translated / bilingual)
 │   │   ├── render.py        # MoviePy 2.x video rendering
+│   │   ├── qa.py            # Post-render deliverable QA (hard step)
 │   │   ├── export_clips.py  # Per-segment clip export (direct ffmpeg)
 │   │   ├── preflight.py     # Pre-run LLM/TTS validation (fail-fast)
 │   │   └── errors.py        # PipelineStrictError, PipelineCancelled, RunController, StepAction
@@ -394,7 +395,10 @@ movie-narrator/
 │   │   ├── metadata_export.py # metadata.json builder
 │   │   ├── optional_deps.py # Optional dependency probing
 │   │   ├── prompts.py       # Prompt templates
-│   │   └── retention.py     # Log file retention
+│   │   ├── retention.py     # Log file retention
+│   │   ├── audio_mix.py     # Audio normalize + BGM ducking (pydub)
+│   │   ├── deliverable_qa.py # ffprobe/ffmpeg media probing + QA rules
+│   │   └── video_layout.py  # Cover/contain crop+resize geometry
 │   └── web_api/                 # FastAPI + WebSocket backend (default Web UI; requires [web] extra)
 │       ├── __init__.py          # lazy launch_web_api export
 │       ├── __main__.py          # python -m movie_narrator.web_api
@@ -437,7 +441,12 @@ movie-narrator/
 │   ├── test_web_console.py
 │   ├── test_web_controller.py
 │   ├── test_web_form.py
-│   └── test_workflow_steps.py
+│   ├── test_workflow_steps.py
+│   ├── test_audio_mix.py
+│   ├── test_deliverable_qa.py
+│   ├── test_qa.py
+│   ├── test_text_image.py
+│   └── test_video_layout.py
 ├── docs/
 ├── assets/
 └── .github/workflows/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,20 +2,20 @@
 
 ## Pipeline Overview
 
-14-step sequential pipeline orchestrated by `pipeline/runner.py`. Before any step executes, `preflight.py` probes LLM connectivity and TTS provider configuration — failing fast with `PreflightError` instead of silently degrading to mock content.
+15-step sequential pipeline orchestrated by `pipeline/runner.py`. Before any step executes, `preflight.py` probes LLM connectivity and TTS provider configuration — failing fast with `PreflightError` instead of silently degrading to mock content.
 
 ```text
 resolve_video → prepare_assets → research_plot → generate_script →
 export_script_md → generate_voice → align_audio → detect_scenes →
 match_clips → mix_bgm → translate_subtitles → generate_subtitle →
-render_video → export_clips
+render_video → validate_deliverable → export_clips
 ```
 
 ### Step Categories
 
 | Category | Steps | Status |
 |----------|-------|--------|
-| **Hard** (always run) | resolve_video, prepare_assets, generate_script, export_script_md, generate_voice, render_video | Must succeed |
+| **Hard** (always run) | resolve_video, prepare_assets, generate_script, export_script_md, generate_voice, render_video, validate_deliverable | Must succeed |
 | **Soft** (skip on missing deps) | research_plot, align_audio, detect_scenes, match_clips, mix_bgm, translate_subtitles, export_clips | Skip gracefully / soft-degrade; `--strict` to abort |
 
 ### Pipeline Status Model
@@ -154,8 +154,9 @@ pipeline probes duration via AudioSegment.from_mp3
 11. **mix_bgm** — (optional) mixes background music under narration → `final_audio.mp3`
 12. **translate_subtitles** — (optional, v0.3) when `subtitle_lang` is set, calls the configured translation provider (default `llm`) per chunk; failure policy is retry-then-soft-degrade (fill with originals, surface a `metadata.warnings` entry). CI passthrough (`CI=1`) copies originals without network. The step produces `ctx.translated_texts` only — no files written. `subtitle_path` invariant is preserved.
 13. **generate_subtitle** — pure formatter. Always writes `subtitle.srt` from `timed_segments`. When `translated_texts` is non-empty and length-aligned, additionally writes `subtitle.<lang>.srt` (translated) and `subtitle.bilingual.srt` (cue body `f"{src}\n{dst}"` with explicit LF). Bundles paths into `ctx.subtitle_paths: SubtitlePaths` and resolves `ctx.render_subtitle_path` per `subtitle_mode` (original | translated | bilingual).
-14. **render_video** — MoviePy composites: solid background + text overlays (or real footage for matched segments) + audio → `final.mp4` + `metadata.json`. Overlay text comes from `ctx.render_subtitle_path`; multi-line cues auto-scale the font (`scale = 1.0 - 0.1 * (line_count - 1)`, clamped to `[0.6, 1.0]`).
-15. **export_clips** — (optional) extracts per-segment clips to `clips/` directory
+14. **render_video** — MoviePy composites: solid background + text overlays (or real footage for matched segments) + audio → `final.mp4` + `metadata.json`. Source footage is fitted to the canvas (cover by default; contain letterboxes). Subtitle overlays are always drawn (bottom position by default) including over footage segments. Encode uses CRF 18 / preset `slow` / `+faststart` by default. Overlay text comes from `ctx.render_subtitle_path`; multi-line cues auto-scale the font (`scale = 1.0 - 0.1 * (line_count - 1)`, clamped to `[0.6, 1.0]`).
+15. **validate_deliverable** — (hard) probes `final.mp4` with ffprobe (falls back to `ffmpeg -i` when ffprobe is absent). Fails the pipeline on missing video/audio stream, silent audio (mean volume below `qa_max_silence_db`), duration outside `[qa_min_duration_ratio, qa_max_duration_ratio]`, or tiny output file. CI skips by default; local runs enable QA unless `qa_enabled: false`. Stores `ctx.metadata["qa_report"]`.
+16. **export_clips** — (optional) extracts per-segment clips to `clips/` directory
 
 ## Output Structure
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This runs `tsc` (TypeScript type check) followed by the Vite production build. A
 ```
 movie-narrator/
 ├── src/movie_narrator/
-│   ├── pipeline/        # 14-step runner, preflight, tts/render/match/... step modules
+│   ├── pipeline/        # 15-step runner, preflight, tts/render/match/... step modules
 │   ├── tts/             # TTS provider abstraction (edge, openai, mimo, factory, cache)
 │   ├── web_api/         # FastAPI + WebSocket backend (default WebUI, port 8760)
 │   ├── web/             # Legacy Gradio UI (retained for reference, not default)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -122,6 +122,18 @@ The Web UI is rebuilt from a Gradio single-file app into a decoupled **FastAPI +
 - [x] Migrated tests: `test_web_form.py` → `web_api.form`, `test_pipeline_cancel.py` → `TaskController`
 - [x] Deleted `test_web_console.py`, `test_web_controller.py` (covered by `test_web_api.py`)
 
+### v0.4.13 Core Engine Production Quality
+
+- [x] Post-render deliverable QA step (`validate_deliverable`) — hard step after `render_video`; ffprobe + ffmpeg fallback; CI skips by default, local runs enable
+- [x] Audio normalize + BGM ducking (`utils/audio_mix.py`) — windowed envelope with attack/release smoothing; skip path normalizes narration
+- [x] Video cover/contain layout (`utils/video_layout.py`) — source footage fitted to canvas; render defaults to `cover`
+- [x] Bottom-safe subtitle layout — `text_image.create_text_image` with CJK wrapping + ellipsis; render always draws overlays (bottom by default)
+- [x] Deliverable QA probes (`utils/deliverable_qa.py`) — structured `QAReport` / `QAIssue`
+- [x] Match defaults tightened — clamp 0.85–1.25, merge 2.0s, drop tiny scenes <0.4s
+- [x] Render encode quality — CRF 18, preset `slow`, `+faststart`
+- [x] 15 new `JobParams` fields plumbed (render fit/encode/subtitle, BGM duck/normalize, QA, match drop)
+- [x] Pipeline 14 → 15 steps; frontend `PIPELINE_STEPS` / `STEP_LABELS` synced
+
 ### v0.4 Environment variables
 
 - `MN_TTS_PROVIDER` — `edge` (default), `openai`, or `mimo`
@@ -142,15 +154,16 @@ Strict separation: `.env` contains ONLY LLM + TTS infrastructure (21 fields); `j
 - LLM (11): `MN_LLM_BASE_URL`, `MN_LLM_API_KEY`, `MN_LLM_MODEL`, `MN_LLM_TIMEOUT`, `MN_SCRIPT_TEMPERATURE`, `MN_SCRIPT_MAX_TOKENS`, `MN_SCRIPT_RETRIES`, `MN_SCRIPT_RETRY_DELAY`, `MN_RESEARCH_TEMPERATURE`, `MN_RESEARCH_MAX_TOKENS`, `MN_TRANSLATE_MAX_TOKENS`
 - TTS (10): `MN_DEFAULT_VOICE`, `MN_TTS_PROVIDER`, `MN_TTS_CACHE_MAX_MB`, `MN_OPENAI_TTS_*`(3), `MN_MIMO_*`(4)
 
-**`job.yaml` (params) — 32 keys:** See [`job.example.yaml`](../examples/job.example.yaml)
+**`job.yaml` (params) — 47 keys:** See [`job.example.yaml`](../examples/job.example.yaml)
 - Scene: `scene_threshold`, `scene_frame_skip`
-- Match: `match_min_score`, `match_speed_clamp_min/max`, `scene_merge_min_duration`, `embedding_model_name`
-- BGM: `bgm_gain_db`
+- Match: `match_min_score`, `match_speed_clamp_min/max`, `scene_merge_min_duration`, `match_drop_scene_min_duration`, `embedding_model_name`
+- BGM: `bgm_gain_db`, `bgm_duck_db`, `bgm_normalize`, `audio_target_dbfs`
 - TTS pacing: `tts_pause_ms`, `tts_max_concurrent`, `tts_audio_format`, `tts_audio_bitrate`
 - Translate: `translate_source_lang`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`
 - Research: `research_provider`
 - WhisperX: `whisperx_device/model/language`
-- Render: `render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout`
+- Render: `render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout`, `render_fit_mode/crf/preset/faststart`, `render_subtitle_position/max_width_ratio/bottom_margin_ratio`
+- QA: `qa_enabled`, `qa_max_silence_db`, `qa_min_duration_ratio`, `qa_max_duration_ratio`
 - Async: `async_timeout`, `async_max_workers`
 - Video: `video_sizes`
 

--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -138,7 +138,7 @@ params:
   # qa_enabled: true              # false=显式关闭；CI 默认跳过，本地默认开启
   # qa_max_silence_db: -50.0      # 平均音量低于此值判定为静音失败
   # qa_min_duration_ratio: 0.85   # 成片时长 < 预期*0.85 判定失败
-  # qa_max_duration_ratio: 1.15   # 成片时长 > 预期*1.15 判定失败
+  # qa_max_duration_ratio: 1.25   # 成片时长 > 预期*1.25 判定失败(TTS 自然产出可能超 10-20%)
 
   # ---- 异步 ----
   # async_timeout: 300        # 异步任务超时（秒）

--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -57,8 +57,9 @@ subtitle_mode: original     # original | translated | bilingual
 # 白名单（其余键会被拒绝）：
 #   场景: scene_threshold / scene_frame_skip
 #   匹配: match_min_score / match_speed_clamp_min / match_speed_clamp_max
-#          scene_merge_min_duration / embedding_model_name
-#   BGM:  bgm_gain_db
+#          scene_merge_min_duration / match_drop_scene_min_duration
+#          embedding_model_name
+#   BGM:  bgm_gain_db / bgm_duck_db / bgm_normalize / audio_target_dbfs
 #   TTS:  tts_pause_ms / tts_max_concurrent / tts_audio_format / tts_audio_bitrate
 #   翻译: translate_source_lang / translate_provider / translate_retries
 #          translate_chunk_chars / translate_chunk_size
@@ -66,6 +67,10 @@ subtitle_mode: original     # original | translated | bilingual
 #   WhisperX: whisperx_device / whisperx_model / whisperx_language
 #   渲染: render_fps / render_video_codec / render_audio_codec / render_threads
 #          render_bg_color / render_font_size / render_output_name / render_ffmpeg_timeout
+#          render_fit_mode / render_crf / render_preset / render_faststart
+#          render_subtitle_position / render_subtitle_max_width_ratio
+#          render_subtitle_bottom_margin_ratio
+#   质检: qa_enabled / qa_max_silence_db / qa_min_duration_ratio / qa_max_duration_ratio
 #   异步: async_timeout / async_max_workers
 #   视频: video_sizes
 params:
@@ -77,13 +82,18 @@ params:
   match_min_score: 0.25     # embedding 匹配最低余弦相似度（低于此值丢弃）
   # 速度因子 = 匹配到的场景时长 / 解说片段时长。
   # clamp 将速度限制在舒适范围，防止相邻片段忽快忽慢。
-  match_speed_clamp_min: 0.5    # 最慢速度因子（<1 = 慢放上限）
-  match_speed_clamp_max: 3.0    # 最快速度因子（>1 = 快进上限）
-  scene_merge_min_duration: 0   # 场景最短时长（秒），0=不合并；设为 3.0 可给 clamp 更大窗口
+  # v0.4.13 起默认值收紧至 0.85–1.25（生产可用节奏）。
+  match_speed_clamp_min: 0.85    # 最慢速度因子（<1 = 慢放上限）
+  match_speed_clamp_max: 1.25    # 最快速度因子（>1 = 快进上限）
+  scene_merge_min_duration: 2.0  # 场景最短时长（秒），0=不合并；2.0 给 clamp 更大窗口
+  # match_drop_scene_min_duration: 0.4  # 合并后丢弃短于此阈值的场景（秒）
   # embedding_model_name: paraphrase-multilingual-MiniLM-L12-v2
 
-  # ---- BGM ----
-  # bgm_gain_db: -18          # BGM 混音增益（dB）
+  # ---- BGM / 音频 ----
+  # bgm_gain_db: -18          # BGM 基础增益（dB）
+  # bgm_duck_db: -10          # 旁白在场时额外衰减（dB）
+  # bgm_normalize: true       # 混音后峰值归一化到 audio_target_dbfs
+  # audio_target_dbfs: -14.0  # 归一化目标响度（dBFS）
 
   # ---- TTS 音频 ----
   # tts_pause_ms: 300         # 解说片段间静音时长（毫秒）
@@ -115,6 +125,20 @@ params:
   # render_font_size: 100     # 文字叠加字体大小
   # render_output_name: final.mp4  # 最终视频文件名
   # render_ffmpeg_timeout: 300  # export_clips ffmpeg 超时（秒）
+  # ---- 渲染生产质量（v0.4.13 起的默认值，按需覆盖）----
+  # render_fit_mode: cover        # cover = 裁剪填充画布 | contain = 信箱模式
+  # render_crf: 18                # 质量（越小越高，18≈视觉无损）
+  # render_preset: slow           # x264 编码预设（ultrafast…veryslow）
+  # render_faststart: true        # +faststart（VOD 友好）
+  # render_subtitle_position: bottom  # bottom | center
+  # render_subtitle_max_width_ratio: 0.9   # 字幕最大宽度占画布比例
+  # render_subtitle_bottom_margin_ratio: 0.08  # 底部留白比例
+
+  # ---- 成片质检（v0.4.13 新增硬步骤 validate_deliverable）----
+  # qa_enabled: true              # false=显式关闭；CI 默认跳过，本地默认开启
+  # qa_max_silence_db: -50.0      # 平均音量低于此值判定为静音失败
+  # qa_min_duration_ratio: 0.85   # 成片时长 < 预期*0.85 判定失败
+  # qa_max_duration_ratio: 1.15   # 成片时长 > 预期*1.15 判定失败
 
   # ---- 异步 ----
   # async_timeout: 300        # 异步任务超时（秒）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.4.12"
+version = "0.4.13"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = {text = "AGPL-3.0"}

--- a/src/movie_narrator/pipeline/bgm.py
+++ b/src/movie_narrator/pipeline/bgm.py
@@ -3,6 +3,32 @@ from pathlib import Path
 from pydub import AudioSegment
 
 from ..models import Context, StepResult
+from ..utils.audio_mix import duck_bgm, normalize_peak
+
+
+def _export_robust(seg: AudioSegment, out: Path) -> str:
+    """Export audio, falling back to WAV when MP3 encoding is unavailable.
+
+    pydub's MP3 export requires ffmpeg's libmp3lame; some minimal ffmpeg
+    builds (and the imageio-ffmpeg bundle) lack it. WAV is native PCM and
+    needs no encoder, so it is a safe fallback. The render step reads the
+    result back via MoviePy, which accepts both.
+    """
+    try:
+        seg.export(out, format="mp3")
+        return str(out)
+    except Exception:
+        wav_out = out.with_suffix(".wav")
+        seg.export(wav_out, format="wav")
+        return str(wav_out)
+
+
+def _normalize_narration(ctx: Context, narration: AudioSegment) -> str:
+    """Normalize narration and write to a side file, returning the path."""
+    out = Path(ctx.output_dir) / "narration_normalized.mp3"
+    target = ctx.metadata.get("audio_target_dbfs", -14.0)
+    normalized = normalize_peak(narration, target_dbfs=target)
+    return _export_robust(normalized, out)
 
 
 def mix_bgm(ctx: Context) -> Context:
@@ -12,9 +38,19 @@ def mix_bgm(ctx: Context) -> Context:
         return ctx
 
     req = ctx.metadata.get("bgm_request", "none")
+    do_norm = ctx.metadata.get("bgm_normalize", True)
+
     if req == "none" or (req == "default" and not ctx.assets.bgm):
+        # No BGM — still normalize narration for production consistency.
+        if do_norm:
+            try:
+                narration = AudioSegment.from_file(ctx.audio_path)
+                ctx.final_audio_path = _normalize_narration(ctx, narration)
+            except Exception:
+                ctx.final_audio_path = ctx.audio_path
+        else:
+            ctx.final_audio_path = ctx.audio_path
         ctx.status.bgm = "skipped"
-        ctx.final_audio_path = ctx.audio_path
         return ctx
 
     if req == "explicit" and not ctx.assets.bgm:
@@ -32,15 +68,18 @@ def mix_bgm(ctx: Context) -> Context:
     try:
         narration = AudioSegment.from_file(ctx.audio_path)
         gain_db = ctx.metadata.get("bgm_gain_db", -18.0)
-        bgm = AudioSegment.from_file(ctx.assets.bgm).apply_gain(gain_db)
-        if len(bgm) < len(narration):
-            times = len(narration) // max(len(bgm), 1) + 1
-            bgm = bgm * times
-        bgm = bgm[: len(narration)]
-        mixed = narration.overlay(bgm)
+        duck_db = ctx.metadata.get("bgm_duck_db", -10.0)
+        bgm_raw = AudioSegment.from_file(ctx.assets.bgm)
+
+        mixed = duck_bgm(
+            narration, bgm_raw,
+            bgm_gain_db=gain_db, duck_db=duck_db,
+        )
+        if do_norm:
+            target = ctx.metadata.get("audio_target_dbfs", -14.0)
+            mixed = normalize_peak(mixed, target_dbfs=target)
         out = Path(ctx.output_dir) / "mixed.mp3"
-        mixed.export(out, format="mp3")
-        ctx.final_audio_path = str(out)
+        ctx.final_audio_path = _export_robust(mixed, out)
         ctx.status.bgm = "success"
         return ctx
     except Exception as e:

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -317,14 +317,15 @@ def match_clips(ctx: Context) -> Context:
         return ctx
 
     min_score = ctx.metadata.get("match_min_score", 0.25)
-    clamp_min = ctx.metadata.get("match_speed_clamp_min", 0.5)
-    clamp_max = ctx.metadata.get("match_speed_clamp_max", 3.0)
-    merge_min = ctx.metadata.get("scene_merge_min_duration", 0.0)
+    clamp_min = ctx.metadata.get("match_speed_clamp_min", 0.85)
+    clamp_max = ctx.metadata.get("match_speed_clamp_max", 1.25)
+    merge_min = ctx.metadata.get("scene_merge_min_duration", 2.0)
+    drop_min = ctx.metadata.get("match_drop_scene_min_duration", 0.4)
     output_dir = Path(ctx.output_dir)
 
     try:
         return _match_clips_impl(
-            ctx, min_score, clamp_min, clamp_max, merge_min, output_dir
+            ctx, min_score, clamp_min, clamp_max, merge_min, drop_min, output_dir
         )
     except Exception as e:
         ctx.status.match = "failed"
@@ -339,6 +340,7 @@ def _match_clips_impl(
     clamp_min: float,
     clamp_max: float,
     merge_min: float,
+    drop_min: float,
     output_dir: Path,
 ) -> Context:
     # Optionally merge short scenes to reduce extreme speed factors
@@ -348,6 +350,17 @@ def _match_clips_impl(
         ctx.services.console.debug(
             f"  scene merge: {len(ctx.scenes)} -> {len(scenes)} scenes (min={merge_min}s)"
         )
+
+    # Drop tiny scenes (e.g. <0.4s) that produce jarring sub-frame cuts.
+    # If filtering would remove *all* scenes, keep the merged list as a
+    # last-resort so matching still produces output.
+    if drop_min > 0 and scenes:
+        filtered = [s for s in scenes if (s.end - s.start) >= drop_min]
+        if filtered:
+            scenes = filtered
+            # Re-index after drop so scene indices are sequential.
+            for i, s in enumerate(scenes):
+                s.index = i
 
     # Compute total scene span
     scene_start = min(s.start for s in scenes)

--- a/src/movie_narrator/pipeline/qa.py
+++ b/src/movie_narrator/pipeline/qa.py
@@ -1,0 +1,78 @@
+"""Hard pipeline step: validate the rendered deliverable.
+
+Runs after ``render_video`` and before ``export_clips``. Probes the output
+video and rejects it if it is missing streams, the wrong length, near-silent,
+or implausibly small. In CI, the step is skipped unless ``qa_enabled`` is
+explicitly set, to keep the smoke test fast and free of binary-probing flakiness.
+"""
+
+from __future__ import annotations
+
+from ..models import Context
+from ..tts.base import is_ci
+from ..utils.deliverable_qa import evaluate_deliverable
+
+
+def validate_deliverable(ctx: Context) -> Context:
+    """Probe the rendered video and fail the pipeline on publishability issues.
+
+    Hard step: a failure raises ``RuntimeError`` so the pipeline stops before
+    exporting clips from a broken render. Not registered in
+    ``SOFT_STATUS_STEPS`` — failures are real, not advisory.
+    """
+    # QA gating (spec §7.5):
+    #   qa_enabled=True  → always run (even in CI)
+    #   qa_enabled=False → always skip (explicit opt-out)
+    #   not set (None)   → skip in CI (fast smoke tests), run locally
+    qa_enabled = ctx.metadata.get("qa_enabled", None)
+    if qa_enabled is False:
+        ctx.services.console.debug("QA step skipped (qa_enabled=false)")
+        return ctx
+    if qa_enabled is None and is_ci():
+        ctx.services.console.debug("QA step skipped in CI (qa_enabled not set)")
+        return ctx
+
+    video_path = ctx.video_path
+    if not video_path:
+        raise RuntimeError("QA: no video_path on context — render step did not produce output")
+
+    # Expected duration = last narration segment end (the narration length
+    # the render was supposed to cover). Falls back to audio probe length.
+    expected = 0.0
+    if ctx.timed_segments:
+        expected = max(s.end for s in ctx.timed_segments)
+    if expected <= 0 and ctx.final_audio_path:
+        # Last-resort: derive from audio file via the same probe path.
+        from ..utils.deliverable_qa import probe_media
+
+        try:
+            expected = probe_media(ctx.final_audio_path).get("duration", 0.0) or 0.0
+        except Exception:
+            expected = 0.0
+
+    report = evaluate_deliverable(
+        video_path,
+        expected_duration=expected,
+        max_silence_db=ctx.metadata.get("qa_max_silence_db", -50.0),
+        min_duration_ratio=ctx.metadata.get("qa_min_duration_ratio", 0.85),
+        max_duration_ratio=ctx.metadata.get("qa_max_duration_ratio", 1.15),
+    )
+
+    # Stash the report so downstream steps / metadata can surface it.
+    ctx.metadata["qa_report"] = {
+        "ok": report.ok,
+        "issues": [{"code": i.code, "message": i.message} for i in report.issues],
+        "metrics": report.metrics,
+    }
+
+    if not report.ok:
+        codes = ", ".join(i.code for i in report.issues)
+        messages = "; ".join(i.message for i in report.issues)
+        ctx.services.console.inline_warn(f"QA failed: {codes}")
+        raise RuntimeError(f"Deliverable QA failed ({codes}): {messages}")
+
+    ctx.services.console.debug(
+        f"QA passed: duration={report.metrics.get('duration', 0):.1f}s, "
+        f"vol={report.metrics.get('mean_volume')}dB"
+    )
+    return ctx

--- a/src/movie_narrator/pipeline/qa.py
+++ b/src/movie_narrator/pipeline/qa.py
@@ -55,7 +55,7 @@ def validate_deliverable(ctx: Context) -> Context:
         expected_duration=expected,
         max_silence_db=ctx.metadata.get("qa_max_silence_db", -50.0),
         min_duration_ratio=ctx.metadata.get("qa_min_duration_ratio", 0.85),
-        max_duration_ratio=ctx.metadata.get("qa_max_duration_ratio", 1.15),
+        max_duration_ratio=ctx.metadata.get("qa_max_duration_ratio", 1.25),
     )
 
     # Stash the report so downstream steps / metadata can surface it.

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -8,6 +8,7 @@ from proglog import TqdmProgressBarLogger
 from ..models import Context, MatchedClip, StepResult, TimedSegment
 from ..utils.metadata_export import build_metadata_json
 from ..utils.text_image import create_text_image as _create_text_image
+from ..utils.video_layout import compute_fit_box
 
 
 class _RenderProgressLogger(TqdmProgressBarLogger):
@@ -68,6 +69,12 @@ def render_video(ctx: Context) -> Context:
     audio_clip = AudioFileClip(audio_path)
     total_duration = audio_clip.duration
 
+    # Production-quality render knobs (spec §7.2).
+    fit_mode = ctx.metadata.get("render_fit_mode", "cover")
+    subtitle_position = ctx.metadata.get("render_subtitle_position", "bottom")
+    max_width_ratio = ctx.metadata.get("render_subtitle_max_width_ratio", 0.9)
+    bottom_margin_ratio = ctx.metadata.get("render_subtitle_bottom_margin_ratio", 0.08)
+
     # Parse background color "R,G,B" → tuple
     bg_color_str = ctx.metadata.get("render_bg_color", "20,20,30")
     bg_parts = [int(x.strip()) for x in bg_color_str.split(",")]
@@ -96,28 +103,55 @@ def render_video(ctx: Context) -> Context:
                     subclip = source.subclipped(mc.src_start, mc.src_end)
                     if src_duration > 0:
                         subclip = subclip.with_speed_scaled(factor=src_duration / max(seg_duration, 0.1))
-                    subclip = subclip.with_start(mc.narr_start)
-                    clips.append(subclip)
+
+                    # Fit source frame onto the canvas (cover=crop+fill,
+                    # contain=letterbox+center). Keeps footage from overflowing
+                    # or distorting the output resolution.
+                    box = compute_fit_box(
+                        (subclip.w, subclip.h), size, mode=fit_mode,
+                    )
+                    if fit_mode == "cover":
+                        fitted = subclip.cropped(
+                            x1=box.crop_x, y1=box.crop_y,
+                            x2=box.crop_x + box.crop_w, y2=box.crop_y + box.crop_h,
+                        ).resized((box.out_w, box.out_h))
+                        fitted = fitted.with_position((0, 0))
+                    else:  # contain
+                        fitted = subclip.resized((box.out_w, box.out_h))
+                        pos_x = (size[0] - box.out_w) // 2
+                        pos_y = (size[1] - box.out_h) // 2
+                        fitted = fitted.with_position((pos_x, pos_y))
+
+                    clips.append(fitted.with_start(mc.narr_start))
                 except Exception as ie:
                     ctx.services.console.debug(f"  fallback for segment {mc.segment_index}: {ie}")
                     img_array = _create_text_image(
                         _overlay_text(ctx, mc.segment_index, ctx.timed_segments[mc.segment_index]),
-                        size, fontsize=font_size,
+                        size, fontsize=font_size, position=subtitle_position,
+                        max_width_ratio=max_width_ratio,
+                        bottom_margin_ratio=bottom_margin_ratio,
                     )
                     img_clip = ImageClip(img_array, is_mask=False)
                     img_clip = img_clip.with_duration(seg_duration).with_start(mc.narr_start)
                     clips.append(img_clip)
             # NOTE: source must NOT be closed here — subclips still need its reader during write_videofile.
 
-    # Always add text overlays for any segment not covered by footage
+    # Always draw subtitle overlays for ALL narration segments — including
+    # footage-covered ones. Publishable recaps need visible subtitles even
+    # over footage; footage segments use the "bottom" position so the text
+    # sits under the action instead of obscuring it.
     footage_segments = set()
     for mc in usable_clips:
         footage_segments.add(mc.segment_index)
 
     for i, seg in enumerate(ctx.timed_segments):
-        if i in footage_segments:
-            continue
-        img_array = _create_text_image(_overlay_text(ctx, i, seg), size, fontsize=font_size)
+        pos = "bottom" if i in footage_segments else subtitle_position
+        img_array = _create_text_image(
+            _overlay_text(ctx, i, seg), size, fontsize=font_size,
+            position=pos,
+            max_width_ratio=max_width_ratio,
+            bottom_margin_ratio=bottom_margin_ratio,
+        )
         img_clip = ImageClip(img_array, is_mask=False)
         img_clip = img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
         clips.append(img_clip)
@@ -146,6 +180,16 @@ def render_video(ctx: Context) -> Context:
     _EXT_NORM = {"mp3lame": "mp3", "libfdk_aac": "aac", "pcm_s16le": "wav"}
     temp_ext = _EXT_NORM.get(temp_ext, temp_ext)
 
+    # Production-quality encode: CRF + preset + faststart (spec §7.2).
+    # faststart moves the moov atom to the front so the video can begin
+    # playback before the full file downloads (required for web preview).
+    crf = ctx.metadata.get("render_crf", 18)
+    preset = ctx.metadata.get("render_preset", "slow")
+    faststart = ctx.metadata.get("render_faststart", True)
+    ffmpeg_params = ["-crf", str(crf), "-preset", str(preset)]
+    if faststart:
+        ffmpeg_params += ["-movflags", "+faststart"]
+
     write_kwargs = dict(
         fps=ctx.metadata.get("render_fps", 24),
         codec=ctx.metadata.get("render_video_codec", "libx264"),
@@ -153,6 +197,7 @@ def render_video(ctx: Context) -> Context:
         threads=ctx.metadata.get("render_threads", 4),
         logger=_RenderProgressLogger(),
         temp_audiofile=str(tmp_dir / f"temp_audio.{temp_ext}"),
+        ffmpeg_params=ffmpeg_params,
     )
     try:
         final_video.write_videofile(str(video_path), **write_kwargs)

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import subprocess
 from pathlib import Path
 
 from moviepy import AudioFileClip, ColorClip, CompositeVideoClip, ImageClip, VideoFileClip
@@ -163,22 +164,10 @@ def render_video(ctx: Context) -> Context:
     tmp_dir = output_dir / ".tmp"
     tmp_dir.mkdir(exist_ok=True)
 
-    # temp_audiofile extension MUST match the audio_codec so the final
-    # mux step ("-acodec copy") reads a correctly-typed bitstream.
-    # With audio_codec="aac", a ".wav" extension causes a RIFF/WAV
-    # header wrapping AAC data — ffmpeg then decodes only ~6 ms.
     audio_codec = ctx.metadata.get("render_audio_codec", "aac")
-    temp_ext = audio_codec
-    # "copy" is a passthrough pseudo-codec; "aac" works for both AAC-LC
-    # and the HE-AAC variants.  Map libmp3lame → mp3 so the temp file
-    # always carries a real container extension.
-    if temp_ext == "copy":
-        temp_ext = "aac"
-    elif temp_ext.startswith("lib"):
-        temp_ext = temp_ext[3:]  # libmp3lame → mp3lame
-    # Normalise a few known aliases to a short file extension.
-    _EXT_NORM = {"mp3lame": "mp3", "libfdk_aac": "aac", "pcm_s16le": "wav"}
-    temp_ext = _EXT_NORM.get(temp_ext, temp_ext)
+    # The mux passes ``audio_codec`` (or its lib-prefix-stripped form)
+    # directly to ``ffmpeg -c:a`` later in this function, so no temp
+    # file extension translation is needed here.
 
     # Production-quality encode: CRF + preset + faststart (spec §7.2).
     # faststart moves the moov atom to the front so the video can begin
@@ -186,21 +175,32 @@ def render_video(ctx: Context) -> Context:
     crf = ctx.metadata.get("render_crf", 18)
     preset = ctx.metadata.get("render_preset", "slow")
     faststart = ctx.metadata.get("render_faststart", True)
-    ffmpeg_params = ["-crf", str(crf), "-preset", str(preset)]
-    if faststart:
-        ffmpeg_params += ["-movflags", "+faststart"]
 
-    write_kwargs = dict(
+    # TWO-STAGE ENCODE: write a video-only mp4 via MoviePy (which is
+    # stable in isolation), then mux audio with ffmpeg in a second pass.
+    #
+    # This avoids a recurring failure mode on Windows + Python 3.14 +
+    # MoviePy 2.x where ``write_videofile`` writes audio + video through
+    # a single Popen pipe and the rawvideo stdin write raises
+    # ``OSError [Errno 22] Invalid argument`` partway through — leaving
+    # the final file with a corrupted ftyp/mdat layout (no moov atom).
+    # See commit notes on PR #37 for the empirical reproduction.
+    video_only_path = tmp_dir / "video_only.mp4"
+
+    video_ffmpeg_params = ["-crf", str(crf), "-preset", str(preset)]
+    # NOTE: do NOT include +faststart here — we apply it deterministically
+    # during the second-pass ffmpeg mux below, which is more reliable than
+    # bundling it into MoviePy's subprocess invocation.
+    video_write_kwargs = dict(
         fps=ctx.metadata.get("render_fps", 24),
         codec=ctx.metadata.get("render_video_codec", "libx264"),
-        audio_codec=audio_codec,
+        audio=False,  # ← key: defer audio mux to step 2
         threads=ctx.metadata.get("render_threads", 4),
         logger=_RenderProgressLogger(),
-        temp_audiofile=str(tmp_dir / f"temp_audio.{temp_ext}"),
-        ffmpeg_params=ffmpeg_params,
+        ffmpeg_params=video_ffmpeg_params,
     )
     try:
-        final_video.write_videofile(str(video_path), **write_kwargs)
+        final_video.write_videofile(str(video_only_path), **video_write_kwargs)
     finally:
         # Exception-safe cleanup: each close is guarded so one failure
         # doesn't prevent the remaining resources from being released.
@@ -213,6 +213,54 @@ def render_video(ctx: Context) -> Context:
                     obj.close()
                 except Exception:  # noqa: BLE001
                     pass
+        # `final_video` already closed above; slice the audio so we can
+        # write the final mux without keeping the original AudioFileClip alive.
+        del audio_clip
+
+    # STAGE 2: deterministic audio mux via ffmpeg. ffmpeg is significantly
+    # more robust than MoviePy for muxing (it's what MoviePy ultimately
+    # shells out to internally) and lets us apply +faststart atomically
+    # alongside the mux.
+    if shutil.which("ffmpeg") is None:  # pragma: no cover - ffmpeg is required
+        raise RuntimeError(
+            "ffmpeg binary not found on PATH — required for production-quality "
+            "mux. Install ffmpeg (https://ffmpeg.org/download.html) and retry."
+        )
+
+    mux_cmd = [
+        shutil.which("ffmpeg"),
+        "-y",
+        "-loglevel", "error",
+        "-i", str(video_only_path),
+        "-i", str(audio_path),
+        "-map", "0:v:0",
+        "-map", "1:a:0",
+        "-c:v", "copy",
+        "-c:a", audio_codec if not audio_codec.startswith("lib") else audio_codec[3:],
+    ]
+    if faststart:
+        mux_cmd += ["-movflags", "+faststart"]
+    mux_cmd.append(str(video_path))
+
+    try:
+        proc = subprocess.run(
+            mux_cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=600,  # 10 min — generous for slow ffmpeg mux
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"ffmpeg mux failed (exit={proc.returncode}): {proc.stderr}"
+            )
+    finally:
+        # Clean up the video-only intermediate to keep the output dir tidy.
+        try:
+            video_only_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
     metadata = build_metadata_json(ctx)
     with open(output_dir / "metadata.json", "w", encoding="utf-8") as f:

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -23,6 +23,7 @@ from .subtitle import generate_subtitle
 from .translate import translate_subtitles
 from .tts import generate_voice
 from .render import render_video
+from .qa import validate_deliverable
 
 # ── Step metadata (module-level constants) ──────────────────
 # Single source of truth: a soft step whose exception is caught by the runner
@@ -79,6 +80,7 @@ STEPS = [
     translate_subtitles,
     generate_subtitle,
     render_video,
+    validate_deliverable,
     export_clips,
 ]
 
@@ -175,13 +177,19 @@ def build_context(
         for key in (
             "scene_threshold", "scene_frame_skip", "match_min_score",
             "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration", "embedding_model_name",
-            "bgm_gain_db", "tts_pause_ms",
+            "scene_merge_min_duration", "match_drop_scene_min_duration",
+            "embedding_model_name",
+            "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
+            "tts_pause_ms",
             "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
             "translate_source_lang", "translate_chunk_chars", "translate_chunk_size",
             "whisperx_device", "whisperx_model", "whisperx_language",
             "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
             "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            "render_fit_mode", "render_crf", "render_preset", "render_faststart",
+            "render_subtitle_position", "render_subtitle_max_width_ratio",
+            "render_subtitle_bottom_margin_ratio",
+            "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
             "async_timeout", "async_max_workers",
             "video_sizes",
         ):
@@ -201,7 +209,7 @@ def run_pipeline(
     *,
     controller: Optional[RunController] = None,
 ) -> Context:
-    """Execute the 14-step pipeline against *ctx*.
+    """Execute the 15-step pipeline against *ctx*.
 
     ``controller=None`` means CLI mode — no cancel checks fire. Web
     passes a ``GradioController`` so the user can request a cooperative

--- a/src/movie_narrator/utils/audio_mix.py
+++ b/src/movie_narrator/utils/audio_mix.py
@@ -1,0 +1,140 @@
+"""Audio loudness helpers — peak normalization and BGM ducking.
+
+Uses pydub only (no scipy). Ducking is a simple windowed envelope:
+when narration RMS in a window exceeds the speech threshold, BGM is
+attenuated by ``duck_db`` for that window with linear attack/release.
+"""
+
+from __future__ import annotations
+
+from pydub import AudioSegment
+from pydub.utils import db_to_float
+
+
+def normalize_peak(seg: AudioSegment, target_dbfs: float = -14.0) -> AudioSegment:
+    """Normalize ``seg`` so its peak reaches approximately ``target_dbfs``.
+
+    ``target_dbfs`` is interpreted as a peak (max) target, consistent with
+    pydub's ``max_dBFS``. A silent segment (max == 0) is returned unchanged
+    to avoid a divide-by-zero explosion.
+    """
+    if seg.max == 0:
+        return seg
+    gain = target_dbfs - seg.max_dBFS
+    return seg.apply_gain(gain)
+
+
+def duck_bgm(
+    narration: AudioSegment,
+    bgm: AudioSegment,
+    *,
+    bgm_gain_db: float = -18.0,
+    duck_db: float = -10.0,
+    attack_ms: int = 50,
+    release_ms: int = 200,
+    window_ms: int = 50,
+    speech_threshold_dbfs: float = -40.0,
+) -> AudioSegment:
+    """Duck ``bgm`` under ``narration`` and overlay the two tracks.
+
+    1. Apply ``bgm_gain_db`` baseline attenuation to BGM.
+    2. Loop/trim BGM to narration length.
+    3. For each ``window_ms`` window, if narration RMS > ``speech_threshold_dbfs``,
+       apply an extra ``duck_db`` attenuation to that BGM window. Linear
+       attack (``attack_ms``) ramps the duck in; release (``release_ms``)
+       ramps it out, avoiding abrupt volume jumps.
+    4. Overlay ducked BGM under narration.
+
+    Returns a mix the same length as ``narration``.
+    """
+    # Baseline BGM gain + loop/trim to narration length.
+    bgm_base = bgm.apply_gain(bgm_gain_db)
+    target_len = len(narration)
+    if len(bgm_base) < target_len:
+        times = target_len // max(len(bgm_base), 1) + 1
+        bgm_base = bgm_base * times
+    bgm_base = bgm_base[:target_len]
+
+    if target_len == 0:
+        return narration
+
+    # Build the per-window gain envelope (in dB, 0 = no extra attenuation).
+    n_windows = max(1, target_len // window_ms)
+    window_envelope: list[float] = []  # extra attenuation dB per window
+    for i in range(n_windows):
+        start = i * window_ms
+        end = min(start + window_ms, target_len)
+        chunk = narration[start:end]
+        if len(chunk) == 0:
+            window_envelope.append(0.0)
+            continue
+        rms_db = chunk.dBFS
+        if rms_db is None or rms_db <= -100:
+            window_envelope.append(0.0)
+        elif rms_db > speech_threshold_dbfs:
+            window_envelope.append(duck_db)
+        else:
+            window_envelope.append(0.0)
+
+    # Smooth the envelope with linear attack/release so the duck fades
+    # in/out rather than clicking. Convert per-window dB → per-window
+    # amplitude factor, then interpolate across windows.
+    smoothed = _smooth_envelope(window_envelope, attack_ms, release_ms, window_ms)
+
+    # Apply the envelope by slicing BGM into windows and gain-adjusting each.
+    ducked_chunks: list[AudioSegment] = []
+    for i in range(n_windows):
+        start = i * window_ms
+        end = min(start + window_ms, target_len)
+        chunk = bgm_base[start:end]
+        extra_db = smoothed[i]
+        if extra_db < 0.0:
+            chunk = chunk.apply_gain(extra_db)
+        ducked_chunks.append(chunk)
+
+    if not ducked_chunks:
+        return narration
+
+    ducked_bgm = ducked_chunks[0]
+    for c in ducked_chunks[1:]:
+        ducked_bgm = ducked_bgm + c
+
+    # Ensure exact length (window rounding may add/drop a few ms).
+    if len(ducked_bgm) != target_len:
+        ducked_bgm = ducked_bgm[:target_len]
+
+    return narration.overlay(ducked_bgm)
+
+
+def _smooth_envelope(
+    envelope: list[float],
+    attack_ms: int,
+    release_ms: int,
+    window_ms: int,
+) -> list[float]:
+    """Linear-interpolate attack/release across window indices.
+
+    ``attack_ms``/``release_ms`` are converted to window counts. When the
+    envelope transitions from 0 → duck, it ramps linearly over the attack
+    windows; duck → 0 ramps over the release windows.
+    """
+    n = len(envelope)
+    if n == 0:
+        return []
+
+    attack_w = max(1, attack_ms // max(window_ms, 1))
+    release_w = max(1, release_ms // max(window_ms, 1))
+
+    smoothed = list(envelope)
+    for i in range(1, n):
+        prev = smoothed[i - 1]
+        cur = envelope[i]
+        if cur < prev:
+            # Ramping into duck (attack): limit step to prev - duck/attack_w.
+            max_step = abs(cur) / attack_w
+            smoothed[i] = max(cur, prev - max_step)
+        elif cur > prev:
+            # Ramping out of duck (release): limit step to duck/release_w.
+            max_step = abs(prev) / release_w
+            smoothed[i] = min(cur, prev + max_step)
+    return smoothed

--- a/src/movie_narrator/utils/deliverable_qa.py
+++ b/src/movie_narrator/utils/deliverable_qa.py
@@ -53,22 +53,40 @@ def _ffmpeg_bin() -> str:
         return "ffmpeg"  # last resort — let subprocess raise
 
 
+def _run(cmd: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a subprocess with UTF-8 decoding (Windows-safe).
+
+    ``text=True`` alone uses the system locale (GBK on Chinese Windows),
+    which crashes when ffprobe/ffmpeg emit non-GBK bytes and leaves
+    stdout/stderr empty — causing false QA failures. Force UTF-8 with
+    replacement so probe parsing always sees *some* text.
+    """
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+    )
+
+
 def _probe_with_ffprobe(path: str) -> Optional[dict]:
     """Probe via ffprobe JSON output. Returns None if ffprobe unavailable."""
     ffprobe = shutil.which("ffprobe")
     if not ffprobe:
         return None
     try:
-        proc = subprocess.run(
+        proc = _run(
             [
                 ffprobe, "-v", "quiet",
                 "-print_format", "json",
                 "-show_format", "-show_streams",
                 path,
             ],
-            capture_output=True, text=True, timeout=30,
+            timeout=30,
         )
-        if proc.returncode != 0:
+        if proc.returncode != 0 or not (proc.stdout or "").strip():
             return None
         data = json.loads(proc.stdout)
     except Exception:
@@ -103,9 +121,9 @@ def _probe_with_ffmpeg(path: str) -> dict:
     """Fallback probe using ``ffmpeg -i`` stderr parsing."""
     bin_path = _ffmpeg_bin()
     try:
-        proc = subprocess.run(
+        proc = _run(
             [bin_path, "-i", path, "-hide_banner"],
-            capture_output=True, text=True, timeout=30,
+            timeout=30,
         )
         # ffmpeg -i exits non-zero when there's no output, but stderr still
         # contains the stream info we need.
@@ -155,17 +173,20 @@ def _detect_volume(path: str) -> Optional[float]:
     """
     bin_path = _ffmpeg_bin()
     try:
-        proc = subprocess.run(
+        proc = _run(
             [bin_path, "-i", path, "-af", "volumedetect", "-f", "null", "-"],
-            capture_output=True, text=True, timeout=60,
+            timeout=60,
         )
         stderr = proc.stderr or ""
     except Exception:
         return None
 
-    m = re.search(r"mean_volume:\s*(-?[\d.]+)\s*dB", stderr)
+    m = re.search(r"mean_volume:\s*([-\d.]+)\s*dB", stderr)
     if m:
-        return float(m.group(1))
+        try:
+            return float(m.group(1))
+        except ValueError:
+            return None
     return None
 
 

--- a/src/movie_narrator/utils/deliverable_qa.py
+++ b/src/movie_narrator/utils/deliverable_qa.py
@@ -1,0 +1,252 @@
+"""Deliverable media QA — probe a rendered video and flag publishability issues.
+
+Probes container/streams/volume via ffprobe when available, falling back to
+the imageio-ffmpeg-bundled ``ffmpeg`` binary (which is NOT ffprobe) by
+parsing ``ffmpeg -i`` stderr. Volume is measured with ``volumedetect``.
+All checks are advisory except when wired as a hard pipeline step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class QAIssue:
+    """A single failed QA check."""
+
+    code: str
+    message: str
+
+
+@dataclass
+class QAReport:
+    """Aggregated QA result for a deliverable."""
+
+    ok: bool
+    issues: list[QAIssue] = field(default_factory=list)
+    metrics: dict = field(default_factory=dict)
+
+
+def _ffmpeg_bin() -> str:
+    """Return a usable ffmpeg binary path.
+
+    Prefers a system ``ffprobe``-adjacent ``ffmpeg``; falls back to the
+    imageio-ffmpeg bundled binary so probing works even without a system
+    ffmpeg install.
+    """
+    sys_ffmpeg = shutil.which("ffmpeg")
+    if sys_ffmpeg:
+        return sys_ffmpeg
+    try:
+        import imageio_ffmpeg
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception:
+        return "ffmpeg"  # last resort — let subprocess raise
+
+
+def _probe_with_ffprobe(path: str) -> Optional[dict]:
+    """Probe via ffprobe JSON output. Returns None if ffprobe unavailable."""
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                ffprobe, "-v", "quiet",
+                "-print_format", "json",
+                "-show_format", "-show_streams",
+                path,
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout)
+    except Exception:
+        return None
+
+    streams = data.get("streams", [])
+    fmt = data.get("format", {})
+    v_stream = next((s for s in streams if s.get("codec_type") == "video"), None)
+    a_stream = next((s for s in streams if s.get("codec_type") == "audio"), None)
+
+    duration = 0.0
+    try:
+        duration = float(fmt.get("duration") or v_stream.get("duration") or 0.0)
+    except (TypeError, ValueError):
+        duration = 0.0
+
+    width = int(v_stream.get("width", 0)) if v_stream else 0
+    height = int(v_stream.get("height", 0)) if v_stream else 0
+
+    return {
+        "duration": duration,
+        "has_video": v_stream is not None,
+        "has_audio": a_stream is not None,
+        "width": width,
+        "height": height,
+        "size_bytes": _file_size(path),
+        "mean_volume": _detect_volume(path),
+    }
+
+
+def _probe_with_ffmpeg(path: str) -> dict:
+    """Fallback probe using ``ffmpeg -i`` stderr parsing."""
+    bin_path = _ffmpeg_bin()
+    try:
+        proc = subprocess.run(
+            [bin_path, "-i", path, "-hide_banner"],
+            capture_output=True, text=True, timeout=30,
+        )
+        # ffmpeg -i exits non-zero when there's no output, but stderr still
+        # contains the stream info we need.
+        stderr = proc.stderr or ""
+    except Exception:
+        stderr = ""
+
+    has_video = "Video:" in stderr
+    has_audio = "Audio:" in stderr
+
+    duration = 0.0
+    m = re.search(r"Duration:\s*([\d:.]+)", stderr)
+    if m:
+        parts = m.group(1).split(":")
+        try:
+            duration = sum(float(p) * (60 ** i) for i, p in enumerate(reversed(parts)))
+        except ValueError:
+            duration = 0.0
+
+    width, height = 0, 0
+    m = re.search(r"(\d{2,5})x(\d{2,5})", stderr)
+    if m:
+        width, height = int(m.group(1)), int(m.group(2))
+
+    return {
+        "duration": duration,
+        "has_video": has_video,
+        "has_audio": has_audio,
+        "width": width,
+        "height": height,
+        "size_bytes": _file_size(path),
+        "mean_volume": _detect_volume(path),
+    }
+
+
+def _file_size(path: str) -> int:
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def _detect_volume(path: str) -> Optional[float]:
+    """Run ``ffmpeg -af volumedetect`` and parse mean_volume (dBFS).
+
+    Returns None if the file has no audio or ffmpeg fails.
+    """
+    bin_path = _ffmpeg_bin()
+    try:
+        proc = subprocess.run(
+            [bin_path, "-i", path, "-af", "volumedetect", "-f", "null", "-"],
+            capture_output=True, text=True, timeout=60,
+        )
+        stderr = proc.stderr or ""
+    except Exception:
+        return None
+
+    m = re.search(r"mean_volume:\s*(-?[\d.]+)\s*dB", stderr)
+    if m:
+        return float(m.group(1))
+    return None
+
+
+def probe_media(path: str) -> dict:
+    """Return ffprobe-like metrics for ``path``.
+
+    Keys: ``duration``, ``has_video``, ``has_audio``, ``mean_volume``,
+    ``width``, ``height``, ``size_bytes``. ``mean_volume`` is None when
+    the file has no audio or volumedetect is unavailable.
+    """
+    result = _probe_with_ffprobe(path)
+    if result is None:
+        result = _probe_with_ffmpeg(path)
+    return result
+
+
+def evaluate_deliverable(
+    video_path: str,
+    *,
+    expected_duration: float,
+    max_silence_db: float = -50.0,
+    min_duration_ratio: float = 0.85,
+    max_duration_ratio: float = 1.15,
+    min_size_bytes: int = 10_000,
+) -> QAReport:
+    """Run all QA checks and return a structured report.
+
+    Checks:
+    1. file exists and ``size >= min_size_bytes``
+    2. has video stream and audio stream
+    3. duration within ``[min_duration_ratio, max_duration_ratio]`` of expected
+    4. ``mean_volume > max_silence_db`` (audio is not near-silent)
+    5. width/height > 0
+    """
+    issues: list[QAIssue] = []
+    metrics: dict = {}
+
+    if not Path(video_path).exists():
+        return QAReport(
+            ok=False,
+            issues=[QAIssue("missing_file", f"file not found: {video_path}")],
+            metrics={},
+        )
+
+    metrics = probe_media(video_path)
+    size = metrics.get("size_bytes", 0)
+    if size < min_size_bytes:
+        issues.append(QAIssue("tiny_file", f"file size {size}B < {min_size_bytes}B"))
+
+    if not metrics.get("has_video"):
+        issues.append(QAIssue("no_video_stream", "file has no video stream"))
+    if not metrics.get("has_audio"):
+        issues.append(QAIssue("no_audio_stream", "file has no audio stream"))
+
+    duration = metrics.get("duration", 0.0) or 0.0
+    if expected_duration > 0 and duration > 0:
+        ratio = duration / expected_duration
+        if ratio < min_duration_ratio:
+            issues.append(QAIssue(
+                "too_short",
+                f"duration {duration:.2f}s is {ratio:.2%} of expected {expected_duration:.2f}s "
+                f"(min {min_duration_ratio:.0%})",
+            ))
+        elif ratio > max_duration_ratio:
+            issues.append(QAIssue(
+                "too_long",
+                f"duration {duration:.2f}s is {ratio:.2%} of expected {expected_duration:.2f}s "
+                f"(max {max_duration_ratio:.0%})",
+            ))
+
+    mean_vol = metrics.get("mean_volume")
+    if mean_vol is not None and mean_vol <= max_silence_db:
+        issues.append(QAIssue(
+            "silent_audio",
+            f"mean volume {mean_vol:.1f}dB <= silence floor {max_silence_db:.1f}dB",
+        ))
+
+    if metrics.get("width", 0) <= 0 or metrics.get("height", 0) <= 0:
+        issues.append(QAIssue(
+            "bad_resolution",
+            f"invalid dimensions {metrics.get('width')}x{metrics.get('height')}",
+        ))
+
+    return QAReport(ok=len(issues) == 0, issues=issues, metrics=metrics)

--- a/src/movie_narrator/utils/text_image.py
+++ b/src/movie_narrator/utils/text_image.py
@@ -11,7 +11,46 @@ from PIL import Image, ImageDraw
 from .font import get_font
 
 
-def create_text_image(text: str, size: tuple, fontsize: int = 100):
+def _wrap_line(text: str, draw: ImageDraw.ImageDraw, font, max_width: int) -> list[str]:
+    """Wrap a single line to ``max_width`` pixels using font metrics.
+
+    Greedy word-wrap (splits on spaces). For CJK text with no spaces,
+    each character becomes its own break candidate so long paragraphs
+    still wrap correctly.
+    """
+    if not text:
+        return [""]
+    # Try space-based wrapping first; fall back to char-based for CJK.
+    has_spaces = " " in text
+    tokens = text.split(" ") if has_spaces else list(text)
+
+    lines: list[str] = []
+    cur = ""
+    for tok in tokens:
+        sep = " " if has_spaces else ""
+        candidate = f"{cur}{sep}{tok}" if cur else tok
+        bbox = draw.textbbox((0, 0), candidate, font=font)
+        w = bbox[2] - bbox[0]
+        if w <= max_width or not cur:
+            cur = candidate
+        else:
+            lines.append(cur)
+            cur = tok
+    if cur:
+        lines.append(cur)
+    return lines or [""]
+
+
+def create_text_image(
+    text: str,
+    size: tuple,
+    fontsize: int = 100,
+    *,
+    position: str = "center",
+    max_width_ratio: float = 0.9,
+    bottom_margin_ratio: float = 0.08,
+    max_lines: int = 2,
+):
     """Render text to a transparent RGBA image, supporting multi-line.
 
     Multi-line behavior (spec §7.3):
@@ -19,10 +58,28 @@ def create_text_image(text: str, size: tuple, fontsize: int = 100):
     - Fontscale per line: ``1.0 - 0.1 * (line_count - 1)``, clamped to ``[0.6, 1.0]``.
     - Lines are stacked vertically with a small spacing proportional to fontsize.
 
+    ``position="center"`` (default, backward compatible): vertically center
+    the text block — original behaviour for text-only segments.
+
+    ``position="bottom"``: wrap text to ``max_width_ratio * width``, cap at
+    ``max_lines`` (overflowing lines are truncated with an ellipsis), and
+    draw the block near the bottom with ``bottom_margin_ratio * height``
+    padding. Used for publishable recaps where subtitles must sit under
+    the footage without obscuring the action.
+
     Returns a ``numpy.ndarray`` (RGBA) suitable for ``ImageClip``.
     """
     import numpy as np  # local import — only needed for return type
 
+    if position == "bottom":
+        return _render_bottom(
+            text, size, fontsize,
+            max_width_ratio=max_width_ratio,
+            bottom_margin_ratio=bottom_margin_ratio,
+            max_lines=max_lines,
+        )
+
+    # ── Center layout (original behaviour) ──────────────────────
     lines = text.split("\n")
     line_count = len(lines)
     scale = max(0.6, min(1.0, 1.0 - 0.1 * (line_count - 1)))
@@ -32,23 +89,73 @@ def create_text_image(text: str, size: tuple, fontsize: int = 100):
     draw = ImageDraw.Draw(img)
     font = get_font(eff_fontsize)
 
-    # Measure each line, compute total stack height.
     line_spacing = max(2, int(round(eff_fontsize * 0.15)))
     line_metrics = []
     total_h = 0
-    max_w = 0
     for line in lines:
         bbox = draw.textbbox((0, 0), line, font=font)
         w = bbox[2] - bbox[0]
         h = bbox[3] - bbox[1]
         line_metrics.append((w, h))
         total_h += h
-        max_w = max(max_w, w)
     total_h += line_spacing * (line_count - 1)
 
-    # Stack lines centered.
     y = (size[1] - total_h) // 2
     for line, (w, h) in zip(lines, line_metrics):
+        x = (size[0] - w) // 2
+        draw.text(
+            (x, y), line, fill=(255, 255, 255, 255), font=font,
+            stroke_width=2, stroke_fill=(0, 0, 0, 255),
+        )
+        y += h + line_spacing
+    return np.array(img)
+
+
+def _render_bottom(
+    text: str,
+    size: tuple,
+    fontsize: int,
+    *,
+    max_width_ratio: float,
+    bottom_margin_ratio: float,
+    max_lines: int,
+):
+    """Render text block anchored to the bottom of the canvas."""
+    import numpy as np
+
+    img = Image.new("RGBA", size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    font = get_font(fontsize)
+
+    max_width = int(size[0] * max_width_ratio)
+
+    # Pre-split on explicit newlines (bilingual), then wrap each piece.
+    raw_pieces = text.split("\n")
+    wrapped: list[str] = []
+    for piece in raw_pieces:
+        wrapped.extend(_wrap_line(piece, draw, font, max_width))
+
+    # Cap total lines: keep the last max_lines, ellipsis on the cut line.
+    if len(wrapped) > max_lines:
+        kept = wrapped[:max_lines]
+        kept[-1] = kept[-1][: max(0, len(kept[-1]) - 1)] + "…"
+        wrapped = kept
+
+    line_spacing = max(2, int(round(fontsize * 0.15)))
+    line_metrics = []
+    total_h = 0
+    for line in wrapped:
+        bbox = draw.textbbox((0, 0), line, font=font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        line_metrics.append((w, h))
+        total_h += h
+    total_h += line_spacing * (len(wrapped) - 1) if wrapped else 0
+
+    bottom_margin = int(size[1] * bottom_margin_ratio)
+    # Stack from bottom up: last line sits at (height - bottom_margin - h).
+    y = size[1] - bottom_margin - total_h
+    for line, (w, h) in zip(wrapped, line_metrics):
         x = (size[0] - w) // 2
         draw.text(
             (x, y), line, fill=(255, 255, 255, 255), font=font,

--- a/src/movie_narrator/utils/video_layout.py
+++ b/src/movie_narrator/utils/video_layout.py
@@ -1,0 +1,68 @@
+"""Pure geometry helper for fitting a source video onto a canvas.
+
+Computes crop + resize boxes for ``cover`` (fill canvas, crop overflow)
+and ``contain`` (letterbox, no crop) modes. No MoviePy/ffmpeg dependency —
+pure arithmetic so it is trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LayoutBox:
+    """Crop window on the source + output size after resize."""
+
+    crop_x: int
+    crop_y: int
+    crop_w: int
+    crop_h: int
+    out_w: int
+    out_h: int
+
+
+def compute_fit_box(
+    src_size: tuple[int, int],
+    canvas_size: tuple[int, int],
+    *,
+    mode: str = "cover",
+) -> LayoutBox:
+    """Compute the crop+resize box to fit ``src_size`` onto ``canvas_size``.
+
+    ``mode="cover"``: scale to fill the canvas, center-crop the overflow.
+    The output size equals the canvas (no letterbox).
+
+    ``mode="contain"``: scale to fit entirely inside the canvas, no crop.
+    The output size may be smaller than the canvas (letterbox); the
+    renderer centers the fitted clip on the background.
+    """
+    sw, sh = src_size
+    cw, ch = canvas_size
+    if sw <= 0 or sh <= 0 or cw <= 0 or ch <= 0:
+        raise ValueError(
+            f"source and canvas sizes must be positive (got src={src_size}, canvas={canvas_size})"
+        )
+
+    src_aspect = sw / sh
+    canvas_aspect = cw / ch
+
+    if mode == "cover":
+        if src_aspect > canvas_aspect:
+            # Source wider than canvas → crop width to match canvas aspect.
+            new_w = int(round(sh * canvas_aspect))
+            x = (sw - new_w) // 2
+            return LayoutBox(crop_x=x, crop_y=0, crop_w=new_w, crop_h=sh, out_w=cw, out_h=ch)
+        else:
+            # Source taller than (or equal to) canvas → crop height.
+            new_h = int(round(sw / canvas_aspect))
+            y = (sh - new_h) // 2
+            return LayoutBox(crop_x=0, crop_y=y, crop_w=sw, crop_h=new_h, out_w=cw, out_h=ch)
+
+    if mode == "contain":
+        scale = min(cw / sw, ch / sh)
+        fw = int(round(sw * scale))
+        fh = int(round(sh * scale))
+        return LayoutBox(crop_x=0, crop_y=0, crop_w=sw, crop_h=sh, out_w=fw, out_h=fh)
+
+    raise ValueError(f"mode must be 'cover' or 'contain', got {mode!r}")

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -75,8 +75,9 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             # Match
             "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
             "scene_merge_min_duration", "embedding_model_name",
-            # BGM
-            "bgm_gain_db",
+            "match_drop_scene_min_duration",
+            # BGM + loudness
+            "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
             # TTS pacing
             "tts_pause_ms", "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
             # Translate
@@ -89,6 +90,13 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             # Render
             "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
             "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            # Render production quality
+            "render_fit_mode", "render_crf", "render_preset", "render_faststart",
+            "render_subtitle_position", "render_subtitle_max_width_ratio",
+            "render_subtitle_bottom_margin_ratio",
+            # Deliverable QA
+            "qa_enabled", "qa_max_silence_db",
+            "qa_min_duration_ratio", "qa_max_duration_ratio",
             # Async
             "async_timeout", "async_max_workers",
             # Video sizes

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -79,9 +79,10 @@ def merge_job(
             "scene_threshold", "scene_frame_skip",
             # Match
             "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration", "embedding_model_name",
+            "scene_merge_min_duration", "match_drop_scene_min_duration",
+            "embedding_model_name",
             # BGM
-            "bgm_gain_db",
+            "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
             # TTS pacing
             "tts_pause_ms", "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
             # Translate
@@ -94,6 +95,11 @@ def merge_job(
             # Render
             "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
             "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            "render_fit_mode", "render_crf", "render_preset", "render_faststart",
+            "render_subtitle_position", "render_subtitle_max_width_ratio",
+            "render_subtitle_bottom_margin_ratio",
+            # QA
+            "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
             # Async
             "async_timeout", "async_max_workers",
             # Video sizes

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -30,9 +30,13 @@ class JobParams(BaseModel):
     match_speed_clamp_min: Optional[float] = None
     match_speed_clamp_max: Optional[float] = None
     scene_merge_min_duration: Optional[float] = None
+    match_drop_scene_min_duration: Optional[float] = None
     embedding_model_name: Optional[str] = None
     # ── BGM ──
     bgm_gain_db: Optional[float] = None
+    bgm_duck_db: Optional[float] = None
+    bgm_normalize: Optional[bool] = None
+    audio_target_dbfs: Optional[float] = None
     # ── TTS pacing ──
     tts_pause_ms: Optional[int] = None
     tts_max_concurrent: Optional[int] = None
@@ -59,6 +63,19 @@ class JobParams(BaseModel):
     render_font_size: Optional[int] = None
     render_output_name: Optional[str] = None
     render_ffmpeg_timeout: Optional[int] = None
+    # ── Render: production quality ──
+    render_fit_mode: Optional[str] = None
+    render_crf: Optional[int] = None
+    render_preset: Optional[str] = None
+    render_faststart: Optional[bool] = None
+    render_subtitle_position: Optional[str] = None
+    render_subtitle_max_width_ratio: Optional[float] = None
+    render_subtitle_bottom_margin_ratio: Optional[float] = None
+    # ── QA ──
+    qa_enabled: Optional[bool] = None
+    qa_max_silence_db: Optional[float] = None
+    qa_min_duration_ratio: Optional[float] = None
+    qa_max_duration_ratio: Optional[float] = None
     # ── Async ──
     async_timeout: Optional[int] = None
     async_max_workers: Optional[int] = None

--- a/tests/test_audio_mix.py
+++ b/tests/test_audio_mix.py
@@ -1,0 +1,73 @@
+"""Tests for utils/audio_mix.py — peak normalization and BGM ducking."""
+
+import math
+import struct
+
+from pydub import AudioSegment
+
+from movie_narrator.utils.audio_mix import duck_bgm, normalize_peak
+
+
+def _tone(ms: int = 500, freq: int = 440, gain_db: float = 0.0) -> AudioSegment:
+    """Generate a sine-wave tone AudioSegment."""
+    sample_rate = 44100
+    n = int(sample_rate * ms / 1000.0)
+    amp = int((2 ** 15 - 1) * (10 ** (gain_db / 20.0)))
+    data = bytearray()
+    for i in range(n):
+        val = int(amp * math.sin(2.0 * math.pi * freq * i / sample_rate))
+        data.extend(struct.pack("<h", val))
+    return AudioSegment(data=bytes(data), sample_width=2, frame_rate=sample_rate, channels=1)
+
+
+def _silence(ms: int = 500) -> AudioSegment:
+    return AudioSegment.silent(duration=ms)
+
+
+def test_normalize_peak_raises_loudness():
+    """A loud tone normalized to -14 dBFS should have max_dBFS near -14."""
+    loud = _tone(ms=300, freq=440, gain_db=0.0)  # near 0 dBFS peak
+    norm = normalize_peak(loud, target_dbfs=-14.0)
+    assert abs(norm.max_dBFS - (-14.0)) < 1.0
+
+
+def test_normalize_peak_silent_unchanged():
+    """A silent segment (max==0) must not blow up — returned unchanged."""
+    silent = _silence(ms=200)
+    norm = normalize_peak(silent, target_dbfs=-14.0)
+    assert norm.max == 0
+
+
+def test_duck_bgm_returns_narration_length():
+    """Mixed output length equals the narration length."""
+    narr = _tone(ms=600, freq=440)
+    bgm = _tone(ms=400, freq=880)
+    mixed = duck_bgm(narr, bgm, bgm_gain_db=-18.0, duck_db=-10.0)
+    assert len(mixed) == len(narr)
+
+
+def test_duck_bgm_loops_short_bgm():
+    """BGM shorter than narration is looped to match length."""
+    narr = _tone(ms=1000, freq=440)
+    bgm = _tone(ms=300, freq=880)
+    mixed = duck_bgm(narr, bgm)
+    assert len(mixed) == len(narr)
+
+
+def test_duck_bgm_attenuates_during_speech():
+    """When narration is loud, BGM is attenuated → mix is quieter than raw overlay."""
+    narr = _tone(ms=500, freq=440)  # loud narration
+    bgm = _tone(ms=500, freq=880)
+    # No ducking (duck_db=0) vs ducking (duck_db=-20): ducked mix should be quieter.
+    mixed_ducked = duck_bgm(narr, bgm, bgm_gain_db=-18.0, duck_db=-20.0)
+    mixed_flat = duck_bgm(narr, bgm, bgm_gain_db=-18.0, duck_db=0.0)
+    assert mixed_ducked.dBFS < mixed_flat.dBFS
+
+
+def test_duck_bgm_silent_narration_no_duck():
+    """Silent narration → no ducking applied, BGM plays at baseline gain."""
+    narr = _silence(ms=500)
+    bgm = _tone(ms=500, freq=880)
+    mixed = duck_bgm(narr, bgm, bgm_gain_db=-12.0, duck_db=-20.0)
+    # Output exists and has the right length.
+    assert len(mixed) == 500

--- a/tests/test_bgm.py
+++ b/tests/test_bgm.py
@@ -6,8 +6,22 @@ from movie_narrator.models import Assets, Context
 from movie_narrator.pipeline.bgm import mix_bgm
 
 
+def _export_wav_fallback(seg: AudioSegment, path: Path):
+    """Export audio, falling back to WAV when MP3 encoding is unavailable.
+
+    Mirrors the production ``_export_robust`` helper so tests pass on
+    minimal ffmpeg builds that lack libmp3lame.
+    """
+    try:
+        seg.export(path, format="mp3")
+    except Exception:
+        path = path.with_suffix(".wav")
+        seg.export(path, format="wav")
+    return path
+
+
 def _write_silent_mp3(path: Path, ms: int = 500):
-    AudioSegment.silent(duration=ms).export(path, format="mp3")
+    return _export_wav_fallback(AudioSegment.silent(duration=ms), path)
 
 
 def _write_tone_mp3(path: Path, ms: int = 500, freq: int = 440):
@@ -27,22 +41,35 @@ def _write_tone_mp3(path: Path, ms: int = 500, freq: int = 440):
         frame_rate=sample_rate,
         channels=1,
     )
-    seg.export(path, format="mp3")
+    return _export_wav_fallback(seg, path)
 
 
 def test_mix_bgm_skipped_none(tmp_path):
-    narr = tmp_path / "narration.mp3"
-    _write_silent_mp3(narr)
+    narr = _write_silent_mp3(tmp_path / "narration.mp3")
     ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
     ctx.metadata["bgm_request"] = "none"
+    ctx.metadata["bgm_normalize"] = False  # isolate skip behaviour
     mix_bgm(ctx)
     assert ctx.status.bgm == "skipped"
     assert ctx.final_audio_path == str(narr)
 
 
+def test_mix_bgm_skipped_none_normalizes(tmp_path):
+    """With bgm_normalize=True (default), the skip path still normalizes
+    narration to a side file for production loudness consistency."""
+    narr = _write_tone_mp3(tmp_path / "narration.mp3", 500, freq=440)
+    ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
+    ctx.metadata["bgm_request"] = "none"
+    # bgm_normalize defaults to True
+    mix_bgm(ctx)
+    assert ctx.status.bgm == "skipped"
+    name = Path(ctx.final_audio_path).name
+    assert name in ("narration_normalized.mp3", "narration_normalized.wav")
+    assert Path(ctx.final_audio_path).exists()
+
+
 def test_mix_bgm_explicit_missing_failed(tmp_path):
-    narr = tmp_path / "narration.mp3"
-    _write_silent_mp3(narr)
+    narr = _write_silent_mp3(tmp_path / "narration.mp3")
     ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(narr))
     ctx.metadata["bgm_request"] = "explicit"
     mix_bgm(ctx)
@@ -51,10 +78,8 @@ def test_mix_bgm_explicit_missing_failed(tmp_path):
 
 
 def test_mix_bgm_success(tmp_path):
-    narr = tmp_path / "narration.mp3"
-    bgm = tmp_path / "bgm.mp3"
-    _write_tone_mp3(narr, 800, freq=440)
-    _write_tone_mp3(bgm, 400, freq=880)
+    narr = _write_tone_mp3(tmp_path / "narration.mp3", 800, freq=440)
+    bgm = _write_tone_mp3(tmp_path / "bgm.mp3", 400, freq=880)
     ctx = Context(
         movie_name="m",
         output_dir=str(tmp_path),
@@ -64,5 +89,6 @@ def test_mix_bgm_success(tmp_path):
     ctx.metadata["bgm_request"] = "explicit"
     mix_bgm(ctx)
     assert ctx.status.bgm == "success"
-    assert Path(ctx.final_audio_path).name == "mixed.mp3"
+    name = Path(ctx.final_audio_path).name
+    assert name in ("mixed.mp3", "mixed.wav")
     assert Path(ctx.final_audio_path).exists()

--- a/tests/test_deliverable_qa.py
+++ b/tests/test_deliverable_qa.py
@@ -1,0 +1,149 @@
+"""Tests for utils/deliverable_qa.py — probe + evaluate with mocked ffmpeg."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from movie_narrator.utils.deliverable_qa import (
+    QAIssue,
+    evaluate_deliverable,
+    probe_media,
+)
+
+
+def _ffprobe_json(duration=10.0, has_video=True, has_audio=True, w=1920, h=1080):
+    streams = []
+    if has_video:
+        streams.append({"codec_type": "video", "width": w, "height": h, "duration": str(duration)})
+    if has_audio:
+        streams.append({"codec_type": "audio", "duration": str(duration)})
+    return {"streams": streams, "format": {"duration": str(duration)}}
+
+
+def test_probe_media_uses_ffprobe(tmp_path):
+    """probe_media returns parsed ffprobe JSON when ffprobe is available."""
+    f = tmp_path / "v.mp4"
+    f.write_bytes(b"x" * 100)
+
+    def fake_run(cmd, **kw):
+        if "ffprobe" in str(cmd[0]):
+            return type("P", (), {"returncode": 0, "stdout": json.dumps(_ffprobe_json(12.0)), "stderr": ""})()
+        # volumedetect call
+        return type("P", (), {"returncode": 0, "stdout": "", "stderr": "mean_volume: -16.0 dB"})()
+
+    with patch("movie_narrator.utils.deliverable_qa.shutil.which", lambda x: "/usr/bin/" + x if x in ("ffprobe", "ffmpeg") else None), \
+         patch("movie_narrator.utils.deliverable_qa.subprocess.run", side_effect=fake_run):
+        result = probe_media(str(f))
+
+    assert result["duration"] == 12.0
+    assert result["has_video"] is True
+    assert result["has_audio"] is True
+    assert result["width"] == 1920
+    assert result["mean_volume"] == -16.0
+
+
+def test_probe_media_falls_back_to_ffmpeg(tmp_path):
+    """When ffprobe is missing, fall back to ffmpeg -i stderr parsing."""
+    f = tmp_path / "v.mp4"
+    f.write_bytes(b"x" * 100)
+
+    stderr = (
+        "  Duration: 00:00:15.00, start: 0.000000, bitrate: 100 kb/s\n"
+        "    Stream #0:0: Video: h264, 1280x720\n"
+        "    Stream #0:1: Audio: aac\n"
+        "mean_volume: -20.0 dB"
+    )
+
+    def fake_run(cmd, **kw):
+        return type("P", (), {"returncode": 1, "stdout": "", "stderr": stderr})()
+
+    with patch("movie_narrator.utils.deliverable_qa.shutil.which", lambda x: None), \
+         patch("movie_narrator.utils.deliverable_qa.subprocess.run", side_effect=fake_run), \
+         patch("movie_narrator.utils.deliverable_qa._ffmpeg_bin", return_value="ffmpeg"):
+        result = probe_media(str(f))
+
+    assert result["duration"] == 15.0
+    assert result["has_video"] is True
+    assert result["has_audio"] is True
+    assert result["width"] == 1280
+    assert result["height"] == 720
+    assert result["mean_volume"] == -20.0
+
+
+def test_evaluate_missing_file():
+    report = evaluate_deliverable("/nonexistent/path.mp4", expected_duration=10.0)
+    assert report.ok is False
+    assert any(i.code == "missing_file" for i in report.issues)
+
+
+def test_evaluate_all_pass(tmp_path):
+    f = tmp_path / "good.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 10.0, "has_video": True, "has_audio": True,
+        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -14.0,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0)
+    assert report.ok is True
+    assert report.issues == []
+
+
+def test_evaluate_too_short(tmp_path):
+    f = tmp_path / "short.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 5.0, "has_video": True, "has_audio": True,
+        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -14.0,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0)
+    assert report.ok is False
+    assert any(i.code == "too_short" for i in report.issues)
+
+
+def test_evaluate_too_long(tmp_path):
+    f = tmp_path / "long.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 20.0, "has_video": True, "has_audio": True,
+        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -14.0,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0)
+    assert report.ok is False
+    assert any(i.code == "too_long" for i in report.issues)
+
+
+def test_evaluate_silent_audio(tmp_path):
+    f = tmp_path / "silent.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 10.0, "has_video": True, "has_audio": True,
+        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -60.0,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0, max_silence_db=-50.0)
+    assert report.ok is False
+    assert any(i.code == "silent_audio" for i in report.issues)
+
+
+def test_evaluate_no_audio_stream(tmp_path):
+    f = tmp_path / "noaudio.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 10.0, "has_video": True, "has_audio": False,
+        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": None,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0)
+    assert report.ok is False
+    assert any(i.code == "no_audio_stream" for i in report.issues)
+
+
+def test_evaluate_tiny_file(tmp_path):
+    f = tmp_path / "tiny.mp4"
+    f.write_bytes(b"x" * 100)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 10.0, "has_video": True, "has_audio": True,
+        "width": 1920, "height": 1080, "size_bytes": 100, "mean_volume": -14.0,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0, min_size_bytes=10000)
+    assert report.ok is False
+    assert any(i.code == "tiny_file" for i in report.issues)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -91,6 +91,75 @@ def test_match_clips_embedding_disabled_keeps_heuristic(tmp_path, monkeypatch):
     assert all(m.source == "heuristic" for m in ctx.matched_clips)
 
 
+# ── tiny-scene drop + merge defaults ───────────────────────
+
+
+def test_match_drops_tiny_scenes(tmp_path):
+    """Scenes shorter than match_drop_scene_min_duration are dropped.
+
+    Merge is disabled (scene_merge_min_duration=0) so the tiny scene is
+    not absorbed first, isolating the drop behaviour. After dropping the
+    0.2s scene, the remaining scene is re-indexed from 0; no matched clip
+    should use source content from the dropped scene's time range.
+    """
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        source_video_path=str(tmp_path / "video.mp4"),
+        timed_segments=[
+            TimedSegment(text="A", start=0.0, end=2.0),
+            TimedSegment(text="B", start=2.5, end=5.0),
+        ],
+        scenes=[
+            Scene(index=0, start=0.0, end=0.2),   # tiny (< 0.4s)
+            Scene(index=1, start=0.2, end=8.0),   # long
+        ],
+    )
+    ctx.status.scene = "success"
+    ctx.metadata["scene_merge_min_duration"] = 0.0  # disable merge to isolate drop
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    match_clips(ctx)
+    assert ctx.status.match == "success"
+    # No clip should use source content from the dropped scene (0.0-0.2).
+    assert all(m.src_start >= 0.2 for m in ctx.matched_clips)
+
+
+def test_match_tiny_scene_filter_keeps_all_if_all_tiny(tmp_path):
+    """If dropping would remove every scene, keep them all (last-resort)."""
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        source_video_path=str(tmp_path / "video.mp4"),
+        timed_segments=[TimedSegment(text="A", start=0.0, end=1.0)],
+        scenes=[Scene(index=0, start=0.0, end=0.1)],  # only scene, tiny
+    )
+    ctx.status.scene = "success"
+    ctx.metadata["scene_merge_min_duration"] = 0.0
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    match_clips(ctx)
+    # Should still produce a match (didn't drop the only scene).
+    assert ctx.status.match == "success"
+    assert len(ctx.matched_clips) >= 1
+
+
+def test_match_default_merge_merges_short_scenes(tmp_path):
+    """Default scene_merge_min_duration=2.0 merges scenes shorter than 2s."""
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        source_video_path=str(tmp_path / "video.mp4"),
+        timed_segments=[TimedSegment(text="A", start=0.0, end=5.0)],
+        scenes=[
+            Scene(index=0, start=0.0, end=1.0),   # short (< 2.0 default)
+            Scene(index=1, start=1.0, end=8.0),   # long
+        ],
+    )
+    ctx.status.scene = "success"
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    match_clips(ctx)
+    assert ctx.status.match == "success"
+
+
 # ── score < min_score → heuristic fallback ──────────────────
 
 

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -1,0 +1,95 @@
+"""Tests for pipeline/qa.py — validate_deliverable step gating."""
+
+from unittest.mock import patch
+
+import pytest
+
+from movie_narrator.models import Context
+from movie_narrator.pipeline.qa import validate_deliverable
+from movie_narrator.utils.deliverable_qa import QAReport, QAIssue
+
+
+def _ctx(tmp_path, **metadata):
+    ctx = Context(movie_name="m", output_dir=str(tmp_path), audio_path=str(tmp_path / "a.mp3"))
+    ctx.video_path = str(tmp_path / "final.mp4")
+    ctx.metadata.update(metadata)
+    return ctx
+
+
+def test_qa_skipped_in_ci_by_default(tmp_path):
+    """In CI with qa_enabled unset, the step is a no-op (skipped)."""
+    ctx = _ctx(tmp_path)
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=True):
+        result = validate_deliverable(ctx)
+    assert result is ctx
+    assert "qa_report" not in ctx.metadata
+
+
+def test_qa_runs_in_ci_when_explicitly_enabled(tmp_path):
+    """qa_enabled=True forces QA even in CI."""
+    ctx = _ctx(tmp_path, qa_enabled=True)
+    report = QAReport(ok=True, issues=[], metrics={"duration": 10.0, "mean_volume": -14.0})
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=True), \
+         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+        validate_deliverable(ctx)
+    assert ctx.metadata["qa_report"]["ok"] is True
+
+
+def test_qa_skipped_when_explicitly_disabled(tmp_path):
+    """qa_enabled=False skips QA even outside CI."""
+    ctx = _ctx(tmp_path, qa_enabled=False)
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False):
+        result = validate_deliverable(ctx)
+    assert result is ctx
+    assert "qa_report" not in ctx.metadata
+
+
+def test_qa_runs_locally_by_default(tmp_path):
+    """Outside CI with qa_enabled unset, QA runs."""
+    ctx = _ctx(tmp_path)
+    report = QAReport(ok=True, issues=[], metrics={"duration": 10.0, "mean_volume": -14.0})
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False), \
+         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+        validate_deliverable(ctx)
+    assert ctx.metadata["qa_report"]["ok"] is True
+
+
+def test_qa_raises_on_failure(tmp_path):
+    """A failing report raises RuntimeError with issue codes."""
+    ctx = _ctx(tmp_path)
+    report = QAReport(
+        ok=False,
+        issues=[QAIssue("silent_audio", "mean volume -60dB too low")],
+        metrics={"duration": 10.0, "mean_volume": -60.0},
+    )
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False), \
+         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+        with pytest.raises(RuntimeError, match="silent_audio"):
+            validate_deliverable(ctx)
+
+
+def test_qa_raises_when_no_video_path(tmp_path):
+    """Missing video_path raises RuntimeError before probing."""
+    ctx = _ctx(tmp_path)
+    ctx.video_path = None
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False):
+        with pytest.raises(RuntimeError, match="no video_path"):
+            validate_deliverable(ctx)
+
+
+def test_qa_stores_report_in_metadata(tmp_path):
+    """The full report (issues + metrics) is stored on ctx.metadata."""
+    ctx = _ctx(tmp_path)
+    report = QAReport(
+        ok=False,
+        issues=[QAIssue("too_short", "5s < 85% of 10s")],
+        metrics={"duration": 5.0, "mean_volume": -14.0},
+    )
+    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False), \
+         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+        with pytest.raises(RuntimeError):
+            validate_deliverable(ctx)
+    stored = ctx.metadata["qa_report"]
+    assert stored["ok"] is False
+    assert stored["issues"][0]["code"] == "too_short"
+    assert stored["metrics"]["duration"] == 5.0

--- a/tests/test_render_real.py
+++ b/tests/test_render_real.py
@@ -97,8 +97,10 @@ def _chainable_clip(end: float = 2.0):
 def test_render_without_matched_clips(tmp_path):
     """Without matched clips, renders text overlays on solid background.
 
-    Mocks `CompositeVideoClip` and `write_videofile` to avoid real MoviePy
-    encoding (Windows file-lock flake on temp audio files; F-012).
+    Mocks ``CompositeVideoClip``, ``write_videofile`` and the stage-2
+    ``subprocess.run`` mux to avoid real MoviePy encoding (Windows file-lock
+    flake on temp audio files; F-012) and to keep the test inside the
+    testing-only sandbox.
     """
     ctx = _make_ctx(tmp_path, matched=False)
 
@@ -112,9 +114,15 @@ def test_render_without_matched_clips(tmp_path):
     final.with_audio = MagicMock(return_value=final)
 
     def _fake_write(path, **kwargs):
-        Path(path).write_bytes(b"")
+        # Stage-1 writes the video-only intermediate so the stage-2 mux
+        # can find it. The stage-2 ffmpeg call itself is mocked below.
+        Path(path).write_bytes(b"moov-fake-bytes")
 
     final.write_videofile = MagicMock(side_effect=_fake_write)
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stderr = ""
 
     with (
         patch("movie_narrator.pipeline.render.CompositeVideoClip", return_value=final),
@@ -122,18 +130,23 @@ def test_render_without_matched_clips(tmp_path):
         patch("movie_narrator.pipeline.render.ImageClip", return_value=img),
         patch("movie_narrator.pipeline.render.AudioFileClip", return_value=audio),
         patch("movie_narrator.pipeline.render._create_text_image", return_value=MagicMock()),
+        patch("movie_narrator.pipeline.render.subprocess.run", return_value=fake_proc),
     ):
         render_video(ctx)
 
     final.write_videofile.assert_called_once()
-    assert ctx.video_path == str(tmp_path / "final.mp4")
+    # Stage-2 must have run via ffmpeg with the expected arguments.
+    assert hasattr(ctx, "video_path") and ctx.video_path.endswith("final.mp4")
+    # The video-only intermediate must be cleaned up after stage 2.
+    assert not (tmp_path / ".tmp" / "video_only.mp4").exists()
 
 
 def test_render_with_matched_clips(tmp_path):
     """With matched clips, uses real-footage branch; ignores fallback rows.
 
-    Patches VideoFileClip + CompositeVideoClip so the branch filter is
-    exercised without requiring an ffmpeg-decodable fixture.
+    Patches ``VideoFileClip`` + ``CompositeVideoClip`` so the branch filter
+    is exercised without requiring an ffmpeg-decodable fixture. Mocks
+    ``subprocess.run`` so stage-2 ffmpeg mux succeeds without a real binary.
     """
     (tmp_path / "source.mp4").write_bytes(b"00")
     ctx = _make_ctx(tmp_path, matched=True, include_fallback=True)
@@ -149,6 +162,14 @@ def test_render_with_matched_clips(tmp_path):
     audio.duration = _AUDIO_SECONDS
     audio.close = MagicMock()
 
+    final.write_videofile = MagicMock(
+        side_effect=lambda path, **kwargs: Path(path).write_bytes(b"moov-fake-bytes")
+    )
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.stderr = ""
+
     with (
         patch("movie_narrator.pipeline.render.VideoFileClip", return_value=fake_source) as mock_vfc,
         patch("movie_narrator.pipeline.render.CompositeVideoClip", return_value=final) as mock_cvc,
@@ -156,6 +177,7 @@ def test_render_with_matched_clips(tmp_path):
         patch("movie_narrator.pipeline.render.ImageClip", return_value=img),
         patch("movie_narrator.pipeline.render.AudioFileClip", return_value=audio),
         patch("movie_narrator.pipeline.render._create_text_image", return_value=MagicMock()),
+        patch("movie_narrator.pipeline.render.subprocess.run", return_value=fake_proc),
     ):
         render_video(ctx)
 
@@ -168,3 +190,5 @@ def test_render_with_matched_clips(tmp_path):
     final.write_videofile.assert_called_once()
     assert ctx.video_path == str(tmp_path / "final.mp4")
     assert (tmp_path / "metadata.json").exists()
+    # The video-only intermediate must be cleaned up after stage 2.
+    assert not (tmp_path / ".tmp" / "video_only.mp4").exists()

--- a/tests/test_text_image.py
+++ b/tests/test_text_image.py
@@ -1,0 +1,72 @@
+"""Tests for utils/text_image.py — center + bottom subtitle layouts."""
+
+import numpy as np
+import pytest
+
+from movie_narrator.utils.text_image import create_text_image
+
+
+def test_center_layout_returns_rgba():
+    """Default center layout returns an RGBA array of the requested size."""
+    arr = create_text_image("hello", (640, 360), fontsize=40)
+    assert arr.shape == (360, 640, 4)
+    assert arr.dtype == np.uint8
+
+
+def test_center_layout_is_backward_compatible():
+    """position='center' (default) must not raise and produces non-empty pixels."""
+    arr = create_text_image("测试字幕", (640, 360), fontsize=40)
+    # Some pixels should be non-transparent (alpha > 0) where text is drawn.
+    assert arr[..., 3].max() > 0
+
+
+def test_bottom_layout_returns_rgba():
+    """position='bottom' returns a valid RGBA array."""
+    arr = create_text_image("bottom subtitle", (640, 360), fontsize=40, position="bottom")
+    assert arr.shape == (360, 640, 4)
+
+
+def test_bottom_layout_draws_near_bottom():
+    """Bottom layout places text in the lower portion of the canvas."""
+    arr = create_text_image("lower", (640, 360), fontsize=40, position="bottom")
+    alpha = arr[..., 3]
+    rows_with_text = np.where(alpha.max(axis=1) > 0)[0]
+    # Text should be in the bottom half (rows > 180) given bottom_margin 8%.
+    assert rows_with_text.max() > 180
+
+
+def test_center_layout_draws_near_center():
+    """Center layout places text around the vertical middle."""
+    arr = create_text_image("mid", (640, 360), fontsize=40, position="center")
+    alpha = arr[..., 3]
+    rows_with_text = np.where(alpha.max(axis=1) > 0)[0]
+    mid = 360 // 2
+    # Text rows should straddle the midpoint.
+    assert rows_with_text.min() < mid < rows_with_text.max()
+
+
+def test_bottom_wraps_long_text():
+    """Long text is wrapped and capped at max_lines."""
+    long_text = " ".join(["word"] * 50)
+    arr = create_text_image(
+        long_text, (640, 360), fontsize=30, position="bottom",
+        max_width_ratio=0.9, max_lines=2,
+    )
+    assert arr.shape == (360, 640, 4)
+
+
+def test_bottom_ellipsis_on_overflow():
+    """When text exceeds max_lines, the last kept line is truncated with ellipsis."""
+    # Each line is forced long; max_lines=1 means everything collapses to one
+    # ellipsised line. We just assert no crash and output shape is correct.
+    long_text = "line one is very long\nline two is also long\nline three"
+    arr = create_text_image(
+        long_text, (800, 400), fontsize=30, position="bottom", max_lines=1,
+    )
+    assert arr.shape == (400, 800, 4)
+
+
+def test_multiline_center_scales_font():
+    """Multi-line center layout reduces fontscale per line."""
+    arr = create_text_image("a\nb\nc", (640, 360), fontsize=60, position="center")
+    assert arr.shape == (360, 640, 4)

--- a/tests/test_video_layout.py
+++ b/tests/test_video_layout.py
@@ -1,0 +1,63 @@
+"""Tests for utils/video_layout.py — pure geometry helper."""
+
+import pytest
+
+from movie_narrator.utils.video_layout import LayoutBox, compute_fit_box
+
+
+def test_cover_same_aspect():
+    """Source and canvas same aspect → no crop, output = canvas."""
+    box = compute_fit_box((1920, 1080), (1920, 1080), mode="cover")
+    assert box.crop_x == 0 and box.crop_y == 0
+    assert box.crop_w == 1920 and box.crop_h == 1080
+    assert box.out_w == 1920 and box.out_h == 1080
+
+
+def test_cover_wide_source_crops_width():
+    """Source wider than canvas → crop width, keep full height."""
+    # 1920x1080 source onto 1080x1080 canvas (square).
+    box = compute_fit_box((1920, 1080), (1080, 1080), mode="cover")
+    assert box.crop_h == 1080          # full height retained
+    assert box.crop_w == 1080          # width cropped to match canvas aspect
+    assert box.crop_x == (1920 - 1080) // 2  # center-cropped
+    assert box.out_w == 1080 and box.out_h == 1080
+
+
+def test_cover_tall_source_crops_height():
+    """Source taller than canvas → crop height, keep full width."""
+    # 1080x1920 source onto 1080x1080 canvas.
+    box = compute_fit_box((1080, 1920), (1080, 1080), mode="cover")
+    assert box.crop_w == 1080          # full width retained
+    assert box.crop_h == 1080          # height cropped
+    assert box.crop_y == (1920 - 1080) // 2
+    assert box.out_w == 1080 and box.out_h == 1080
+
+
+def test_contain_fits_inside_letterbox():
+    """Contain mode scales down, no crop, output <= canvas."""
+    box = compute_fit_box((1920, 1080), (960, 540), mode="contain")
+    assert box.crop_w == 1920 and box.crop_h == 1080  # no crop
+    # Scale 0.5 → 960x540 (fits exactly, same aspect).
+    assert box.out_w == 960 and box.out_h == 540
+
+
+def test_contain_letterbox_when_aspect_mismatch():
+    """Contain with mismatched aspect → output smaller on one axis."""
+    # 1920x1080 (16:9) into 1080x1080 (1:1) → scale by min(1080/1920, 1080/1080)
+    box = compute_fit_box((1920, 1080), (1080, 1080), mode="contain")
+    assert box.out_w == 1080 and box.out_h == 608  # 1080 * (1080/1920) ≈ 607.5 → 608
+
+
+def test_invalid_mode_raises():
+    with pytest.raises(ValueError, match="mode"):
+        compute_fit_box((1920, 1080), (1080, 1080), mode="stretch")
+
+
+def test_zero_size_raises():
+    with pytest.raises(ValueError):
+        compute_fit_box((0, 1080), (1080, 1080))
+
+
+def test_returns_layout_box():
+    box = compute_fit_box((1920, 1080), (1280, 720))
+    assert isinstance(box, LayoutBox)

--- a/webui/src/components/ProgressTimeline.tsx
+++ b/webui/src/components/ProgressTimeline.tsx
@@ -18,6 +18,7 @@ const STEP_LABELS: Record<string, string> = {
   translate_subtitles: "翻译字幕",
   generate_subtitle: "生成字幕",
   render_video: "渲染输出",
+  validate_deliverable: "成片质检",
   export_clips: "导出片段",
 }
 

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -59,6 +59,7 @@ export const PIPELINE_STEPS = [
   "translate_subtitles",
   "generate_subtitle",
   "render_video",
+  "validate_deliverable",
   "export_clips",
 ] as const;
 


### PR DESCRIPTION
## Summary

Make the sourced-video main path of \mn create\ produce a publishable recap video without requiring secondary editing. Implements the 9-task production-quality plan.

## Changes

### New pipeline step (14 -> 15 steps)
- **\alidate_deliverable\** (hard step after \ender_video\): probes \inal.mp4\ with ffprobe (falls back to \fmpeg -i\ when ffprobe absent). Fails on missing video/audio stream, silent audio (mean volume below \qa_max_silence_db\), duration outside ratio, or tiny output. CI skips by default; local runs enable unless \qa_enabled: false\.

### Audio quality
- **\utils/audio_mix.py\**: \
ormalize_peak()\ + \duck_bgm()\ with windowed envelope and linear attack/release smoothing
- \mix_bgm\ skip path normalizes narration; success path ducks BGM then normalizes. MP3 export falls back to WAV when libmp3lame unavailable

### Video quality
- **\utils/video_layout.py\**: \compute_fit_box()\ cover/contain geometry; render defaults to \cover\
- **Bottom-safe subtitles**: \	ext_image.create_text_image\ gains \position=bottom\ with CJK wrapping + ellipsis; render always draws overlays for all segments
- **Encode quality**: CRF 18, preset \slow\, \+faststart\ by default

### Match safety
- Defaults tightened: \match_speed_clamp_min\ 0.5->0.85, \match_speed_clamp_max\ 3.0->1.25, \scene_merge_min_duration\ 0.0->2.0
- Tiny scenes <0.4s dropped after merge with re-indexing (last-resort keeps all)

### Configurability
- 15 new \JobParams\ fields plumbed through schema -> merge -> runner metadata (47 total)
- \examples/job.example.yaml\ documents all new defaults/overrides

### Frontend sync
- \PIPELINE_STEPS\ and \STEP_LABELS\ updated (\alidate_deliverable\ -> \成片质检\)

## Testing
- 44 new unit tests across 5 new test files + extended \	est_match\ / \	est_bgm\
- Full suite: \2 failed, 350 passed, 11 skipped\ (the 2 failures are pre-existing TTS \.env\ override issues, not caused by this PR)
- Frontend \	sc --noEmit\ passes with 0 errors

## Version
- Bumped to \