### PR TITLE
release: v0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.15] - 2026-07-17
+
+### Added (Narration preset system — Stage 0.5)
+- **Pluggable preset framework**: new `src/movie_narrator/presets/` package with `Preset` Protocol, closed-vocabulary validation (`ALLOWED_PARAM_KEYS` + `ALLOWED_PROMPT_TAGS`), and registry. Preset params are the BASELINE; user params (CLI / YAML) always override.
+- **Three built-in presets** covering the most popular recap styles:
+  - `douyin-fast` (default, backward-compatible): 18 sentences × 3.3s, fast cuts, deep BGM ducking (-10dB), brisk cadence
+  - `mainstream-dry`: 12 sentences × 5s, slow cuts (speed_clamp 0.90–1.05), light BGM (-15dB), measured cadence (谷阿莫/影视飓风 rhythm)
+  - `bilibili-long`: 8 sentences × 7.5s, large scene merge (5s), very light BGM (-18dB), languid cadence (粉丝留存型长解说)
+- **CLI**: `--narration-preset` / `-p` flag on `mn create`; new `mn preset` command to list presets or show full params/tags (`mn preset mainstream-dry`).
+- **YAML config**: `narration_preset` top-level field in `job.yaml` (CLI flag overrides YAML).
+- **Web API**: `FormData.narration_preset` field.
+- **Prompt shaping**: closed-vocabulary tags (`prompt_cadence` / `prompt_register` / `prompt_connectors`) injected into `SCRIPT_PROMPT` as conditional hints via `build_cadence_hint()`. Three new `JobParams` keys: `prompt_target_sentences`, `prompt_max_chars_per_sentence`, `prompt_hook_seconds`.
+
+### Changed
+- **Single-source whitelist**: `PARAM_WHITELIST` frozenset in `runner.py` is now the authoritative param whitelist. `build_context` iterates it instead of a hardcoded tuple. `ALLOWED_PARAM_KEYS` in `presets/base.py` is validated as a subset at registry build time.
+- `prompts.py` `SCRIPT_PROMPT` now uses `{target_sentences}`, `{max_chars}`, `{hook_seconds}`, `{cadence_hint}` placeholders instead of hardcoded "15-20 sentences" / "15 characters" / "3 seconds".
+
+### Hand-test findings (2026-07-17 满江红对比实验)
+- **Preset prompt tags verified effective**: cadence/register/connectors all produced perceptible style differences (brisk → 61% exclamation sentences; written → literary vocabulary; interjection → interactive calls).
+- **Known limitation**: `prompt_target_sentences` constraint is weak — LLM output 18 sentences for all three presets regardless of the 12/8 targets. Style differences were carried by sentence length and rhetoric instead of sentence count. Planned fix: stronger prompt wording + post-processing truncation.
+
 ## [0.4.14] - 2026-07-17
 
 ### Added (Publishable bottom subtitle)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,6 +141,18 @@ The Web UI is rebuilt from a Gradio single-file app into a decoupled **FastAPI +
 - [x] Bug fix: empty wrapped list early return; per-line height re-measurement via `textbbox`
 - [x] Cross-platform test threshold (60% → 50%) for Linux CI font metrics
 
+### v0.4.15 Narration Preset System (Stage 0.5)
+
+- [x] Pluggable `Preset` Protocol with closed-vocabulary validation (`ALLOWED_PARAM_KEYS` + `ALLOWED_PROMPT_TAGS`)
+- [x] Three built-in presets: `douyin-fast` (default), `mainstream-dry`, `bilibili-long`
+- [x] CLI `--narration-preset` / `-p` flag + `mn preset` list/show command
+- [x] YAML `narration_preset` top-level field + Web API `FormData.narration_preset`
+- [x] Prompt shaping via closed-vocabulary tags (cadence / register / connectors)
+- [x] Single-source `PARAM_WHITELIST` frozenset (runner.py) — eliminates dual-maintained whitelist
+- [x] Hand-test verified: prompt tags produce perceptible style differences
+- [ ] Known limitation: `prompt_target_sentences` constraint weak (LLM ignores 12/8 targets) — planned fix: stronger prompt + post-processing truncation
+- [ ] Stage 2 (future): SPI discover via `entry_points` + opt-in local folder scan
+
 ### v0.4 Environment variables
 
 - `MN_TTS_PROVIDER` — `edge` (default), `openai`, or `mimo`

--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -52,6 +52,16 @@ subtitle_lang: ""           # 目标语言标签，如 en / ja / zh-TW；留空 
 subtitle_mode: original     # original | translated | bilingual
 
 # ============================================================
+# 解说风格 Preset（v0.4.15+）
+# ============================================================
+# 内置三种 preset，CLI --narration-preset / -p 优先级高于本字段
+#   douyin-fast      18句×3.3s, 快切镜, 深度闪避 (-10dB), 口语+感叹
+#   mainstream-dry   12句×5s, 慢切镜, 轻音乐 (-15dB), 从容叙事 (谷阿莫节奏)
+#   bilibili-long    8句×7.5s, 大场景合并, 极轻BGM (-18dB), 书面长解说
+# 留空 = douyin-fast（向后兼容 v0.4.14 行为）
+narration_preset: ""        # douyin-fast | mainstream-dry | bilibili-long
+
+# ============================================================
 # 精细参数（所有流水线行为配置都在这里）
 # ============================================================
 # 白名单（其余键会被拒绝）：
@@ -71,6 +81,7 @@ subtitle_mode: original     # original | translated | bilingual
 #          render_subtitle_position / render_subtitle_max_width_ratio
 #          render_subtitle_bottom_margin_ratio
 #   质检: qa_enabled / qa_max_silence_db / qa_min_duration_ratio / qa_max_duration_ratio
+#   文案: prompt_target_sentences / prompt_max_chars_per_sentence / prompt_hook_seconds
 #   异步: async_timeout / async_max_workers
 #   视频: video_sizes
 params:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.4.14"
+version = "0.4.15"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = {text = "AGPL-3.0"}


### PR DESCRIPTION
Version bump 0.4.14 -> 0.4.15. Documents the narration preset system (Stage 0.5): pluggable Preset Protocol, three built-in styles (douyin-fast, mainstream-dry, bilibili-long), prompt shaping tags, mn preset command, single-source PARAM_WHITELIST, and known limitation (prompt_target_sentences constraint weak).