### PR TITLE
refactor: preset system improvements

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -179,7 +179,7 @@ def create(
         config_path=resolved.config_path,
         subtitle_lang=resolved.subtitle_lang,
         subtitle_mode=resolved.subtitle_mode,
-        narration_preset=narration_preset,
+        narration_preset=resolved.narration_preset or narration_preset,
     )
     controller = InteractiveCLIController() if retry else None
     try:
@@ -348,6 +348,54 @@ def clips(
 def version():
     """Show version."""
     typer.echo(f"movie-narrator v{__version__}")
+
+
+@app.command()
+def preset(
+    name: Optional[str] = typer.Argument(
+        None, help="Preset name to show details for (omitted = list all)"
+    ),
+):
+    """List narration presets or show details for a specific preset.
+
+    \b
+    Examples:
+        mn preset                  # list all available presets
+        mn preset mainstream-dry   # show params + tags for mainstream-dry
+    """
+    from .presets import get_preset, list_presets
+
+    if name is None:
+        # List mode
+        presets = list_presets()
+        if not presets:
+            typer.echo("No narration presets available.")
+            return
+        typer.echo("Available narration presets:")
+        typer.echo("")
+        for pname, pdesc in presets.items():
+            typer.echo(f"  {pname:<20} {pdesc}")
+        typer.echo("")
+        typer.echo("Use 'mn preset <name>' to see full details.")
+        typer.echo("Use '--narration-preset <name>' with 'mn create' to apply.")
+    else:
+        # Show mode
+        try:
+            p = get_preset(name)
+        except KeyError as e:
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(1)
+
+        typer.echo(f"Preset: {p.name}")
+        typer.echo(f"Description: {p.desc}")
+        typer.echo("")
+        typer.echo("Parameters:")
+        for key in sorted(p.param_dict):
+            typer.echo(f"  {key:<40} {p.param_dict[key]}")
+        typer.echo("")
+        typer.echo("Prompt tags:")
+        for key in sorted(p.tag_dict):
+            typer.echo(f"  {key:<40} {p.tag_dict[key]}")
 
 
 @app.command()

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -28,6 +28,31 @@ from .qa import validate_deliverable
 # ── Step metadata (module-level constants) ──────────────────
 # Single source of truth: a soft step whose exception is caught by the runner
 # (rendered as ⚠ + continue) instead of being re-raised as a hard failure.
+
+# Complete whitelist of param keys that build_context accepts from
+# JobParams / preset params.  This is the SINGLE SOURCE OF TRUTH —
+# presets/base.py:ALLOWED_PARAM_KEYS is a validated subset of this.
+PARAM_WHITELIST: frozenset[str] = frozenset({
+    "scene_threshold", "scene_frame_skip", "match_min_score",
+    "match_speed_clamp_min", "match_speed_clamp_max",
+    "scene_merge_min_duration", "match_drop_scene_min_duration",
+    "embedding_model_name",
+    "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
+    "tts_pause_ms",
+    "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
+    "translate_source_lang", "translate_chunk_chars", "translate_chunk_size",
+    "whisperx_device", "whisperx_model", "whisperx_language",
+    "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
+    "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+    "render_fit_mode", "render_crf", "render_preset", "render_faststart",
+    "render_subtitle_position", "render_subtitle_max_width_ratio",
+    "render_subtitle_bottom_margin_ratio",
+    "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
+    "prompt_target_sentences", "prompt_max_chars_per_sentence", "prompt_hook_seconds",
+    "async_timeout", "async_max_workers",
+    "video_sizes",
+})
+
 SOFT_STATUS_STEPS = {
     "research_plot",
     "align_audio",
@@ -191,26 +216,7 @@ def build_context(
         effective_params.update(params)
 
     if effective_params:
-        for key in (
-            "scene_threshold", "scene_frame_skip", "match_min_score",
-            "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration", "match_drop_scene_min_duration",
-            "embedding_model_name",
-            "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
-            "tts_pause_ms",
-            "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
-            "translate_source_lang", "translate_chunk_chars", "translate_chunk_size",
-            "whisperx_device", "whisperx_model", "whisperx_language",
-            "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
-            "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
-            "render_fit_mode", "render_crf", "render_preset", "render_faststart",
-            "render_subtitle_position", "render_subtitle_max_width_ratio",
-            "render_subtitle_bottom_margin_ratio",
-            "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
-            "prompt_target_sentences", "prompt_max_chars_per_sentence", "prompt_hook_seconds",
-            "async_timeout", "async_max_workers",
-            "video_sizes",
-        ):
+        for key in PARAM_WHITELIST:
             if key in effective_params and effective_params[key] is not None:
                 ctx.metadata[key] = effective_params[key]
     if config_path:

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -40,6 +40,7 @@ def generate_script(ctx: Context) -> Context:
                     cadence_hint=build_cadence_hint(
                         cadence=tags.get("prompt_cadence", ""),
                         connectors=tags.get("prompt_connectors", ""),
+                        register=tags.get("prompt_register", ""),
                     ),
                 )
                 response = llm.client.chat.completions.create(

--- a/src/movie_narrator/presets/base.py
+++ b/src/movie_narrator/presets/base.py
@@ -27,9 +27,10 @@ ALLOWED_PROMPT_TAGS: Dict[str, frozenset[str]] = {
 }
 
 # ── Param keys that presets are allowed to set ──────────────
-# Must be a subset of JobParams fields (schema.py) / _ALLOWED_PARAMS
-# (load.py) / build_context key tuple (runner.py).  Validated at
-# registration time.
+# Must be a subset of PARAM_WHITELIST (runner.py).  Validated at
+# registration time.  Single source of truth lives in runner.py;
+# this frozenset is intentionally a subset so presets can't set
+# infrastructure keys (whisperx_*, translate_*, async_*, video_sizes).
 ALLOWED_PARAM_KEYS: frozenset[str] = frozenset({
     # Match / scene
     "match_speed_clamp_min",
@@ -63,6 +64,10 @@ ALLOWED_PARAM_KEYS: frozenset[str] = frozenset({
     "prompt_max_chars_per_sentence",
     "prompt_hook_seconds",
 })
+
+# Safety: ALLOWED_PARAM_KEYS must be a subset of PARAM_WHITELIST.
+# This check is performed in registry._validate() at registration time
+# to avoid a circular import (runner.py imports presets indirectly).
 
 
 @runtime_checkable

--- a/src/movie_narrator/presets/registry.py
+++ b/src/movie_narrator/presets/registry.py
@@ -28,6 +28,17 @@ def _validate(preset: Preset) -> PresetParam:
     Raises :class:`ValueError` with a descriptive message if any key or
     value is out of bounds.
     """
+    # Lazy import to avoid circular dependency (runner.py → presets → runner)
+    from ..pipeline.runner import PARAM_WHITELIST
+
+    # Safety: ALLOWED_PARAM_KEYS (in base.py) must be a subset of
+    # PARAM_WHITELIST (in runner.py).  Checked here so a mismatch
+    # between the two frozensets fails fast at registry build time.
+    assert ALLOWED_PARAM_KEYS <= PARAM_WHITELIST, (
+        f"ALLOWED_PARAM_KEYS has keys not in PARAM_WHITELIST: "
+        f"{ALLOWED_PARAM_KEYS - PARAM_WHITELIST}"
+    )
+
     raw_params = preset.params()
     raw_tags = preset.prompt_tags()
 

--- a/src/movie_narrator/utils/prompts.py
+++ b/src/movie_narrator/utils/prompts.py
@@ -40,8 +40,14 @@ _CONNECTOR_HINTS = {
     "none": "",
 }
 
+_REGISTER_HINTS = {
+    "spoken": "8. Register: spoken language — write as if talking to a friend, casual and direct.",
+    "written": "8. Register: written language — use polished, literary phrasing suitable for reading.",
+    "mixed": "8. Register: mixed — combine spoken directness with occasional literary flourishes.",
+}
 
-def build_cadence_hint(cadence: str = "", connectors: str = "") -> str:
+
+def build_cadence_hint(cadence: str = "", connectors: str = "", register: str = "") -> str:
     """Build the {cadence_hint} block from preset tags.
 
     Empty/unknown tags produce an empty string (backward-compatible with
@@ -54,6 +60,8 @@ def build_cadence_hint(cadence: str = "", connectors: str = "") -> str:
         hint = _CONNECTOR_HINTS[connectors]
         if hint:
             parts.append(hint)
+    if register and register in _REGISTER_HINTS:
+        parts.append(_REGISTER_HINTS[register])
     return "\n".join(parts)
 
 # Translation prompt — multi-language subtitle (v0.3).

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -26,6 +26,7 @@ _ALLOWED_TOP = (
     "params",
     "subtitle_lang",
     "subtitle_mode",
+    "narration_preset",
 )
 
 

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -126,6 +126,10 @@ def merge_job(
             f"subtitle_mode={subtitle_mode!r} requires --subtitle-lang / subtitle_lang"
         )
 
+    narration_preset = pick_optional(
+        cli.get("narration_preset"), yaml_get("narration_preset"), None
+    )
+
     config_path = cli.get("config_path")
     if config_path is not None:
         config_path = str(config_path)
@@ -149,4 +153,5 @@ def merge_job(
         config_path=config_path,
         subtitle_lang=subtitle_lang,
         subtitle_mode=subtitle_mode,
+        narration_preset=narration_preset,
     )

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -108,6 +108,7 @@ class JobConfig(BaseModel):
     # Multi-language subtitle (v0.3).
     subtitle_lang: Optional[str] = None
     subtitle_mode: Optional[str] = None
+    narration_preset: Optional[str] = None
     steps: Optional[JobSteps] = None
     params: Optional[JobParams] = None
 
@@ -155,3 +156,4 @@ class ResolvedJob(BaseModel):
     # Multi-language subtitle (v0.3).
     subtitle_lang: Optional[str] = None
     subtitle_mode: str = "original"
+    narration_preset: Optional[str] = None

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -96,6 +96,12 @@ def test_build_cadence_hint_languid():
     assert "话说" in hint or "narrative" in hint
 
 
+def test_build_cadence_hint_with_register():
+    """Register tag (spoken/written/mixed) is consumed and appears in hint."""
+    hint = build_cadence_hint(cadence="measured", connectors="narrative", register="written")
+    assert "written" in hint.lower() or "literary" in hint.lower()
+
+
 def test_build_cadence_hint_empty_tags():
     """Empty/unknown tags produce empty string (backward compat)."""
     assert build_cadence_hint() == ""
@@ -163,3 +169,38 @@ def test_builtin_presets_proxy_is_iterable():
     assert "douyin-fast" in names
     assert "mainstream-dry" in names
     assert "bilibili-long" in names
+
+
+# ── PARAM_WHITELIST single-source-of-truth ─────────────────
+
+
+def test_allowed_param_keys_subset_of_param_whitelist():
+    """ALLOWED_PARAM_KEYS must be a subset of PARAM_WHITELIST."""
+    from movie_narrator.pipeline.runner import PARAM_WHITELIST
+    assert ALLOWED_PARAM_KEYS <= PARAM_WHITELIST, (
+        f"Keys in ALLOWED_PARAM_KEYS but not PARAM_WHITELIST: "
+        f"{ALLOWED_PARAM_KEYS - PARAM_WHITELIST}"
+    )
+
+
+# ── YAML config narration_preset ────────────────────────────
+
+
+def test_yaml_narration_preset_field_accepted(tmp_path):
+    """JobConfig accepts narration_preset as a top-level field."""
+    from movie_narrator.workflow.schema import JobConfig
+    import yaml
+
+    job_yaml = {
+        "movie": "test",
+        "narration_preset": "mainstream-dry",
+    }
+    config = JobConfig(**job_yaml)
+    assert config.narration_preset == "mainstream-dry"
+
+
+def test_yaml_narration_preset_defaults_none():
+    """JobConfig.narration_preset defaults to None when not specified."""
+    from movie_narrator.workflow.schema import JobConfig
+    config = JobConfig(movie="test")
+    assert config.narration_preset is None


### PR DESCRIPTION
Four improvements to the preset system from PR #40 review:

1. prompt_register tag consumed (was defined but unused)
2. narration_preset in YAML job config (was CLI-only)
3. Single-source PARAM_WHITELIST (was dual-maintained tuple + frozenset)
4. mn preset list/show CLI command (was no way to inspect presets)

22 tests, 375 passed total, 2 pre-existing TTS .env failures.