### PR TITLE
release: v0.4.16 — two-phase script gen, CLI/config improvements, resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.16] - 2026-07-17
+
+### Added (Two-phase script generation + CLI/Config improvements)
+- **Two-phase script generation**: `generate_script()` now splits into Phase 1 (plot beat extraction at low temperature) + Phase 2 (beat expansion at moderate temperature) + fallback trim. Decouples count control from style expression, making `prompt_target_sentences` actually enforceable.
+- **First-run config notice**: `ensure_user_config()` now prints a one-time informational message to stderr when creating `~/.movie-narrator/.env`, telling the user which fields to edit. Non-interactive (no prompt), CI mode skips the notice.
+- **CLI help improvements**: `no_args_is_help=True` (bare `mn` now shows help instead of "Missing command"), `rich_markup_mode="rich"` for colored output, all 9 commands now have bilingual (中文/English) help text and docstrings.
+- **`-h` conflict resolved**: `web` command's `--host` no longer binds `-h` short option, freeing `-h` for `--help` across all commands.
+- New config field: `script_expand_temperature=0.5` (Phase 2 temperature, separate from `script_temperature=0.7`).
+
+### Fixed
+- **Phase 1 None silent conversion**: `str(None)="None"` was truthy and passed filtering, producing meaningless "None" beats. Now explicitly filters None/empty/"None" strings.
+- **Phase 2 empty text segments**: Whitespace-only segments were accepted, would produce silent TTS audio. Now strips and filters.
+- **Retry failure debug logging**: Last error now logged via `console.debug()` before raising RuntimeError.
+
+### Changed
+- `prompts.py`: Added `BEATS_PROMPT` (Phase 1) and `EXPAND_PROMPT` (Phase 2). `SCRIPT_PROMPT` retained for backward reference.
+- `config.py`: `research_retries=3` + `research_retry_delay=1.5` (Research step now retries, matching script.py pattern).
+- `pipeline/runner.py`: `SOFT_STEP_CONSEQUENCES` map — soft-step failures now append human-readable consequence messages. Pipeline-end degradation summary warns about reduced quality.
+- `pipeline/tts.py`: Per-segment TTS retry (3 attempts, 1s delay) — single network hiccup no longer kills entire batch.
+
 ## [0.4.15] - 2026-07-17
 
 ### Added (Narration preset system — Stage 0.5)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,8 +150,21 @@ The Web UI is rebuilt from a Gradio single-file app into a decoupled **FastAPI +
 - [x] Prompt shaping via closed-vocabulary tags (cadence / register / connectors)
 - [x] Single-source `PARAM_WHITELIST` frozenset (runner.py) — eliminates dual-maintained whitelist
 - [x] Hand-test verified: prompt tags produce perceptible style differences
-- [ ] Known limitation: `prompt_target_sentences` constraint weak (LLM ignores 12/8 targets) — planned fix: stronger prompt + post-processing truncation
+- [x] Known limitation fixed in v0.4.16: two-phase generation enforces `prompt_target_sentences`
 - [ ] Stage 2 (future): SPI discover via `entry_points` + opt-in local folder scan
+
+### v0.4.16 Two-Phase Script Generation + CLI/Config Improvements
+
+- [x] Two-phase script generation: Phase 1 (plot beats, low temp) → Phase 2 (expansion, moderate temp) → fallback trim
+- [x] `prompt_target_sentences` now enforceable (was ignored by LLM in v0.4.15)
+- [x] First-run config notice: `ensure_user_config()` prints one-time message to stderr
+- [x] CLI help: `no_args_is_help=True`, `rich_markup_mode="rich"`, bilingual (中文/English) help
+- [x] `-h` conflict resolved (web command `--host` no longer binds `-h`)
+- [x] Phase 1 None/empty beat filtering + Phase 2 empty text filtering
+- [x] TTS per-segment retry (3 attempts) — single failure no longer kills batch
+- [x] Research step retry (was zero retry, now matches script.py pattern)
+- [x] Degradation warnings: `SOFT_STEP_CONSEQUENCES` + pipeline-end summary
+- [x] Retry failure debug logging
 
 ### v0.4 Environment variables
 

--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -59,6 +59,7 @@ subtitle_mode: original     # original | translated | bilingual
 #   mainstream-dry   12句×5s, 慢切镜, 轻音乐 (-15dB), 从容叙事 (谷阿莫节奏)
 #   bilibili-long    8句×7.5s, 大场景合并, 极轻BGM (-18dB), 书面长解说
 # 留空 = douyin-fast（向后兼容 v0.4.14 行为）
