### PR TITLE
feat: dynamic sentence count by duration (方案 B)

### DIFF
--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -48,7 +48,7 @@ PARAM_WHITELIST: frozenset[str] = frozenset({
     "render_subtitle_position", "render_subtitle_max_width_ratio",
     "render_subtitle_bottom_margin_ratio",
     "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
-    "prompt_target_sentences", "prompt_max_chars_per_sentence", "prompt_hook_seconds",
+    "prompt_target_sentences", "prompt_target_segment_duration", "prompt_max_chars_per_sentence", "prompt_hook_seconds",
     "async_timeout", "async_max_workers",
     "video_sizes",
 })

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -194,16 +194,29 @@ def generate_script(ctx: Context) -> Context:
     mock content (same as v0.4.15).
     """
     settings = get_settings()
-    target_count = ctx.metadata.get("prompt_target_sentences")
+    base_count = ctx.metadata.get("prompt_target_sentences")
+    seg_duration = ctx.metadata.get("prompt_target_segment_duration")
 
     for attempt in range(settings.script_retries):
         try:
             with get_llm_client() as llm:
-                # Determine target sentence count
-                if target_count and isinstance(target_count, int):
-                    n = target_count
+                # Determine target sentence count.
+                # If preset defines target_segment_duration, compute count
+                # dynamically from the actual target duration so that
+                # longer videos get more sentences (not longer sentences).
+                # This keeps per-sentence length natural (19-25 chars)
+                # regardless of total video duration.
+                #
+                # Example: bilibili-long (seg_duration=7.5s)
+                #   60s  → 8 sentences  (7.5s each)
+                #   90s  → 12 sentences (7.5s each)
+                #   120s → 16 sentences (7.5s each)
+                if seg_duration and isinstance(seg_duration, (int, float)) and seg_duration > 0:
+                    n = max(1, round(ctx.duration / seg_duration))
+                elif base_count and isinstance(base_count, int):
+                    n = base_count
                 else:
-                    # No preset active — use legacy range "15-20", pick 18
+                    # No preset active — use legacy default
                     n = 18
 
                 # Phase 1: extract plot beats

--- a/src/movie_narrator/presets/base.py
+++ b/src/movie_narrator/presets/base.py
@@ -61,6 +61,7 @@ ALLOWED_PARAM_KEYS: frozenset[str] = frozenset({
     "qa_max_duration_ratio",
     # Prompt shaping (new — added to whitelist in schema/load/runner)
     "prompt_target_sentences",
+    "prompt_target_segment_duration",
     "prompt_max_chars_per_sentence",
     "prompt_hook_seconds",
 })

--- a/src/movie_narrator/presets/bilibili_long.py
+++ b/src/movie_narrator/presets/bilibili_long.py
@@ -28,9 +28,11 @@ class BilibiliLongPreset:
             "render_font_size": 75,
             # TTS: 长停顿,留白
             "tts_pause_ms": 300,
-            # Prompt: 8 句×~7.5s
+            # Prompt: 8 句×~7.5s (60s 基准), max_chars 按字速 3.8 字/s 计算
+            # 7.5s × 3.8 = 28.5 字, max_chars=32 留 12% 余量
             "prompt_target_sentences": 8,
-            "prompt_max_chars_per_sentence": 22,
+            "prompt_target_segment_duration": 7.5,
+            "prompt_max_chars_per_sentence": 32,
             "prompt_hook_seconds": 7,
         }
 

--- a/src/movie_narrator/presets/douyin_fast.py
+++ b/src/movie_narrator/presets/douyin_fast.py
@@ -28,8 +28,9 @@ class DouyinFastPreset:
             "render_font_size": 100,
             # TTS: 紧凑停顿
             "tts_pause_ms": 150,
-            # Prompt: 18 句×~3.3s
+            # Prompt: 18 句×~3.3s (60s 基准), max_chars 按字速 3.8 字/s 计算
             "prompt_target_sentences": 18,
+            "prompt_target_segment_duration": 3.3,
             "prompt_max_chars_per_sentence": 15,
             "prompt_hook_seconds": 3,
         }

--- a/src/movie_narrator/presets/mainstream_dry.py
+++ b/src/movie_narrator/presets/mainstream_dry.py
@@ -28,9 +28,11 @@ class MainstreamDryPreset:
             "render_font_size": 90,
             # TTS: 留呼吸
             "tts_pause_ms": 200,
-            # Prompt: 12 句×~5s
+            # Prompt: 12 句×~5s (60s 基准), max_chars 按字速 3.8 字/s 计算
+            # 5.0s × 3.8 = 19.0 字, max_chars=22 留 16% 余量
             "prompt_target_sentences": 12,
-            "prompt_max_chars_per_sentence": 18,
+            "prompt_target_segment_duration": 5.0,
+            "prompt_max_chars_per_sentence": 22,
             "prompt_hook_seconds": 5,
         }
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -730,3 +730,90 @@ def test_no_preset_defaults_to_18_sentences(tmp_path):
 
     assert len(result.segments) == 18
     assert result.metadata["script_segment_count"] == 18
+
+
+# ── 13. Dynamic sentence count (duration-aware) ────────────
+#
+# R5b 发现: 方案 B — 按时长动态调整句数, 保持每段字数自然.
+# 句数 = round(duration / target_segment_duration)
+# 60s 时与 preset 的 prompt_target_sentences 一致 (向后兼容).
+# 非 60s 时句数按比例缩放, max_chars 不变.
+
+
+_DYNAMIC_CASES = [
+    # (preset_name, duration, expected_count)
+    # 60s baseline — matches preset's prompt_target_sentences
+    ("douyin-fast", 60, 18),      # 60 / 3.3 = 18.2 → 18
+    ("mainstream-dry", 60, 12),   # 60 / 5.0 = 12.0 → 12
+    ("bilibili-long", 60, 8),     # 60 / 7.5 = 8.0 → 8
+    # 120s — double the sentences, same per-sentence length
+    ("douyin-fast", 120, 36),     # 120 / 3.3 = 36.4 → 36
+    ("mainstream-dry", 120, 24),  # 120 / 5.0 = 24.0 → 24
+    ("bilibili-long", 120, 16),   # 120 / 7.5 = 16.0 → 16
+    # 90s — 1.5x sentences
+    ("bilibili-long", 90, 12),    # 90 / 7.5 = 12.0 → 12
+    # 30s — half sentences
+    ("douyin-fast", 30, 9),       # 30 / 3.3 = 9.1 → 9
+    ("bilibili-long", 30, 4),     # 30 / 7.5 = 4.0 → 4
+]
+
+
+@pytest.mark.parametrize("preset_name,duration,expected_count", _DYNAMIC_CASES)
+def test_dynamic_sentence_count_by_duration(preset_name, duration, expected_count, tmp_path):
+    """Sentence count must scale with duration, keeping per-sentence length fixed.
+
+    This is the core of 方案 B: longer videos get more sentences,
+    not longer sentences. The per-sentence max_chars stays constant
+    (defined by preset), but the total count adjusts to fill the duration.
+
+    Formula: n = round(duration / target_segment_duration)
+    """
+    from movie_narrator.presets import get_preset
+
+    preset = get_preset(preset_name)
+    seg_dur = preset.param_dict.get("prompt_target_segment_duration")
+    assert seg_dur is not None, f"{preset_name} missing prompt_target_segment_duration"
+
+    # Verify formula matches expected
+    calculated = max(1, round(duration / seg_dur))
+    assert calculated == expected_count, (
+        f"{preset_name} duration={duration}: "
+        f"round({duration}/{seg_dur}) = {calculated}, expected {expected_count}"
+    )
+
+    # End-to-end: generate_script with this duration should produce expected count
+    ctx = _make_ctx(tmp_path, duration=duration)
+    ctx.metadata["prompt_target_sentences"] = preset.param_dict.get("prompt_target_sentences")
+    ctx.metadata["prompt_target_segment_duration"] = seg_dur
+
+    beats_resp = _mock_llm_response(_beats_json(expected_count))
+    seg_resp = _mock_llm_response(_segments_json([f"s{i}" for i in range(expected_count)]))
+    mock_cm = _mock_llm_cm(side_effect=[beats_resp, seg_resp])
+
+    with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
+        with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
+            result = generate_script(ctx)
+
+    assert len(result.segments) == expected_count, (
+        f"{preset_name} duration={duration}s: expected {expected_count} segments, "
+        f"got {len(result.segments)}. Dynamic count formula is broken."
+    )
+
+
+def test_dynamic_count_60s_matches_preset_baseline(tmp_path):
+    """At 60s, dynamic count must equal preset's prompt_target_sentences.
+
+    This is the backward compatibility guarantee: existing 60s videos
+    behave exactly as before.
+    """
+    from movie_narrator.presets import get_preset
+
+    for name in ("douyin-fast", "mainstream-dry", "bilibili-long"):
+        preset = get_preset(name)
+        base_count = preset.param_dict.get("prompt_target_sentences")
+        seg_dur = preset.param_dict.get("prompt_target_segment_duration")
+        dynamic_count = round(60 / seg_dur)
+        assert dynamic_count == base_count, (
+            f"{name}: 60s dynamic count {dynamic_count} != "
+            f"preset baseline {base_count}"
+        )


### PR DESCRIPTION
R5b 真实 TTS 数据分析后的设计决策: 按时长动态调整句数, 保持每段字数自然.

**问题**: R5b 发现 60s 目标下 mainstream(-19%) 和 bilibili(-25%) 时长严重偏短. 根因是 max_chars 上限太低, LLM 写不出足够字数填满时长.

**方案 B** (选中, 非 A): 句数 = round(duration / target_segment_duration)
- 60s bilibili: 8 句 (向后兼容)
- 120s bilibili: 16 句 (不是 8 句×57 字的怪物)
- 每段字数保持在 19-25 字自然区间

**修正 max_chars** (基于 R5b 实测字速 3.8 字/s):
- douyin: 15 (不变)
- mainstream: 18→22
- bilibili: 22→32

10 new tests (9 parametrized + 1 backward compat), 47 in test_script.py, 414 passed total.