### PR TITLE
feat: narration preset system (Stage 0.5)

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -80,6 +80,10 @@ def create(
     subtitle_mode: Optional[str] = typer.Option(
         None, "--subtitle-mode", help="Overlay mode: original|translated|bilingual",
     ),
+    narration_preset: Optional[str] = typer.Option(
+        None, "--narration-preset", "-p",
+        help="Narration style preset: douyin-fast (default) | mainstream-dry | bilibili-long",
+    ),
 ):
     from .config import get_settings
     from .workflow import JobConfigError, load_job_config, merge_job
@@ -175,6 +179,7 @@ def create(
         config_path=resolved.config_path,
         subtitle_lang=resolved.subtitle_lang,
         subtitle_mode=resolved.subtitle_mode,
+        narration_preset=narration_preset,
     )
     controller = InteractiveCLIController() if retry else None
     try:

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -110,6 +110,7 @@ def build_context(
     subtitle_lang: Optional[str] = None,
     subtitle_mode: Optional[str] = None,
     services: Optional[Services] = None,
+    narration_preset: Optional[str] = None,
 ) -> Context:
     """Assemble a :class:`Context` ready for :func:`run_pipeline`.
 
@@ -173,7 +174,23 @@ def build_context(
 
     if workflow_steps:
         ctx.metadata["workflow_steps"] = dict(workflow_steps)
+
+    # ── Preset merge: preset params are the BASELINE; user params override ──
+    # The preset provides style defaults (match cadence, BGM ducking, subtitle
+    # layout, prompt shaping).  User-supplied params always win, so users can
+    # do e.g. --narration-preset mainstream-dry while still overriding a
+    # single knob via job.yaml params.
+    effective_params: Dict[str, Any] = {}
+    if narration_preset:
+        from ..presets import get_preset
+        preset = get_preset(narration_preset)
+        effective_params.update(preset.param_dict)
+        ctx.metadata["narration_preset"] = narration_preset
+        ctx.metadata["narration_preset_tags"] = dict(preset.tag_dict)
     if params:
+        effective_params.update(params)
+
+    if effective_params:
         for key in (
             "scene_threshold", "scene_frame_skip", "match_min_score",
             "match_speed_clamp_min", "match_speed_clamp_max",
@@ -190,11 +207,12 @@ def build_context(
             "render_subtitle_position", "render_subtitle_max_width_ratio",
             "render_subtitle_bottom_margin_ratio",
             "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
+            "prompt_target_sentences", "prompt_max_chars_per_sentence", "prompt_hook_seconds",
             "async_timeout", "async_max_workers",
             "video_sizes",
         ):
-            if key in params and params[key] is not None:
-                ctx.metadata[key] = params[key]
+            if key in effective_params and effective_params[key] is not None:
+                ctx.metadata[key] = effective_params[key]
     if config_path:
         ctx.metadata["config_path"] = config_path
 

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -1,6 +1,6 @@
 from ..config import get_settings
 from ..models import Context, ScriptSegment
-from ..utils.prompts import SCRIPT_PROMPT
+from ..utils.prompts import SCRIPT_PROMPT, build_cadence_hint
 from ..utils.llm import get_llm_client
 from ..utils.json_parser import extract_json
 from ..tts.base import is_ci
@@ -26,11 +26,21 @@ def generate_script(ctx: Context) -> Context:
                 if ctx.research and ctx.research.summary:
                     research_block = f"\nResearch context: {ctx.research.summary}\nGenres: {', '.join(ctx.research.genres)}\n"
 
+                # Preset-driven prompt shaping (v0.4.15+).
+                # Falls back to v0.4.14 defaults when no preset is active.
+                tags = ctx.metadata.get("narration_preset_tags", {})
                 prompt = SCRIPT_PROMPT.format(
                     movie=ctx.movie_name,
                     style=ctx.style,
                     duration=ctx.duration,
                     research=research_block,
+                    max_chars=ctx.metadata.get("prompt_max_chars_per_sentence", 15),
+                    target_sentences=ctx.metadata.get("prompt_target_sentences", "15-20"),
+                    hook_seconds=ctx.metadata.get("prompt_hook_seconds", 3),
+                    cadence_hint=build_cadence_hint(
+                        cadence=tags.get("prompt_cadence", ""),
+                        connectors=tags.get("prompt_connectors", ""),
+                    ),
                 )
                 response = llm.client.chat.completions.create(
                     model=llm.model,

--- a/src/movie_narrator/presets/__init__.py
+++ b/src/movie_narrator/presets/__init__.py
@@ -1,0 +1,26 @@
+"""Narration preset system — pluggable style modes.
+
+A preset bundles a set of default parameter values (match cadence, BGM
+ducking, subtitle layout, prompt shaping) that together produce a
+recognisable narration style.  Built-in presets cover three popular
+recap styles; third-party presets can be added later via entry-points.
+
+Usage::
+
+    from movie_narrator.presets import get_preset, BUILTIN_PRESETS
+
+    preset = get_preset("mainstream-dry")
+    params = preset.params()          # dict of JobParams keys
+    prompt_tags = preset.prompt_tags() # dict of prompt shaping labels
+"""
+
+from .base import Preset, PresetParam
+from .registry import get_preset, list_presets, BUILTIN_PRESETS
+
+__all__ = [
+    "Preset",
+    "PresetParam",
+    "get_preset",
+    "list_presets",
+    "BUILTIN_PRESETS",
+]

--- a/src/movie_narrator/presets/base.py
+++ b/src/movie_narrator/presets/base.py
@@ -1,0 +1,113 @@
+"""Preset protocol and data structures.
+
+A :class:`Preset` is a named bundle of parameter defaults and prompt
+shaping tags.  The interface is intentionally minimal so that future
+SPI discover (entry-points / local folder) can wrap any callable that
+returns the right shape.
+
+Prompt tags are a closed vocabulary — the preset may only return keys
+listed in :data:`ALLOWED_PROMPT_TAGS`, and the values must be one of
+the enumerated options.  This prevents prompt-template condition
+branches from exploding.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Protocol, runtime_checkable
+
+# ── Closed prompt-tag vocabulary ────────────────────────────
+# Each key maps to the set of allowed string values.  Presets that
+# return tags outside this vocabulary will be rejected at registration
+# time.
+ALLOWED_PROMPT_TAGS: Dict[str, frozenset[str]] = {
+    "prompt_cadence": frozenset({"measured", "brisk", "languid"}),
+    "prompt_register": frozenset({"spoken", "written", "mixed"}),
+    "prompt_connectors": frozenset({"interjection", "narrative", "none"}),
+}
+
+# ── Param keys that presets are allowed to set ──────────────
+# Must be a subset of JobParams fields (schema.py) / _ALLOWED_PARAMS
+# (load.py) / build_context key tuple (runner.py).  Validated at
+# registration time.
+ALLOWED_PARAM_KEYS: frozenset[str] = frozenset({
+    # Match / scene
+    "match_speed_clamp_min",
+    "match_speed_clamp_max",
+    "scene_merge_min_duration",
+    "match_drop_scene_min_duration",
+    "match_min_score",
+    # BGM
+    "bgm_gain_db",
+    "bgm_duck_db",
+    "bgm_normalize",
+    "audio_target_dbfs",
+    # Render / subtitle
+    "render_subtitle_position",
+    "render_subtitle_max_width_ratio",
+    "render_subtitle_bottom_margin_ratio",
+    "render_font_size",
+    "render_fit_mode",
+    "render_crf",
+    "render_preset",
+    "render_faststart",
+    # TTS pacing
+    "tts_pause_ms",
+    # QA
+    "qa_enabled",
+    "qa_max_silence_db",
+    "qa_min_duration_ratio",
+    "qa_max_duration_ratio",
+    # Prompt shaping (new — added to whitelist in schema/load/runner)
+    "prompt_target_sentences",
+    "prompt_max_chars_per_sentence",
+    "prompt_hook_seconds",
+})
+
+
+@runtime_checkable
+class Preset(Protocol):
+    """A narration style preset.
+
+    Implementations may be classes or modules; the only requirement is
+    that they expose ``name``, ``params()``, ``prompt_tags()``, and
+    ``description()``.
+    """
+
+    #: Unique preset identifier (kebab-case, e.g. ``"mainstream-dry"``).
+    name: str
+
+    def params(self) -> Dict[str, Any]:
+        """Return JobParams-compatible key-value defaults.
+
+        Keys must be in :data:`ALLOWED_PARAM_KEYS`.  Values must be
+        valid for the corresponding :class:`JobParams` field.
+        """
+        ...
+
+    def prompt_tags(self) -> Dict[str, str]:
+        """Return closed-vocabulary prompt shaping labels.
+
+        Keys must be in :data:`ALLOWED_PROMPT_TAGS` and values must be
+        in the corresponding allowed set.
+        """
+        ...
+
+    def description(self) -> str:
+        """Human-readable description shown in ``--help`` and docs."""
+        ...
+
+
+@dataclass(frozen=True)
+class PresetParam:
+    """Materialised preset parameters ready for merge into ctx.metadata.
+
+    Created by :func:`movie_narrator.presets.registry.get_preset` after
+    validation.  ``param_dict`` is the validated ``params()`` output;
+    ``tag_dict`` is the validated ``prompt_tags()`` output.
+    """
+
+    name: str
+    param_dict: Dict[str, Any] = field(default_factory=dict)
+    tag_dict: Dict[str, str] = field(default_factory=dict)
+    desc: str = ""

