### PR TITLE
feat: pipeline resilience — TTS retry, research retry, degradation warnings

### DIFF
--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -89,6 +89,8 @@ class Settings(BaseSettings):
     script_retry_delay: float = 1.5
     research_temperature: float = 0.3
     research_max_tokens: int = 1024
+    research_retries: int = 3
+    research_retry_delay: float = 1.5
     translate_max_tokens: int = 4096
     # ── TTS ──
     default_voice: str = "zh-CN-YunxiNeural"

--- a/src/movie_narrator/pipeline/research.py
+++ b/src/movie_narrator/pipeline/research.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from time import sleep
 
 from ..config import get_settings
 from ..models import Context, ResearchInfo, StepResult
@@ -52,34 +53,50 @@ def research_plot(ctx: Context) -> Context:
         ctx.status.research = "failed"
         return ctx
 
-    try:
-        settings = get_settings()
-        with get_llm_client() as llm:
-            prompt = RESEARCH_PROMPT.format(movie=ctx.movie_name)
-            response = llm.client.chat.completions.create(
-                model=llm.model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=settings.research_temperature,
-                max_tokens=settings.research_max_tokens,
-            )
-            raw = response.choices[0].message.content or ""
-            data = extract_json(raw)
+    settings = get_settings()
+    console = ctx.services.console
+    last_err = None
 
-            ctx.research = ResearchInfo(
-                title=data.get("title", ctx.movie_name),
-                year=data.get("year"),
-                summary=data.get("summary", ""),
-                genres=data.get("genres", []),
-                cast=data.get("cast", []),
-                keywords=data.get("keywords", []),
-            )
-            _write_envelope(output_dir, "success", None, ctx.research.model_dump())
-            ctx.status.research = "success"
-            return ctx
-    except Exception as e:
-        err = str(e)
-        ctx.step_state.result = StepResult.WARNING
-        ctx.step_state.message = err
-        _write_envelope(output_dir, "failed", err, None)
-        ctx.status.research = "failed"
-        return ctx
+    for attempt in range(settings.research_retries):
+        try:
+            with get_llm_client() as llm:
+                prompt = RESEARCH_PROMPT.format(movie=ctx.movie_name)
+                response = llm.client.chat.completions.create(
+                    model=llm.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=settings.research_temperature,
+                    max_tokens=settings.research_max_tokens,
+                )
+                raw = response.choices[0].message.content or ""
+                data = extract_json(raw)
+
+                ctx.research = ResearchInfo(
+                    title=data.get("title", ctx.movie_name),
+                    year=data.get("year"),
+                    summary=data.get("summary", ""),
+                    genres=data.get("genres", []),
+                    cast=data.get("cast", []),
+                    keywords=data.get("keywords", []),
+                )
+                _write_envelope(output_dir, "success", None, ctx.research.model_dump())
+                ctx.status.research = "success"
+                return ctx
+        except Exception as e:
+            last_err = e
+            if attempt < settings.research_retries - 1:
+                console.debug(
+                    f"  research_plot: attempt {attempt + 1}/{settings.research_retries} failed: {e}"
+                )
+                sleep(settings.research_retry_delay)
+            else:
+                console.debug(
+                    f"  research_plot: all {settings.research_retries} attempts failed: {e}"
+                )
+
+    # All retries exhausted — soft-degrade (research is a soft step)
+    err = str(last_err) if last_err else "unknown error"
+    ctx.step_state.result = StepResult.WARNING
+    ctx.step_state.message = f"research failed after {settings.research_retries} attempts: {err}"
+    _write_envelope(output_dir, "failed", err, None)
+    ctx.status.research = "failed"
+    return ctx

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -63,6 +63,19 @@ SOFT_STATUS_STEPS = {
     "translate_subtitles",
 }
 
+# Human-readable consequence messages for soft-step degradation.
+# When a soft step fails or is skipped, this map provides a concise
+# explanation of what the user should expect in the final output.
+SOFT_STEP_CONSEQUENCES: Dict[str, str] = {
+    "research_plot": "research unavailable — script will use generic plot description",
+    "align_audio": "audio alignment skipped — subtitle timestamps may drift from actual speech",
+    "detect_scenes": "scene detection skipped — clips will use fixed-duration segments",
+    "match_clips": "clip matching skipped — segments mapped to sequential clips without embedding search",
+    "mix_bgm": "BGM mixing failed — final video will have narration audio only, no background music",
+    "export_clips": "clip export skipped — no standalone clip files will be produced",
+    "translate_subtitles": "translation failed — only original-language subtitles will be available",
+}
+
 # Map soft step name → PipelineStatus field name. Steps not in this map
 # (e.g. resolve_video, generate_script, render_video) do not write to
 # PipelineStatus because a hard failure there aborts the pipeline anyway.
