### PR TITLE
release: v0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.14] - 2026-07-17
+
+### Added (Publishable bottom subtitle)
+- **Backdrop bar + thicker stroke**: bottom-subtitle layout (`_render_bottom` in `text_image.py`) now draws a semi-transparent black backdrop bar (65% alpha, 16px horizontal / 12px vertical padding, clamped inside frame) behind the text block, plus a 4px black stroke (was 2px) around white fill — matches the standardized recap style consumed by short-video platforms and stays legible on bright footage.
+- Two new unit tests: `test_bottom_layout_has_semi_transparent_backdrop_bar` (verifies dark pixel band spans ≥50% width in bottom ~22% of canvas) and `test_bottom_layout_full_canvas_outside_textband_is_transparent` (verifies alpha=0 outside subtitle band so source footage is preserved).
+
+### Fixed
+- **Empty wrapped list edge case**: `_render_bottom` now returns early when wrapping produces zero lines, instead of computing `line_spacing * (0-1)`.
+- **Line height measurement**: each line's height is re-measured via `textbbox` instead of reusing the first line's metric — more accurate for mixed CJK/Latin text.
+- **Cross-platform test threshold**: backdrop bar width assertion lowered from 60% to 50% to accommodate Linux CI's narrower font metrics (PIL renders text narrower on Linux than Windows).
+
 ## [0.4.13] - 2026-07-17
 
 ### Added (Core engine production quality)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,6 +134,13 @@ The Web UI is rebuilt from a Gradio single-file app into a decoupled **FastAPI +
 - [x] 15 new `JobParams` fields plumbed (render fit/encode/subtitle, BGM duck/normalize, QA, match drop)
 - [x] Pipeline 14 → 15 steps; frontend `PIPELINE_STEPS` / `STEP_LABELS` synced
 
+### v0.4.14 Publishable Bottom Subtitle
+
+- [x] Semi-transparent black backdrop bar (65% alpha, 16px/12px padding) behind bottom subtitle text — matches short-video recap style
+- [x] Thicker stroke (2px → 4px) for legibility on bright footage
+- [x] Bug fix: empty wrapped list early return; per-line height re-measurement via `textbbox`
+- [x] Cross-platform test threshold (60% → 50%) for Linux CI font metrics
+
 ### v0.4 Environment variables
 
 - `MN_TTS_PROVIDER` — `edge` (default), `openai`, or `mimo`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.4.13"
+version = "0.4.14"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = {text = "AGPL-3.0"}


### PR DESCRIPTION
Version bump 0.4.13 -> 0.4.14 with CHANGELOG and ROADMAP updates. Documents the publishable bottom subtitle improvements (backdrop bar + thicker stroke) from PR #38.