+# v0.4.16+: 两阶段生成确保 prompt_target_sentences 被严格遵守
 narration_preset: ""        # douyin-fast | mainstream-dry | bilibili-long
 
 # ============================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.4.15"
+version = "0.4.16"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = {text = "AGPL-3.0"}

--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -11,7 +11,11 @@ from .pipeline.resolve import resolve_video
 from .pipeline.research import research_plot
 from .pipeline.runner import build_context, run_pipeline
 
-app = typer.Typer(help="Generate narrated movie recap videos from a single prompt.")
+app = typer.Typer(
+    help="Movie Narrator — 从一个提示词生成解说短视频 / Generate narrated movie recap videos from a single prompt.",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
 
 # Packaged example YAML — used as fallback when no --config and no cwd/job.yaml.
 _EXAMPLE_YAML = Path(__file__).resolve().parent.parent.parent / "examples" / "job.example.yaml"
@@ -58,33 +62,45 @@ from .utils.sanitize import sanitize_filename as _sanitize_filename
 
 @app.command()
 def create(
-    movie: Optional[str] = typer.Option(None, "--movie", "-m", help="Movie name"),
-    style: str = typer.Option("热血搞笑", "--style", "-s", help="Narration style"),
-    duration: int = typer.Option(60, "--duration", "-d", help="Target duration (seconds)"),
-    voice: Optional[str] = typer.Option(None, "--voice", "-v", help="TTS voice (Edge TTS)"),
-    format: str = typer.Option("16:9", "--format", "-f", help="Video format: 16:9 or 9:16"),
-    keep_cache: bool = typer.Option(False, "--keep-cache", help="Keep TTS cache files"),
-    video: Optional[str] = typer.Option(None, "--video", help="Source movie file path"),
-    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="Movie library directory"),
-    research: Optional[bool] = typer.Option(None, "--research/--no-research", help="Enable plot research"),
-    bgm: Optional[str] = typer.Option(None, "--bgm", help="Background music file"),
-    no_bgm: bool = typer.Option(False, "--no-bgm", help="Disable BGM even if default set"),
-    no_clips: bool = typer.Option(False, "--no-clips", help="Skip clips/export"),
-    strict: bool = typer.Option(False, "--strict", help="Abort on soft step failure"),
-    retry: bool = typer.Option(False, "--retry", help="Enable interactive retry on hard step failure"),
-    config: Optional[str] = typer.Option(None, "--config", help="Path to job YAML config"),
+    movie: Optional[str] = typer.Option(None, "--movie", "-m", help="电影名称 / Movie name"),
+    style: str = typer.Option("热血搞笑", "--style", "-s", help="解说风格 / Narration style"),
+    duration: int = typer.Option(60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"),
+    voice: Optional[str] = typer.Option(None, "--voice", "-v", help="TTS 语音 / TTS voice (Edge TTS)"),
+    format: str = typer.Option("16:9", "--format", "-f", help="视频格式 16:9 或 9:16 / Video format: 16:9 or 9:16"),
+    keep_cache: bool = typer.Option(False, "--keep-cache", help="保留 TTS 缓存 / Keep TTS cache files"),
+    video: Optional[str] = typer.Option(None, "--video", help="源视频文件路径 / Source movie file path"),
+    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library directory"),
+    research: Optional[bool] = typer.Option(None, "--research/--no-research", help="启用剧情研究 / Enable plot research"),
+    bgm: Optional[str] = typer.Option(None, "--bgm", help="背景音乐文件 / Background music file"),
+    no_bgm: bool = typer.Option(False, "--no-bgm", help="禁用 BGM / Disable BGM even if default set"),
+    no_clips: bool = typer.Option(False, "--no-clips", help="跳过片段导出 / Skip clips/export"),
+    strict: bool = typer.Option(False, "--strict", help="软步骤失败即中止 / Abort on soft step failure"),
+    retry: bool = typer.Option(False, "--retry", help="硬步骤失败时交互重试 / Enable interactive retry on hard step failure"),
+    config: Optional[str] = typer.Option(None, "--config", help="job YAML 配置路径 / Path to job YAML config"),
     # Multi-language subtitle (v0.3).
     subtitle_lang: Optional[str] = typer.Option(
-        None, "--subtitle-lang", help="Target language tag (e.g. en, ja, zh-TW); empty = feature off",
+        None, "--subtitle-lang", help="目标语言标签(如 en, ja, zh-TW) / Target language tag; empty = off",
     ),
     subtitle_mode: Optional[str] = typer.Option(
-        None, "--subtitle-mode", help="Overlay mode: original|translated|bilingual",
+        None, "--subtitle-mode", help="字幕模式 original|translated|bilingual / Overlay mode",
     ),
     narration_preset: Optional[str] = typer.Option(
         None, "--narration-preset", "-p",
-        help="Narration style preset: douyin-fast (default) | mainstream-dry | bilibili-long",
+        help="解说风格预设 douyin-fast | mainstream-dry | bilibili-long / Narration style preset",
     ),
 ):
+    """生成解说短视频 — 从电影名到成片一站式产出.
+
+    \b
+    快速开始 / Quick start:
+        mn create -m 满江红 -p douyin-fast
+        mn create -m 满江红 -p mainstream-dry --bgm music.mp3
+        mn create --config job.yaml
+
+    \b
+    查看可用预设 / List available presets:
+        mn preset
+    """
     from .config import get_settings
     from .workflow import JobConfigError, load_job_config, merge_job
 
@@ -204,11 +220,11 @@ def create(
 
 @app.command()
 def resolve(
-    movie: str = typer.Option(..., "--movie", "-m", help="Movie name to resolve"),
-    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="Movie library directory"),
-    json_output: bool = typer.Option(False, "--json", help="Output result as JSON"),
+    movie: str = typer.Option(..., "--movie", "-m", help="电影名称 / Movie name to resolve"),
+    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library directory"),
+    json_output: bool = typer.Option(False, "--json", help="JSON 格式输出 / Output result as JSON"),
 ):
-    """Resolve a movie from library directory."""
+    """从影视库中查找电影 / Resolve a movie from library directory."""
     output_dir = Path("output") / _sanitize_filename(movie)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -230,9 +246,9 @@ def resolve(
 
 @app.command()
 def research(
-    movie: str = typer.Option(..., "--movie", "-m", help="Movie name to research"),
+    movie: str = typer.Option(..., "--movie", "-m", help="电影名称 / Movie name to research"),
 ):
-    """Run plot research and write research.json to output/<movie>/."""
+    """运行剧情研究并输出 research.json / Run plot research."""
     output_dir = Path("output") / _sanitize_filename(movie)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -252,11 +268,11 @@ def research(
 
 @app.command()
 def scenes(
-    video: str = typer.Option(..., "--video", help="Video file path"),
-    threshold: float = typer.Option(27.0, "--threshold", help="Scene detection threshold"),
-    output: Optional[str] = typer.Option(None, "--output", help="Output directory"),
+    video: str = typer.Option(..., "--video", help="视频文件路径 / Video file path"),
+    threshold: float = typer.Option(27.0, "--threshold", help="场景检测阈值 / Scene detection threshold"),
+    output: Optional[str] = typer.Option(None, "--output", help="输出目录 / Output directory"),
 ):
-    """Detect scenes in a video file."""
+    """检测视频中的场景 / Detect scenes in a video file."""
     from movie_narrator.pipeline.scenes import detect_scenes
     from movie_narrator.models import Context
     out = Path(output) if output else Path("output") / "scenes_debug"
@@ -280,11 +296,11 @@ def scenes(
 
 @app.command()
 def align(
-    audio: str = typer.Option(..., "--audio", help="Audio file path"),
-    script: Optional[str] = typer.Option(None, "--script", help="Script text file (one per line)"),
-    output: Optional[str] = typer.Option(None, "--output", help="Output directory"),
+    audio: str = typer.Option(..., "--audio", help="音频文件路径 / Audio file path"),
+    script: Optional[str] = typer.Option(None, "--script", help="脚本文本文件(每行一句) / Script text file"),
+    output: Optional[str] = typer.Option(None, "--output", help="输出目录 / Output directory"),
 ):
-    """Align audio with script using WhisperX."""
+    """使用 WhisperX 对齐音频与脚本 / Align audio with script using WhisperX."""
     from movie_narrator.pipeline.align import align_audio
     from movie_narrator.models import Context, TimedSegment
     out = Path(output) if output else Path("output") / "align_debug"
@@ -314,11 +330,11 @@ def align(
 
 @app.command()
 def clips(
-    video: str = typer.Option(..., "--video", help="Source video path"),
-    scenes_path: str = typer.Option(..., "--scenes", help="scenes.json path"),
-    output: Optional[str] = typer.Option(None, "--output", help="Output directory"),
+    video: str = typer.Option(..., "--video", help="源视频路径 / Source video path"),
+    scenes_path: str = typer.Option(..., "--scenes", help="scenes.json 路径 / scenes.json path"),
+    output: Optional[str] = typer.Option(None, "--output", help="输出目录 / Output directory"),
 ):
-    """Export clips from scenes.json."""
+    """从 scenes.json 导出片段 / Export clips from scenes.json."""
     from movie_narrator.pipeline.export_clips import export_clips
     from movie_narrator.models import Context, Scene
     import json
@@ -346,22 +362,22 @@ def clips(
 
 @app.command()
 def version():
-    """Show version."""
+    """显示版本号 / Show version."""
     typer.echo(f"movie-narrator v{__version__}")
 
 
 @app.command()
 def preset(
     name: Optional[str] = typer.Argument(
-        None, help="Preset name to show details for (omitted = list all)"
+        None, help="预设名称(省略则列出全部) / Preset name (omitted = list all)"
     ),
 ):
-    """List narration presets or show details for a specific preset.
+    """列出解说预设或查看指定预设详情 / List presets or show details.
 
     \b
-    Examples:
-        mn preset                  # list all available presets
-        mn preset mainstream-dry   # show params + tags for mainstream-dry
+    示例 / Examples:
+        mn preset                  # 列出所有可用预设
+        mn preset mainstream-dry   # 查看 mainstream-dry 的参数和标签
     """
     from .presets import get_preset, list_presets
 
@@ -400,10 +416,10 @@ def preset(
 
 @app.command()
 def web(
-    host: str = typer.Option("127.0.0.1", "--host", "-h", help="Bind host"),
-    port: int = typer.Option(8760, "--port", "-p", help="Bind port"),
-    reload: bool = typer.Option(False, "--reload", help="Auto-reload on file changes"),
+    host: str = typer.Option("127.0.0.1", "--host", help="绑定地址 / Bind host"),
+    port: int = typer.Option(8760, "--port", help="绑定端口 / Bind port"),
+    reload: bool = typer.Option(False, "--reload", help="文件变更时自动重载 / Auto-reload on file changes"),
 ):
-    """Launch the Web UI (FastAPI + React)."""
+    """启动 Web UI (FastAPI + React) / Launch the Web UI."""
     from .web_api import launch_web_api
     launch_web_api(host=host, port=port, reload=reload)

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -43,12 +43,17 @@ def ensure_user_config() -> Path:
     Returns the path to the user-level .env (existing or newly created).
     Safe to call multiple times — never overwrites an existing file.
 
+    On first creation, prints a one-time informational message to stderr
+    telling the user where the config was created and which fields to edit.
+    This is non-interactive (no prompt) so the CLI remains scriptable.
+
     Write is atomic (temp file + ``os.replace``) to prevent partial writes
     if the process is interrupted mid-write (TOCTOU safe).
     """
     if not _USER_ENV.exists():
         import os
         import tempfile
+        import sys
 
         _USER_DIR.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(dir=_USER_DIR, suffix=".env.tmp")
@@ -62,7 +67,29 @@ def ensure_user_config() -> Path:
             except OSError:
                 pass
             raise
+
+        # One-time first-run notice (non-interactive, goes to stderr
+        # so it doesn't pollute stdout in piped workflows).
+        _print_first_run_notice(_USER_ENV)
     return _USER_ENV
+
+
+def _print_first_run_notice(env_path: Path) -> None:
+    """Print a one-time message when the config file is first created."""
+    # CI mode: skip the notice entirely (CI runs don't need it).
+    if os.getenv("CI"):
+        return
+    print(
+        f"\n[movie-narrator] 首次运行：已创建配置文件\n"
+        f"  路径: {env_path}\n"
+        f"  请编辑此文件，填入你的 LLM 和 TTS 配置：\n"
+        f"    MN_LLM_BASE_URL  — LLM API 地址 (如 http://localhost:11434/v1)\n"
+        f"    MN_LLM_API_KEY   — LLM API 密钥\n"
+        f"    MN_LLM_MODEL     — LLM 模型名称\n"
+        f"    MN_DEFAULT_VOICE — TTS 语音 (如 zh-CN-YunxiNeural)\n"
+        f"  配置完成后重新运行即可。\n",
+        file=sys.stderr,
+    )
 
 
 class TTSProviderType(str, Enum):


### PR DESCRIPTION
Version bump 0.4.15 -> 0.4.16. Bundles:

1. Two-phase script generation (beats -> expansion -> trim)
2. CLI help: no_args_is_help, rich markup, bilingual help, -h conflict resolved
3. First-run config notice (non-interactive, stderr, CI-skipped)
4. TTS per-segment retry + Research retry + degradation warnings
5. Phase 1 None/empty beat filtering + Phase 2 empty text filtering

Docs: CHANGELOG, ROADMAP, CLAUDE.md, job.example.yaml all updated.
398 passed, 2 pre-existing TTS .env failures, 11 skipped.