@@ -300,10 +313,15 @@ def run_pipeline(
                 elapsed = time.time() - step_start
                 if name in SOFT_STATUS_STEPS:
                     _set_pipeline_status_failed(ctx, name)
+                    consequence = SOFT_STEP_CONSEQUENCES.get(name, "")
+                    msg = str(e)
+                    if consequence:
+                        msg = f"{msg} — {consequence}"
                     ctx.step_state = StepState(
-                        result=StepResult.WARNING, message=str(e)
+                        result=StepResult.WARNING, message=msg
                     )
                     console.step_warn(name, ctx.step_state.message)
+                    ctx.metadata.setdefault("_degraded_steps", []).append(name)
                     _check_strict(ctx, name)
                     break  # exit retry loop, continue to next step
 
@@ -334,6 +352,16 @@ def run_pipeline(
 
     total_elapsed = time.time() - total_start
     console.done(total_elapsed)
+
+    # ── Degradation summary ─────────────────────────────
+    # If any soft steps degraded during this run, warn the user about
+    # the quality impact on the final output.
+    degraded = ctx.metadata.get("_degraded_steps", [])
+    if degraded:
+        console.inline_warn(
+            f"Pipeline completed with {len(degraded)} degraded step(s): "
+            f"{', '.join(degraded)}. The final output may have reduced quality."
+        )
 
     return ctx
 

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -16,6 +16,10 @@ from ..tts.cache import (
 
 __all__ = ["generate_voice"]
 
+# Per-segment TTS retry: network hiccups shouldn't kill the entire batch.
+_TTS_SEGMENT_RETRIES = 3
+_TTS_RETRY_DELAY = 1.0  # seconds
+
 
 def generate_voice(ctx: Context) -> Context:
     settings = get_settings()
@@ -29,6 +33,7 @@ def generate_voice(ctx: Context) -> Context:
     max_concurrent = ctx.metadata.get("tts_max_concurrent", 3)
     audio_fmt = ctx.metadata.get("tts_audio_format", "mp3")
     audio_bitrate = ctx.metadata.get("tts_audio_bitrate", "128k")
+    console = ctx.services.console
 
     def _key(seg_text: str) -> TTSCacheKey:
         return TTSCacheKey(
@@ -65,7 +70,25 @@ def generate_voice(ctx: Context) -> Context:
                     tmp.unlink(missing_ok=True)
                 else:
                     if not cached.exists():
-                        await provider.synthesize(seg.text, voice, cached)
+                        # Per-segment retry: a single network hiccup shouldn't
+                        # kill the entire batch.  Retry up to _TTS_SEGMENT_RETRIES
+                        # times with a short delay before giving up.
+                        last_err = None
+                        for attempt in range(_TTS_SEGMENT_RETRIES):
+                            try:
+                                await provider.synthesize(seg.text, voice, cached)
+                                last_err = None
+                                break
+                            except Exception as e:
+                                last_err = e
+                                if attempt < _TTS_SEGMENT_RETRIES - 1:
+                                    await asyncio.sleep(_TTS_RETRY_DELAY)
+                                else:
+                                    console.inline_warn(
+                                        f"TTS failed for segment after {_TTS_SEGMENT_RETRIES} attempts: {e}"
+                                    )
+                        if last_err is not None:
+                            raise last_err
                     audio = AudioSegment.from_mp3(cached)
                 return audio, round(len(audio) / 1000.0, 3)
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -21,6 +21,8 @@ def test_research_unknown_provider_failed(tmp_path):
     ctx.metadata["research_enabled"] = True
     with patch("movie_narrator.pipeline.research.get_settings") as gs:
         gs.return_value.research_provider = "tmdb"
+        gs.return_value.research_retries = 3
+        gs.return_value.research_retry_delay = 0
         research_plot(ctx)
     assert ctx.status.research == "failed"
     assert (tmp_path / "research.json").exists()
@@ -43,6 +45,10 @@ def test_research_llm_success(tmp_path):
     with patch("movie_narrator.pipeline.research.get_settings") as gs, \
          patch("movie_narrator.pipeline.research.get_llm_client") as gl:
         gs.return_value.research_provider = "llm"
+        gs.return_value.research_retries = 3
+        gs.return_value.research_retry_delay = 0
+        gs.return_value.research_temperature = 0.3
+        gs.return_value.research_max_tokens = 1024
         gl.return_value.__enter__.return_value = gl.return_value
         gl.return_value.client.chat.completions.create.return_value = mock_response
         research_plot(ctx)


### PR DESCRIPTION
Three resilience improvements from the L2 production assessment:

P0: TTS per-segment retry — single network hiccup no longer kills entire batch
P1: Research step retry — matches script.py pattern, was zero retry
P1: Degradation warnings — soft-step failures now show consequences + end-of-run summary

375 passed, 2 pre-existing TTS .env failures, 11 skipped.