--- a/src/movie_narrator/presets/bilibili_long.py
+++ b/src/movie_narrator/presets/bilibili_long.py
@@ -1,0 +1,45 @@
+"""Bilibili-long preset — 8 句×7.5s, 大场景合并, 字幕小.
+
+B站长解说风格。慢节奏,突出源片,相邻 scene 合并,字幕更小更克制。
+适合粉丝留存型长解说。
+"""
+
+from typing import Any, Dict
+
+
+class BilibiliLongPreset:
+    """B站长解说风格 — 慢节奏, 突出源片。"""
+
+    name = "bilibili-long"
+
+    def params(self) -> Dict[str, Any]:
+        return {
+            # Match: 大场景合并,几乎不拉伸
+            "match_speed_clamp_min": 0.95,
+            "match_speed_clamp_max": 1.02,
+            "scene_merge_min_duration": 5.0,
+            "match_drop_scene_min_duration": 0.8,
+            # BGM: 很轻
+            "bgm_duck_db": -18.0,
+            "bgm_normalize": True,
+            "audio_target_dbfs": -16.0,
+            # Render: 小字幕,克制
+            "render_subtitle_position": "bottom",
+            "render_font_size": 75,
+            # TTS: 长停顿,留白
+            "tts_pause_ms": 300,
+            # Prompt: 8 句×~7.5s
+            "prompt_target_sentences": 8,
+            "prompt_max_chars_per_sentence": 22,
+            "prompt_hook_seconds": 7,
+        }
+
+    def prompt_tags(self) -> Dict[str, str]:
+        return {
+            "prompt_cadence": "languid",
+            "prompt_register": "written",
+            "prompt_connectors": "narrative",
+        }
+
+    def description(self) -> str:
+        return "B站长解说 — 8句×7.5s, 慢节奏, 突出源片, 粉丝留存型"

