### PR TITLE
feat: two-phase script generation — beats extraction + expansion + trim

### DIFF
--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -84,6 +84,7 @@ class Settings(BaseSettings):
     llm_model: str = "qwen2.5:7b"
     llm_timeout: int = 60
     script_temperature: float = 0.7
+    script_expand_temperature: float = 0.5
     script_max_tokens: int = 2048
     script_retries: int = 3
     script_retry_delay: float = 1.5

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -1,6 +1,8 @@
+from typing import List
+
 from ..config import get_settings
 from ..models import Context, ScriptSegment
-from ..utils.prompts import SCRIPT_PROMPT, build_cadence_hint
+from ..utils.prompts import BEATS_PROMPT, EXPAND_PROMPT, build_cadence_hint
 from ..utils.llm import get_llm_client
 from ..utils.json_parser import extract_json
 from ..tts.base import is_ci
@@ -16,56 +18,192 @@ _CI_MOCK_SEGMENTS = [
 ]
 
 
+# ── Fallback trim ───────────────────────────────────────────
+
+
+def _trim_segments(segments: List[ScriptSegment], target: int) -> List[ScriptSegment]:
+    """Trim segments to exactly *target* count if over.
+
+    Strategy: preserve the first ``hook_count`` segments (hooks must stay),
+    then from the remaining pool select those whose length is closest to
+    the median.  This avoids outlier sentences (very short or very long)
+    and keeps the most "normal" content.
+
+    If ``len(segments) <= target``, returns as-is (no padding).
+    """
+    if len(segments) <= target:
+        return segments
+
+    # Lock the first hook_count segments (hooks must be preserved)
+    hook_count = min(3, target)
+    locked = list(segments[:hook_count])
+    pool = list(segments[hook_count:])
+
+    need = target - hook_count
+    if need <= 0:
+        return locked[:target]
+
+    # Rank pool by proximity to median length
+    lengths = sorted(len(s.text) for s in pool)
+    median_len = lengths[len(lengths) // 2]
+    ranked = sorted(pool, key=lambda s: abs(len(s.text) - median_len))
+    selected = ranked[:need]
+
+    # Reassemble in original order
+    all_selected = locked + selected
+    # Use stable sort by original index to preserve chronological order
+    original_indices = {id(s): i for i, s in enumerate(segments)}
+    all_selected.sort(key=lambda s: original_indices.get(id(s), 0))
+    return all_selected
+
+
+# ── Phase 1: plot beat extraction ──────────────────────────
+
+
+def _generate_plot_beats(
+    ctx: Context, settings, llm, target_count: int
+) -> List[str]:
+    """Phase 1: Extract exactly *target_count* plot beats from the movie.
+
+    Uses low temperature (research_temperature) for structured extraction.
+    Raises ValueError if the LLM doesn't return exactly target_count beats.
+    """
+    research_block = ""
+    if ctx.research and ctx.research.summary:
+        research_block = (
+            f"\nResearch context: {ctx.research.summary}\n"
+            f"Genres: {', '.join(ctx.research.genres)}\n"
+        )
+
+    prompt = BEATS_PROMPT.format(
+        movie=ctx.movie_name,
+        style=ctx.style,
+        research=research_block,
+        target_count=target_count,
+    )
+
+    response = llm.client.chat.completions.create(
+        model=llm.model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=settings.research_temperature,
+        max_tokens=settings.research_max_tokens,
+    )
+    raw = response.choices[0].message.content or ""
+    data = extract_json(raw)
+    beats = data.get("beats", [])
+
+    if not isinstance(beats, list):
+        raise ValueError(f"Phase 1: 'beats' is not a list (got {type(beats).__name__})")
+    if len(beats) == 0:
+        raise ValueError("Phase 1: LLM returned zero beats")
+    if len(beats) != target_count:
+        raise ValueError(
+            f"Phase 1: expected {target_count} beats, got {len(beats)}"
+        )
+
+    return [str(b).strip() for b in beats if str(b).strip()]
+
+
+# ── Phase 2: beat expansion ────────────────────────────────
+
+
+def _expand_beats_to_script(
+    ctx: Context, settings, llm, beats: List[str], target_count: int
+) -> List[ScriptSegment]:
+    """Phase 2: Expand each beat into exactly one narration segment.
+
+    Uses moderate temperature (script_expand_temperature) for style
+    expression while keeping count controlled.
+    """
+    tags = ctx.metadata.get("narration_preset_tags", {})
+    max_chars = ctx.metadata.get("prompt_max_chars_per_sentence", 15)
+    hook_seconds = ctx.metadata.get("prompt_hook_seconds", 3)
+
+    # Format beats as a numbered list for the prompt
+    beats_text = "\n".join(f"{i+1}. {b}" for i, b in enumerate(beats))
+
+    prompt = EXPAND_PROMPT.format(
+        movie=ctx.movie_name,
+        style=ctx.style,
+        duration=ctx.duration,
+        cadence_hint=build_cadence_hint(
+            cadence=tags.get("prompt_cadence", ""),
+            connectors=tags.get("prompt_connectors", ""),
+            register=tags.get("prompt_register", ""),
+        ),
+        beats=beats_text,
+        target_count=target_count,
+        max_chars=max_chars,
+        hook_seconds=hook_seconds,
+    )
+
+    response = llm.client.chat.completions.create(
+        model=llm.model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=settings.script_expand_temperature,
+        max_tokens=settings.script_max_tokens,
+    )
+    raw = response.choices[0].message.content or ""
+    data = extract_json(raw)
+    raw_segments = data.get("segments", [])
+
+    segments = []
+    for item in raw_segments:
+        if isinstance(item, str):
+            segments.append(ScriptSegment(text=item))
+        elif isinstance(item, dict) and "text" in item:
+            segments.append(ScriptSegment(text=item["text"]))
+
+    if not segments:
+        raise ValueError("Phase 2: LLM returned zero segments")
+
+    return segments
+
+
+# ── Main entry point ───────────────────────────────────────
+
+
 def generate_script(ctx: Context) -> Context:
+    """Two-phase script generation: plot beats -> narration expansion -> trim.
+
+    Phase 1 extracts exactly N plot beats (low temperature, structured).
+    Phase 2 expands each beat into one narration line (style tags applied).
+    Fallback trim ensures exactly N segments even if LLM overshoots.
+
+    The retry loop wraps both phases together.  CI mode falls back to
+    mock content (same as v0.4.15).
+    """
     settings = get_settings()
+    target_count = ctx.metadata.get("prompt_target_sentences")
+
     for attempt in range(settings.script_retries):
         try:
             with get_llm_client() as llm:
+                # Determine target sentence count
+                if target_count and isinstance(target_count, int):
+                    n = target_count
+                else:
+                    # No preset active — use legacy range "15-20", pick 18
+                    n = 18
 
-                research_block = ""
-                if ctx.research and ctx.research.summary:
-                    research_block = f"\nResearch context: {ctx.research.summary}\nGenres: {', '.join(ctx.research.genres)}\n"
+                # Phase 1: extract plot beats
+                beats = _generate_plot_beats(ctx, settings, llm, n)
 
-                # Preset-driven prompt shaping (v0.4.15+).
-                # Falls back to v0.4.14 defaults when no preset is active.
-                tags = ctx.metadata.get("narration_preset_tags", {})
-                prompt = SCRIPT_PROMPT.format(
-                    movie=ctx.movie_name,
-                    style=ctx.style,
-                    duration=ctx.duration,
-                    research=research_block,
-                    max_chars=ctx.metadata.get("prompt_max_chars_per_sentence", 15),
-                    target_sentences=ctx.metadata.get("prompt_target_sentences", "15-20"),
-                    hook_seconds=ctx.metadata.get("prompt_hook_seconds", 3),
-                    cadence_hint=build_cadence_hint(
-                        cadence=tags.get("prompt_cadence", ""),
-                        connectors=tags.get("prompt_connectors", ""),
-                        register=tags.get("prompt_register", ""),
-                    ),
-                )
-                response = llm.client.chat.completions.create(
-                    model=llm.model,
-                    messages=[{"role": "user", "content": prompt}],
-                    temperature=settings.script_temperature,
-                    max_tokens=settings.script_max_tokens,
-                )
-                raw = response.choices[0].message.content or ""
-                data = extract_json(raw)
-                raw_segments = data.get("segments", [])
-                segments = []
-                for item in raw_segments:
-                    if isinstance(item, str):
-                        segments.append(ScriptSegment(text=item))
-                    elif isinstance(item, dict) and "text" in item:
-                        segments.append(ScriptSegment(text=item["text"]))
-                if not segments:
-                    raise ValueError("empty script from LLM")
+                # Phase 2: expand beats into narration segments
+                segments = _expand_beats_to_script(ctx, settings, llm, beats, n)
+
+                # Fallback: trim to exactly n if LLM overshot
+                segments = _trim_segments(segments, n)
+
                 ctx.segments = segments
                 ctx.metadata["script_source"] = "llm"
+                ctx.metadata["script_phase"] = "two-phase"
+                ctx.metadata["script_beat_count"] = len(beats)
+                ctx.metadata["script_segment_count"] = len(segments)
                 return ctx
         except Exception as e:
             if attempt == settings.script_retries - 1:
-                # LLM failed after all retries.
+                # All retries exhausted.
                 # In CI: fall back to mock content (with warning) so the
                 # full pipeline can be exercised without an LLM.
                 # In production: hard fail — user must know the script

--- a/src/movie_narrator/utils/prompts.py
+++ b/src/movie_narrator/utils/prompts.py
@@ -24,6 +24,56 @@ Output in JSON format:
 Output ONLY the JSON, no extra text or markdown markers.
 """
 
+# ── Two-phase script generation (v0.4.16+) ─────────────────
+# Phase 1: extract exactly N plot beats (low temperature, structured task)
+# Phase 2: expand each beat into one narration line (style tags applied)
+# This decouples count control from style expression, making
+# prompt_target_sentences actually enforceable.
+
+BEATS_PROMPT = """\
+You are a film story analyst. Extract EXACTLY {target_count} key plot points from the movie "{movie}".
+
+Style: {style}.
+{research}
+Requirements:
+- Each point MUST be one concise sentence summarising a pivotal story moment.
+- Total MUST be exactly {target_count} points — no more, no less.
+- Points should span the full movie arc: opening hook -> rising tension -> climax -> resolution.
+- Arrange in chronological order of the film's plot.
+
+Output ONLY a JSON object:
+{{
+  "beats": ["Point 1", "Point 2", ..., "Point {target_count}"]
+}}
+
+The "beats" array MUST contain exactly {target_count} items.
+"""
+
+EXPAND_PROMPT = """\
+You are a million-follower movie narration blogger. Write a narration script from these plot points for "{movie}" ({duration}s).
+
+Style: {style}.
+{cadence_hint}
+
+Given plot points (one sentence -> exactly one narration line):
+{beats}
+
+Requirements:
+1. Turn EACH plot point into ONE narration sentence — exactly {target_count} segments.
+2. Each sentence <= {max_chars} characters. Keep it punchy and visual.
+3. First {hook_seconds}s worth of sentences MUST hook hard (suspense, surprise, conflict).
+4. Last sentence needs emotional elevation or a thought-provoking punch.
+5. Maintain the given plot order. One input point -> one output segment.
+
+Output ONLY JSON:
+{{
+  "segments": [
+    {{"text": "segment 1"}},
+    ...
+  ]
+}}
+"""
+
 # ── Cadence/register/connector hints for preset-driven prompt shaping ──
 # These are injected into SCRIPT_PROMPT via {cadence_hint}.  Each preset
 # selects one hint per dimension; the combination produces a distinctive

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,7 +1,8 @@
-"""Tests for the generate_script pipeline step.
+"""Tests for the generate_script pipeline step (two-phase v0.4.16+).
 
-Covers: LLM success path, retry-then-hard-fail, research context
-injection, empty-response handling, and script_source metadata.
+Covers: Phase 1 beat extraction, Phase 2 expansion, fallback trim,
+retry/fail behavior, research context injection, CI mock fallback,
+and preset tag propagation.
 """
 
 from unittest.mock import MagicMock, patch
@@ -9,7 +10,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from movie_narrator.models import Context, ResearchInfo, Services, ScriptSegment
-from movie_narrator.pipeline.script import generate_script
+from movie_narrator.pipeline.script import (
+    generate_script,
+    _trim_segments,
+    _generate_plot_beats,
+    _expand_beats_to_script,
+)
 
 
 def _make_ctx(tmp_path, **kw):
@@ -46,121 +52,354 @@ def _mock_llm_cm(response=None, side_effect=None):
     return mock_cm
 
 
-# ── 1. LLM success ──────────────────────────────────────────
+def _mock_settings(**overrides):
+    """Build a mock Settings object with sensible defaults."""
+    s = MagicMock()
+    s.script_retries = overrides.get("script_retries", 3)
+    s.script_retry_delay = overrides.get("script_retry_delay", 0)
+    s.script_temperature = overrides.get("script_temperature", 0.7)
+    s.script_expand_temperature = overrides.get("script_expand_temperature", 0.5)
+    s.script_max_tokens = overrides.get("script_max_tokens", 2048)
+    s.research_temperature = overrides.get("research_temperature", 0.3)
+    s.research_max_tokens = overrides.get("research_max_tokens", 1024)
+    return s
 
 
-def test_generate_script_llm_success(tmp_path):
-    """Valid JSON from LLM → segments set, script_source = 'llm'."""
+def _beats_json(n: int) -> str:
+    """Build a valid Phase 1 response with n beats."""
+    beats = [f"剧情关键点{i+1}" for i in range(n)]
+    return '{"beats": ' + str(beats).replace("'", '"') + '}'
+
+
+def _segments_json(texts: list) -> str:
+    """Build a valid Phase 2 response with segments."""
+    segs = [{"text": t} for t in texts]
+    import json
+    return json.dumps({"segments": segs}, ensure_ascii=False)
+
+
+# ── 1. Two-phase success ────────────────────────────────────
+
+
+def test_generate_script_two_phase_success(tmp_path):
+    """Phase 1 returns N beats, Phase 2 returns N segments → success."""
     ctx = _make_ctx(tmp_path)
-    json_resp = '{"segments": [{"text": "一段精彩的旁白。"}, {"text": "另一段旁白。"}]}'
-    mock_cm = _mock_llm_cm(response=_mock_llm_response(json_resp))
+    ctx.metadata["prompt_target_sentences"] = 5
 
-    with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-        result = generate_script(ctx)
+    beats_resp = _mock_llm_response(_beats_json(5))
+    seg_resp = _mock_llm_response(_segments_json([f"旁白{i}" for i in range(5)]))
+    mock_cm = _mock_llm_cm(side_effect=[beats_resp, seg_resp])
 
-    assert len(result.segments) == 2
-    assert result.segments[0].text == "一段精彩的旁白。"
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+            result = generate_script(ctx)
+
+    assert len(result.segments) == 5
     assert result.metadata["script_source"] == "llm"
+    assert result.metadata["script_phase"] == "two-phase"
+    assert result.metadata["script_beat_count"] == 5
+    assert result.metadata["script_segment_count"] == 5
 
 
-# ── 2. LLM failure → hard fail ─────────────────────────────
+def test_generate_script_no_preset_defaults_to_18(tmp_path):
+    """Without prompt_target_sentences, default target is 18."""
+    ctx = _make_ctx(tmp_path)
+
+    beats_resp = _mock_llm_response(_beats_json(18))
+    seg_resp = _mock_llm_response(_segments_json([f"s{i}" for i in range(18)]))
+    mock_cm = _mock_llm_cm(side_effect=[beats_resp, seg_resp])
+
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+            result = generate_script(ctx)
+
+    assert len(result.segments) == 18
+    # Verify Phase 1 prompt asked for 18 beats
+    mock_llm = mock_cm.__enter__.return_value
+    phase1_call = mock_llm.client.chat.completions.create.call_args_list[0]
+    assert "18" in phase1_call.kwargs["messages"][0]["content"]
+
+
+# ── 2. Fallback trim ────────────────────────────────────────
+
+
+def test_trim_segments_no_trim_when_under_target():
+    """If segments <= target, return as-is."""
+    segs = [ScriptSegment(text=f"s{i}") for i in range(3)]
+    result = _trim_segments(segs, 5)
+    assert len(result) == 3
+    assert result == segs
+
+
+def test_trim_segments_exact_match():
+    """If segments == target, return as-is."""
+    segs = [ScriptSegment(text=f"s{i}") for i in range(5)]
+    result = _trim_segments(segs, 5)
+    assert len(result) == 5
+
+
+def test_trim_segments_trims_to_exact_target():
+    """If segments > target, trim to exactly target."""
+    segs = [ScriptSegment(text=f"s{i}") for i in range(10)]
+    result = _trim_segments(segs, 5)
+    assert len(result) == 5
+
+
+def test_trim_preserves_first_three_hooks():
+    """First 3 segments (hooks) must be preserved during trim."""
+    segs = [ScriptSegment(text=f"hook{i}") for i in range(3)] + \
+           [ScriptSegment(text=f"body{i}") for i in range(7)]
+    result = _trim_segments(segs, 5)
+    assert len(result) == 5
+    # First 3 must be the hooks
+    assert result[0].text == "hook0"
+    assert result[1].text == "hook1"
+    assert result[2].text == "hook2"
+
+
+def test_trim_preserves_chronological_order():
+    """After trim, segments should be in original chronological order."""
+    segs = [ScriptSegment(text=f"s{i:02d}") for i in range(8)]
+    result = _trim_segments(segs, 4)
+    assert len(result) == 4
+    # The result should be a subsequence of the original, in order
+    original_texts = [s.text for s in segs]
+    result_texts = [s.text for s in result]
+    # All result texts must appear in original in the same relative order
+    idx = 0
+    for rt in result_texts:
+        found = original_texts.index(rt, idx)
+        idx = found + 1
+
+
+def test_trim_with_small_target():
+    """target=2 should keep first 2 (hook_count=min(3,2)=2)."""
+    segs = [ScriptSegment(text=f"s{i}") for i in range(6)]
+    result = _trim_segments(segs, 2)
+    assert len(result) == 2
+    assert result[0].text == "s0"
+    assert result[1].text == "s1"
+
+
+# ── 3. Phase 1 beat extraction ─────────────────────────────
+
+
+def test_phase1_wrong_beat_count_raises(tmp_path):
+    """Phase 1 returning wrong number of beats → ValueError."""
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["prompt_target_sentences"] = 8
+
+    # LLM returns 5 beats but we asked for 8
+    beats_resp = _mock_llm_response(_beats_json(5))
+    mock_cm = _mock_llm_cm(response=beats_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with pytest.raises(ValueError, match="expected 8 beats, got 5"):
+            _generate_plot_beats(ctx, _mock_settings(), mock_llm, 8)
+
+
+def test_phase1_zero_beats_raises(tmp_path):
+    """Phase 1 returning zero beats → ValueError."""
+    ctx = _make_ctx(tmp_path)
+    beats_resp = _mock_llm_response('{"beats": []}')
+    mock_cm = _mock_llm_cm(response=beats_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    with pytest.raises(ValueError, match="zero beats"):
+        _generate_plot_beats(ctx, _mock_settings(), mock_llm, 5)
+
+
+def test_phase1_includes_research_context(tmp_path):
+    """Research summary should appear in Phase 1 prompt."""
+    ctx = _make_ctx(tmp_path)
+    ctx.research = ResearchInfo(
+        title="测试电影", year="2024", summary="一部关于勇气的电影",
+        genres=["动作"], cast=["演员A"], keywords=["勇气"],
+    )
+    beats_resp = _mock_llm_response(_beats_json(3))
+    mock_cm = _mock_llm_cm(response=beats_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    _generate_plot_beats(ctx, _mock_settings(), mock_llm, 3)
+    call_args = mock_llm.client.chat.completions.create.call_args
+    prompt = call_args.kwargs["messages"][0]["content"]
+    assert "一部关于勇气的电影" in prompt
+
+
+def test_phase1_uses_low_temperature(tmp_path):
+    """Phase 1 should use research_temperature (0.3), not script_temperature."""
+    ctx = _make_ctx(tmp_path)
+    beats_resp = _mock_llm_response(_beats_json(3))
+    mock_cm = _mock_llm_cm(response=beats_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    settings = _mock_settings()
+    _generate_plot_beats(ctx, settings, mock_llm, 3)
+    call_args = mock_llm.client.chat.completions.create.call_args
+    assert call_args.kwargs["temperature"] == 0.3
+
+
+# ── 4. Phase 2 beat expansion ───────────────────────────────
+
+
+def test_phase2_returns_segments(tmp_path):
+    """Phase 2 expands beats into segments."""
+    ctx = _make_ctx(tmp_path)
+    beats = ["关键点1", "关键点2", "关键点3"]
+    seg_resp = _mock_llm_response(_segments_json(["旁白1", "旁白2", "旁白3"]))
+    mock_cm = _mock_llm_cm(response=seg_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    segments = _expand_beats_to_script(ctx, _mock_settings(), mock_llm, beats, 3)
+    assert len(segments) == 3
+    assert segments[0].text == "旁白1"
+
+
+def test_phase2_uses_expand_temperature(tmp_path):
+    """Phase 2 should use script_expand_temperature (0.5)."""
+    ctx = _make_ctx(tmp_path)
+    beats = ["b1", "b2"]
+    seg_resp = _mock_llm_response(_segments_json(["s1", "s2"]))
+    mock_cm = _mock_llm_cm(response=seg_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    settings = _mock_settings()
+    _expand_beats_to_script(ctx, settings, mock_llm, beats, 2)
+    call_args = mock_llm.client.chat.completions.create.call_args
+    assert call_args.kwargs["temperature"] == 0.5
+
+
+def test_phase2_zero_segments_raises(tmp_path):
+    """Phase 2 returning zero segments → ValueError."""
+    ctx = _make_ctx(tmp_path)
+    beats = ["b1", "b2"]
+    seg_resp = _mock_llm_response('{"segments": []}')
+    mock_cm = _mock_llm_cm(response=seg_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    with pytest.raises(ValueError, match="zero segments"):
+        _expand_beats_to_script(ctx, _mock_settings(), mock_llm, beats, 2)
+
+
+def test_phase2_preset_tags_in_prompt(tmp_path):
+    """Preset tags should appear in Phase 2 prompt via cadence_hint."""
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["narration_preset_tags"] = {
+        "prompt_cadence": "brisk",
+        "prompt_connectors": "interjection",
+        "prompt_register": "spoken",
+    }
+    beats = ["b1"]
+    seg_resp = _mock_llm_response(_segments_json(["s1"]))
+    mock_cm = _mock_llm_cm(response=seg_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    _expand_beats_to_script(ctx, _mock_settings(), mock_llm, beats, 1)
+    call_args = mock_llm.client.chat.completions.create.call_args
+    prompt = call_args.kwargs["messages"][0]["content"]
+    assert "brisk" in prompt
+    assert "spoken" in prompt
+
+
+def test_phase2_beats_formatted_as_numbered_list(tmp_path):
+    """Beats should be formatted as a numbered list in the prompt."""
+    ctx = _make_ctx(tmp_path)
+    beats = ["第一点", "第二点", "第三点"]
+    seg_resp = _mock_llm_response(_segments_json(["s1", "s2", "s3"]))
+    mock_cm = _mock_llm_cm(response=seg_resp)
+    mock_llm = mock_cm.__enter__.return_value
+
+    _expand_beats_to_script(ctx, _mock_settings(), mock_llm, beats, 3)
+    call_args = mock_llm.client.chat.completions.create.call_args
+    prompt = call_args.kwargs["messages"][0]["content"]
+    assert "1. 第一点" in prompt
+    assert "2. 第二点" in prompt
+    assert "3. 第三点" in prompt
+
+
+# ── 5. End-to-end with trim ─────────────────────────────────
+
+
+def test_generate_script_trims_overshoot(tmp_path):
+    """Phase 2 returns more segments than target → trim to exact."""
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["prompt_target_sentences"] = 5
+
+    beats_resp = _mock_llm_response(_beats_json(5))
+    # Phase 2 returns 8 segments but target is 5
+    seg_resp = _mock_llm_response(_segments_json([f"s{i}" for i in range(8)]))
+    mock_cm = _mock_llm_cm(side_effect=[beats_resp, seg_resp])
+
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+            result = generate_script(ctx)
+
+    assert len(result.segments) == 5
+    assert result.metadata["script_segment_count"] == 5
+
+
+# ── 6. Retry behavior ───────────────────────────────────────
 
 
 def test_generate_script_hard_fails_on_all_retries(tmp_path, monkeypatch):
-    """3 consecutive LLM failures → RuntimeError (no fake mock fallback)."""
+    """3 consecutive failures → RuntimeError (no mock fallback)."""
     monkeypatch.delenv("CI", raising=False)
     ctx = _make_ctx(tmp_path)
-    mock_cm = _mock_llm_cm(side_effect=ConnectionError("unreachable"))
+    ctx.metadata["prompt_target_sentences"] = 3
 
-    with patch("movie_narrator.pipeline.script.is_ci", return_value=False):
-        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-            with patch("movie_narrator.pipeline.script.sleep", return_value=None):
-                with pytest.raises(RuntimeError, match="LLM script generation failed"):
-                    generate_script(ctx)
-
-
-# ── 3. Research context injection ───────────────────────────
-
-
-def test_generate_script_includes_research_context(tmp_path):
-    """When ctx.research has a summary, it should be included in the prompt."""
-    ctx = _make_ctx(tmp_path)
-    ctx.research = ResearchInfo(
-        title="测试电影",
-        year="2024",
-        summary="一部关于勇气的电影",
-        genres=["动作"],
-        cast=["演员A"],
-        keywords=["勇气"],
-    )
-    json_resp = '{"segments": [{"text": "旁白"}]}'
-    mock_cm = _mock_llm_cm(response=_mock_llm_response(json_resp))
-
-    with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm) as m:
-        generate_script(ctx)
-        # Verify the LLM was called
-        mock_llm = mock_cm.__enter__.return_value
-        call_args = mock_llm.client.chat.completions.create.call_args
-        prompt_content = call_args.kwargs["messages"][0]["content"]
-        assert "一部关于勇气的电影" in prompt_content
-
-
-def test_generate_script_without_research_context(tmp_path):
-    """When ctx.research is empty, no research block is added to prompt."""
-    ctx = _make_ctx(tmp_path)
-    json_resp = '{"segments": [{"text": "旁白"}]}'
-    mock_cm = _mock_llm_cm(response=_mock_llm_response(json_resp))
-
-    with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-        generate_script(ctx)
-        mock_llm = mock_cm.__enter__.return_value
-        call_args = mock_llm.client.chat.completions.create.call_args
-        prompt_content = call_args.kwargs["messages"][0]["content"]
-        assert "Research context" not in prompt_content
-
-
-# ── 4. Empty segments triggers retry → hard fail ───────────
-
-
-def test_generate_script_empty_segments_triggers_retry(tmp_path, monkeypatch):
-    """LLM returns empty segments → ValueError → retry → eventually hard fail."""
-    monkeypatch.delenv("CI", raising=False)  # ensure not in CI mode
-    ctx = _make_ctx(tmp_path)
-    empty_resp = _mock_llm_response('{"segments": []}')
     mock_cm = _mock_llm_cm(side_effect=[
-        empty_resp,
-        empty_resp,
-        empty_resp,
+        ConnectionError("unreachable"),  # attempt 1 Phase 1
+        ConnectionError("unreachable"),  # attempt 2 Phase 1
+        ConnectionError("unreachable"),  # attempt 3 Phase 1
     ])
 
     with patch("movie_narrator.pipeline.script.is_ci", return_value=False):
-        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-            with patch("movie_narrator.pipeline.script.sleep", return_value=None):
+        with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+            with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
                 with pytest.raises(RuntimeError, match="LLM script generation failed"):
                     generate_script(ctx)
-
-
-# ── 5. Retry succeeds on second attempt ─────────────────────
 
 
 def test_generate_script_retry_succeeds(tmp_path):
-    """First attempt fails, second succeeds → script_source = 'llm'."""
+    """First attempt fails, second succeeds."""
     ctx = _make_ctx(tmp_path)
-    good_resp = _mock_llm_response('{"segments": [{"text": "成功的旁白"}]}')
+    ctx.metadata["prompt_target_sentences"] = 3
+
+    beats_resp = _mock_llm_response(_beats_json(3))
+    seg_resp = _mock_llm_response(_segments_json(["s1", "s2", "s3"]))
     mock_cm = _mock_llm_cm(side_effect=[
-        ConnectionError("timeout"),
-        good_resp,
+        ConnectionError("timeout"),  # attempt 1 Phase 1 fails
+        beats_resp,                   # attempt 2 Phase 1
+        seg_resp,                     # attempt 2 Phase 2
     ])
 
-    with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-        with patch("movie_narrator.pipeline.script.sleep", return_value=None):
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
             result = generate_script(ctx)
 
     assert result.metadata["script_source"] == "llm"
-    assert result.segments[0].text == "成功的旁白"
+    assert len(result.segments) == 3
 
 
-# ── 6. CI mode mock fallback ────────────────────────────────
+def test_generate_script_phase1_count_mismatch_triggers_retry(tmp_path, monkeypatch):
+    """Phase 1 returns wrong count → retry → eventually hard fail."""
+    monkeypatch.delenv("CI", raising=False)
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["prompt_target_sentences"] = 8
+
+    # All 3 attempts: Phase 1 returns wrong count
+    wrong_resp = _mock_llm_response(_beats_json(5))
+    mock_cm = _mock_llm_cm(side_effect=[wrong_resp, wrong_resp, wrong_resp])
+
+    with patch("movie_narrator.pipeline.script.is_ci", return_value=False):
+        with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+            with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+                with pytest.raises(RuntimeError, match="LLM script generation failed"):
+                    generate_script(ctx)
+
+
+# ── 7. CI mode mock fallback ────────────────────────────────
 
 
 def test_generate_script_ci_mock_fallback(tmp_path, monkeypatch):
@@ -169,16 +408,15 @@ def test_generate_script_ci_mock_fallback(tmp_path, monkeypatch):
     mock_cm = _mock_llm_cm(side_effect=ConnectionError("unreachable"))
 
     with patch("movie_narrator.pipeline.script.is_ci", return_value=True):
-        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-            with patch("movie_narrator.pipeline.script.sleep", return_value=None):
-                result = generate_script(ctx)
+        with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+            with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+                with patch("movie_narrator.pipeline.script.sleep", return_value=None):
+                    result = generate_script(ctx)
 
     assert result.metadata["script_source"] == "ci_mock"
     assert result.metadata["script_degraded"] is True
     assert len(result.segments) == 4
-    # Mock text should contain movie name
     assert "test_movie" in result.segments[0].text
-    # inline_warn should have been called
     ctx.services.console.inline_warn.assert_called()
 
 
@@ -189,7 +427,35 @@ def test_generate_script_ci_mock_not_used_in_production(tmp_path, monkeypatch):
     mock_cm = _mock_llm_cm(side_effect=ConnectionError("unreachable"))
 
     with patch("movie_narrator.pipeline.script.is_ci", return_value=False):
-        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
-            with patch("movie_narrator.pipeline.script.sleep", return_value=None):
+        with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+            with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
                 with pytest.raises(RuntimeError, match="LLM script generation failed"):
                     generate_script(ctx)
+
+
+# ── 8. Research context propagation ─────────────────────────
+
+
+def test_generate_script_research_in_phase1(tmp_path):
+    """Research context should appear in Phase 1 prompt, not Phase 2."""
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["prompt_target_sentences"] = 3
+    ctx.research = ResearchInfo(
+        title="测试电影", year="2024", summary="一部关于勇气的电影",
+        genres=["动作"], cast=["演员A"], keywords=["勇气"],
+    )
+
+    beats_resp = _mock_llm_response(_beats_json(3))
+    seg_resp = _mock_llm_response(_segments_json(["s1", "s2", "s3"]))
+    mock_cm = _mock_llm_cm(side_effect=[beats_resp, seg_resp])
+
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+            generate_script(ctx)
+
+    mock_llm = mock_cm.__enter__.return_value
+    calls = mock_llm.client.chat.completions.create.call_args_list
+    phase1_prompt = calls[0].kwargs["messages"][0]["content"]
+    phase2_prompt = calls[1].kwargs["messages"][0]["content"]
+    assert "一部关于勇气的电影" in phase1_prompt
+    assert "一部关于勇气的电影" not in phase2_prompt


### PR DESCRIPTION
Decouples count control from style expression by splitting script generation into two LLM calls:

**Phase 1**: Extract EXACTLY N plot beats at low temperature (0.3). Structured extraction with strict count validation.
**Phase 2**: Expand each beat into one narration segment at moderate temperature (0.5). Style tags applied here.
**Fallback trim**: If Phase 2 overshoots, trim to exact N. Preserves hooks, selects by median length.

Fixes the known limitation from v0.4.15: LLM was ignoring prompt_target_sentences (12/8 targets → always 18). Two-phase makes count enforceable.

24 tests, 391 passed total, 2 pre-existing TTS .env failures.