--- a/src/movie_narrator/presets/douyin_fast.py
+++ b/src/movie_narrator/presets/douyin_fast.py
@@ -1,0 +1,45 @@
+"""Douyin-fast preset — 18 句×3.3s, 快切镜, 紧凑.
+
+60s 短视频高完播率风格。句密高,切镜快,BGM 闪避深。
+这是 v0.4.13 的行为基线,作为默认 preset 保证向后兼容。
+"""
+
+from typing import Any, Dict
+
+
+class DouyinFastPreset:
+    """抖音快剪风格 — 高完播率短视频。"""
+
+    name = "douyin-fast"
+
+    def params(self) -> Dict[str, Any]:
+        return {
+            # Match: 快切镜,允许较大速度拉伸
+            "match_speed_clamp_min": 0.85,
+            "match_speed_clamp_max": 1.25,
+            "scene_merge_min_duration": 2.0,
+            "match_drop_scene_min_duration": 0.4,
+            # BGM: 深度闪避,不抢人声
+            "bgm_duck_db": -10.0,
+            "bgm_normalize": True,
+            "audio_target_dbfs": -14.0,
+            # Render: 紧凑字幕
+            "render_subtitle_position": "bottom",
+            "render_font_size": 100,
+            # TTS: 紧凑停顿
+            "tts_pause_ms": 150,
+            # Prompt: 18 句×~3.3s
+            "prompt_target_sentences": 18,
+            "prompt_max_chars_per_sentence": 15,
+            "prompt_hook_seconds": 3,
+        }
+
+    def prompt_tags(self) -> Dict[str, str]:
+        return {
+            "prompt_cadence": "brisk",
+            "prompt_register": "spoken",
+            "prompt_connectors": "interjection",
+        }
+
+    def description(self) -> str:
+        return "抖音快剪 — 18句×3.3s, 快切镜, 高完播率短视频风格"

--- a/src/movie_narrator/presets/mainstream_dry.py
+++ b/src/movie_narrator/presets/mainstream_dry.py
@@ -1,0 +1,45 @@
+"""Mainstream-dry preset — 12 句×5s, 慢切镜, 厚背板字幕.
+
+主流干货剪辑风格(谷阿莫/影视飓风节奏)。句速放慢,切镜稳,BGM 轻。
+适合"电影速看"类中长视频。
+"""
+
+from typing import Any, Dict
+
+
+class MainstreamDryPreset:
+    """主流干货风格 — 谷阿莫/影视飓风节奏。"""
+
+    name = "mainstream-dry"
+
+    def params(self) -> Dict[str, Any]:
+        return {
+            # Match: 慢切镜,拒绝大幅拉伸
+            "match_speed_clamp_min": 0.9,
+            "match_speed_clamp_max": 1.05,
+            "scene_merge_min_duration": 3.5,
+            "match_drop_scene_min_duration": 0.5,
+            # BGM: 更轻,不抢人声
+            "bgm_duck_db": -15.0,
+            "bgm_normalize": True,
+            "audio_target_dbfs": -14.0,
+            # Render: 厚背板字幕
+            "render_subtitle_position": "bottom",
+            "render_font_size": 90,
+            # TTS: 留呼吸
+            "tts_pause_ms": 200,
+            # Prompt: 12 句×~5s
+            "prompt_target_sentences": 12,
+            "prompt_max_chars_per_sentence": 18,
+            "prompt_hook_seconds": 5,
+        }
+
+    def prompt_tags(self) -> Dict[str, str]:
+        return {
+            "prompt_cadence": "measured",
+            "prompt_register": "spoken",
+            "prompt_connectors": "narrative",
+        }
+
+    def description(self) -> str:
+        return "主流干货 — 12句×5s, 慢切镜, 谷阿莫/影视飓风节奏"

--- a/src/movie_narrator/presets/registry.py
+++ b/src/movie_narrator/presets/registry.py
@@ -1,0 +1,162 @@
+"""Preset registry — registration, validation, and lookup.
+
+Stage 0.5: only built-in presets are registered (no SPI discover yet).
+The :func:`discover_presets` hook is reserved for Stage 2 (entry-points
++ local folder scan) and currently returns an empty list.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .base import (
+    ALLOWED_PARAM_KEYS,
+    ALLOWED_PROMPT_TAGS,
+    Preset,
+    PresetParam,
+)
+
+# ── Built-in presets ────────────────────────────────────────
+from .mainstream_dry import MainstreamDryPreset
+from .douyin_fast import DouyinFastPreset
+from .bilibili_long import BilibiliLongPreset
+
+
+def _validate(preset: Preset) -> PresetParam:
+    """Validate a preset's params and tags against the closed vocabularies.
+
+    Raises :class:`ValueError` with a descriptive message if any key or
+    value is out of bounds.
+    """
+    raw_params = preset.params()
+    raw_tags = preset.prompt_tags()
+
+    # Validate param keys
+    bad_keys = set(raw_params) - ALLOWED_PARAM_KEYS
+    if bad_keys:
+        raise ValueError(
+            f"Preset '{preset.name}': param keys not in ALLOWED_PARAM_KEYS: {bad_keys}"
+        )
+
+    # Validate prompt tag keys and values
+    for tag_key, tag_val in raw_tags.items():
+        if tag_key not in ALLOWED_PROMPT_TAGS:
+            raise ValueError(
+                f"Preset '{preset.name}': prompt tag '{tag_key}' is not in "
+                f"ALLOWED_PROMPT_TAGS. Allowed: {sorted(ALLOWED_PROMPT_TAGS)}"
+            )
+        allowed_vals = ALLOWED_PROMPT_TAGS[tag_key]
+        if tag_val not in allowed_vals:
+            raise ValueError(
+                f"Preset '{preset.name}': prompt tag '{tag_key}' value '{tag_val}' "
+                f"is not allowed. Allowed values: {sorted(allowed_vals)}"
+            )
+
+    return PresetParam(
+        name=preset.name,
+        param_dict=dict(raw_params),
+        tag_dict=dict(raw_tags),
+        desc=preset.description(),
+    )
+
+
+def _build_registry() -> Dict[str, PresetParam]:
+    """Build the validated preset registry.
+
+    Built-in presets are always loaded.  Future SPI discover results
+    are merged on top (Stage 2).
+    """
+    registry: Dict[str, PresetParam] = {}
+
+    # 1. Built-in presets (hardcoded — Stage 0.5)
+    builtin = [
+        DouyinFastPreset(),
+        MainstreamDryPreset(),
+        BilibiliLongPreset(),
+    ]
+
+    # 2. SPI discover (Stage 2 — currently returns [])
+    external = discover_presets()
+
+    for preset in builtin + external:
+        validated = _validate(preset)
+        if validated.name in registry:
+            raise ValueError(
+                f"Duplicate preset name '{validated.name}' — "
+                f"built-in and external presets must have unique names"
+            )
+        registry[validated.name] = validated
+
+    return registry
+
+
+def discover_presets() -> List[Preset]:
+    """Discover external presets via SPI.
+
+    Stage 0.5 stub — returns empty list.  Stage 2 will implement:
+    1. ``importlib.metadata.entry_points(group="movie_narrator.presets")``
+    2. Opt-in local folder scan (``~/.movie-narrator/presets/*.py``)
+    """
+    return []
+
+
+# ── Public API ──────────────────────────────────────────────
+
+_REGISTRY: Dict[str, PresetParam] | None = None
+
+
+def _get_registry() -> Dict[str, PresetParam]:
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_registry()
+    return _REGISTRY
+
+
+def get_preset(name: str) -> PresetParam:
+    """Look up a validated preset by name.
+
+    Raises :class:`KeyError` if not found.  Use :func:`list_presets`
+    to see available names.
+    """
+    reg = _get_registry()
+    if name not in reg:
+        available = ", ".join(sorted(reg))
+        raise KeyError(
+            f"Unknown narration preset '{name}'. Available: {available}"
+        )
+    return reg[name]
+
+
+def list_presets() -> Dict[str, str]:
+    """Return ``{name: description}`` for all registered presets."""
+    return {name: p.desc for name, p in _get_registry().items()}
+
+
+# Lazy-loaded constant for __init__ re-export
+def _build_builtin_dict():
+    return _get_registry()
+
+
+class _LazyPresets:
+    """Lazy proxy so BUILTIN_PRESETS doesn't trigger registry build at import."""
+
+    def __iter__(self):
+        return iter(_get_registry())
+
+    def __len__(self):
+        return len(_get_registry())
+
+    def __contains__(self, item):
+        return item in _get_registry()
+
+    def items(self):
+        return _get_registry().items()
+
+    def keys(self):
+        return _get_registry().keys()
+
+    def values(self):
+        return _get_registry().values()
+
+
+BUILTIN_PRESETS = _LazyPresets()

--- a/src/movie_narrator/utils/prompts.py
+++ b/src/movie_narrator/utils/prompts.py
@@ -5,11 +5,12 @@ Style: {style}.
 
 {research}
 Requirements:
-1. Each sentence no more than 15 characters.
+1. Each sentence no more than {max_chars} characters.
 2. Each sentence is its own paragraph (one sentence = one segment).
-3. Total 15-20 sentences.
-4. First 3 seconds must have a strong hook (suspense, conflict, surprise).
+3. Total {target_sentences} sentences.
+4. First {hook_seconds} seconds must have a strong hook (suspense, conflict, surprise).
 5. The last segment needs emotional elevation or a thought-provoking ending.
+{cadence_hint}
 
 Output in JSON format:
 {{
@@ -22,6 +23,38 @@ Output in JSON format:
 
 Output ONLY the JSON, no extra text or markdown markers.
 """
+
+# ── Cadence/register/connector hints for preset-driven prompt shaping ──
+# These are injected into SCRIPT_PROMPT via {cadence_hint}.  Each preset
+# selects one hint per dimension; the combination produces a distinctive
+# narrative voice without replacing the entire prompt template.
+_CADENCE_HINTS = {
+    "brisk": "6. Pacing: keep it brisk and punchy — short, energetic sentences that grab attention fast.",
+    "measured": "6. Pacing: measured and clear — give each point room to breathe, natural rhythm.",
+    "languid": "6. Pacing: slow and contemplative — let scenes linger, use pauses for emphasis.",
+}
+
+_CONNECTOR_HINTS = {
+    "interjection": '7. Tone: conversational — use interjections like \u201c哦？\u201d \u201c等等\u201d \u201c注意这里\u201d to engage the viewer.',
+    "narrative": '7. Tone: narrative — use connecting phrases like \u201c话说\u201d \u201c你知道吗\u201d for smooth flow.',
+    "none": "",
+}
+
+
+def build_cadence_hint(cadence: str = "", connectors: str = "") -> str:
+    """Build the {cadence_hint} block from preset tags.
+
+    Empty/unknown tags produce an empty string (backward-compatible with
+    configs that don't use presets).
+    """
+    parts = []
+    if cadence and cadence in _CADENCE_HINTS:
+        parts.append(_CADENCE_HINTS[cadence])
+    if connectors and connectors in _CONNECTOR_HINTS:
+        hint = _CONNECTOR_HINTS[connectors]
+        if hint:
+            parts.append(hint)
+    return "\n".join(parts)
 
 # Translation prompt — multi-language subtitle (v0.3).
 # The LLM must return a JSON object with a "translations" array aligned

--- a/src/movie_narrator/web_api/form.py
+++ b/src/movie_narrator/web_api/form.py
@@ -35,6 +35,7 @@ class FormData:
     match_min_score: Optional[float]
     translate_provider: str
     translate_retries: Optional[int]
+    narration_preset: str = ""
 
 
 def validate_form(data: FormData) -> List[str]:
@@ -94,4 +95,5 @@ def form_to_context_args(data: FormData) -> Dict[str, Any]:
         config_path=None,
         subtitle_lang=data.subtitle_lang.strip() or None,
         subtitle_mode=data.subtitle_mode,
+        narration_preset=data.narration_preset.strip() or None,
     )

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -97,6 +97,9 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             # Deliverable QA
             "qa_enabled", "qa_max_silence_db",
             "qa_min_duration_ratio", "qa_max_duration_ratio",
+            # Prompt shaping (preset-driven)
+            "prompt_target_sentences", "prompt_max_chars_per_sentence",
+            "prompt_hook_seconds",
             # Async
             "async_timeout", "async_max_workers",
             # Video sizes

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -76,6 +76,10 @@ class JobParams(BaseModel):
     qa_max_silence_db: Optional[float] = None
     qa_min_duration_ratio: Optional[float] = None
     qa_max_duration_ratio: Optional[float] = None
+    # ── Prompt shaping (preset-driven) ──
+    prompt_target_sentences: Optional[int] = None
+    prompt_max_chars_per_sentence: Optional[int] = None
+    prompt_hook_seconds: Optional[int] = None
     # ── Async ──
     async_timeout: Optional[int] = None
     async_max_workers: Optional[int] = None

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,165 @@
+"""Tests for the narration preset system (Stage 0.5)."""
+
+import pytest
+
+from movie_narrator.presets import get_preset, list_presets, BUILTIN_PRESETS
+from movie_narrator.presets.base import (
+    ALLOWED_PARAM_KEYS,
+    ALLOWED_PROMPT_TAGS,
+)
+from movie_narrator.presets.registry import _validate
+from movie_narrator.utils.prompts import build_cadence_hint, SCRIPT_PROMPT
+
+
+# ── Registry / lookup ───────────────────────────────────────
+
+
+def test_list_presets_returns_three_builtins():
+    presets = list_presets()
+    assert "douyin-fast" in presets
+    assert "mainstream-dry" in presets
+    assert "bilibili-long" in presets
+    assert len(presets) >= 3
+
+
+def test_get_preset_returns_validated_params():
+    preset = get_preset("mainstream-dry")
+    assert preset.name == "mainstream-dry"
+    assert isinstance(preset.param_dict, dict)
+    assert isinstance(preset.tag_dict, dict)
+    assert preset.desc  # non-empty description
+
+
+def test_get_preset_unknown_raises():
+    with pytest.raises(KeyError, match="Unknown narration preset"):
+        get_preset("nonexistent-preset")
+
+
+# ── Preset param keys within whitelist ──────────────────────
+
+
+@pytest.mark.parametrize("preset_name", ["douyin-fast", "mainstream-dry", "bilibili-long"])
+def test_preset_params_within_allowed_keys(preset_name):
+    preset = get_preset(preset_name)
+    bad_keys = set(preset.param_dict) - ALLOWED_PARAM_KEYS
+    assert not bad_keys, f"Preset '{preset_name}' has keys outside ALLOWED_PARAM_KEYS: {bad_keys}"
+
+
+@pytest.mark.parametrize("preset_name", ["douyin-fast", "mainstream-dry", "bilibili-long"])
+def test_preset_tags_within_allowed_vocab(preset_name):
+    preset = get_preset(preset_name)
+    for tag_key, tag_val in preset.tag_dict.items():
+        assert tag_key in ALLOWED_PROMPT_TAGS, f"Unknown tag key: {tag_key}"
+        assert tag_val in ALLOWED_PROMPT_TAGS[tag_key], f"Tag '{tag_key}' value '{tag_val}' not allowed"
+
+
+# ── Preset differentiation ──────────────────────────────────
+
+
+def test_presets_have_different_sentence_counts():
+    """Each preset should target a different sentence count."""
+    counts = {
+        name: get_preset(name).param_dict.get("prompt_target_sentences")
+        for name in ("douyin-fast", "mainstream-dry", "bilibili-long")
+    }
+    assert counts["douyin-fast"] > counts["mainstream-dry"] > counts["bilibili-long"]
+
+
+def test_presets_have_different_cadence():
+    tags = {
+        name: get_preset(name).tag_dict.get("prompt_cadence")
+        for name in ("douyin-fast", "mainstream-dry", "bilibili-long")
+    }
+    assert len(set(tags.values())) == 3  # all different
+
+
+def test_douyin_fast_is_fastest_preset():
+    """Douyin-fast should have the highest speed_clamp_max (fastest pacing)."""
+    dy = get_preset("douyin-fast").param_dict
+    md = get_preset("mainstream-dry").param_dict
+    bl = get_preset("bilibili-long").param_dict
+    assert dy["match_speed_clamp_max"] > md["match_speed_clamp_max"] > bl["match_speed_clamp_max"]
+
+
+# ── Prompt shaping ──────────────────────────────────────────
+
+
+def test_build_cadence_hint_brisk():
+    hint = build_cadence_hint(cadence="brisk", connectors="interjection")
+    assert "brisk" in hint
+    assert "interjection" in hint or "哦" in hint
+
+
+def test_build_cadence_hint_languid():
+    hint = build_cadence_hint(cadence="languid", connectors="narrative")
+    assert "slow" in hint or "contemplative" in hint
+    assert "话说" in hint or "narrative" in hint
+
+
+def test_build_cadence_hint_empty_tags():
+    """Empty/unknown tags produce empty string (backward compat)."""
+    assert build_cadence_hint() == ""
+    assert build_cadence_hint(cadence="unknown", connectors="unknown") == ""
+
+
+def test_script_prompt_has_all_placeholders():
+    """SCRIPT_PROMPT must have all required format placeholders."""
+    # Should format without errors when all keys are provided
+    formatted = SCRIPT_PROMPT.format(
+        movie="Test",
+        style="drama",
+        duration=60,
+        research="",
+        max_chars=15,
+        target_sentences=15,
+        hook_seconds=3,
+        cadence_hint="",
+    )
+    assert "Test" in formatted
+    assert "15" in formatted
+
+
+# ── Validation ──────────────────────────────────────────────
+
+
+def test_validate_rejects_bad_param_key():
+    """A preset with a param key outside ALLOWED_PARAM_KEYS is rejected."""
+
+    class BadPreset:
+        name = "bad"
+        def params(self):
+            return {"nonexistent_key": 42}
+        def prompt_tags(self):
+            return {}
+        def description(self):
+            return "bad"
+
+    with pytest.raises(ValueError, match="not in ALLOWED_PARAM_KEYS"):
+        _validate(BadPreset())
+
+
+def test_validate_rejects_bad_tag_value():
+    """A preset with a tag value outside the allowed set is rejected."""
+
+    class BadTagPreset:
+        name = "bad-tag"
+        def params(self):
+            return {}
+        def prompt_tags(self):
+            return {"prompt_cadence": "supersonic"}  # not in allowed set
+        def description(self):
+            return "bad tag"
+
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate(BadTagPreset())
+
+
+# ── BUILTIN_PRESETS proxy ───────────────────────────────────
+
+
+def test_builtin_presets_proxy_is_iterable():
+    """BUILTIN_PRESETS should be iterable and contain the three builtins."""
+    names = list(BUILTIN_PRESETS)
+    assert "douyin-fast" in names
+    assert "mainstream-dry" in names
+    assert "bilibili-long" in names


### PR DESCRIPTION
Three built-in narration style presets (douyin-fast default, mainstream-dry, bilibili-long) with pluggable Preset Protocol interface. Preset params are baseline; user params override. Prompt shaping via closed-vocabulary tags. 19 new tests, 371 passed total.