### PR TITLE
fix: P0 hardening — MS-01/MS-02/AQ-01/AQ-05

### DIFF
--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -3,12 +3,12 @@ from ..utils.optional_deps import probe
 
 
 def align_audio(ctx: Context) -> Context:
-    """Align timed segments using WhisperX transcription on the rendered audio.
+    """Align timed segments using WhisperX transcription + forced alignment.
 
-    WhisperX is optional — requires the ``[ml]`` extra or a manual
-    ``pip install movie-narrator[ml]``.  When unavailable the step is
-    marked *disabled* and skipped so the rest of the pipeline keeps
-    running.
+    AQ-01 fix (Q-X11): Now runs the full WhisperX pipeline
+    (transcribe → align) instead of only midpoint remapping.
+    Adds monotonic/non-overlap validation and drift detection.
+    Degrades to ``status='skipped'`` when ASR is empty or unreliable.
 
     Parameters
     ----------
@@ -38,53 +38,117 @@ def align_audio(ctx: Context) -> Context:
         import whisperx
 
         device = ctx.metadata.get("whisperx_device", "cpu")
+        language = ctx.metadata.get("whisperx_language", "zh")
         audio = whisperx.load_audio(ctx.audio_path)
         model = whisperx.load_model(
             ctx.metadata.get("whisperx_model", "medium"), device=device
         )
-        result = model.transcribe(
-            audio, language=ctx.metadata.get("whisperx_language", "zh")
-        )
+        result = model.transcribe(audio, language=language)
 
-        if result and "segments" in result:
-            wx_segments = []
-            for wseg in result["segments"]:
-                start = wseg.get("start", 0.0)
-                end = wseg.get("end", 0.0)
-                text = wseg.get("text", "").strip()
-                if text:
-                    wx_segments.append({"start": start, "end": end, "text": text})
+        if not result or "segments" not in result or not result["segments"]:
+            # ── AQ-01: empty ASR → skipped (not success) ──
+            ctx.services.console.inline_warn(
+                "WhisperX returned no speech segments; "
+                "timestamps remain TTS-estimated"
+            )
+            ctx.status.align = "skipped"
+            ctx.step_state.result = StepResult.WARNING
+            ctx.step_state.message = "WhisperX ASR returned empty"
+            ctx.metadata["align_degraded"] = True
+            return ctx
 
-            if not wx_segments:
-                ctx.services.console.inline_warn(
-                    "WhisperX returned no speech segments; "
-                    "timestamps remain TTS-estimated"
-                )
-            else:
-                # Match by time overlap instead of index.
-                # Index-based alignment causes drift when WhisperX produces
-                # a different number of segments than the script (common for
-                # long videos with silence or music-only sections).
-                for i, ts in enumerate(ctx.timed_segments):
-                    ts_mid = (ts.start + ts.end) / 2.0
-                    best = None
-                    best_dist = float("inf")
-                    for wseg in wx_segments:
-                        # Prefer segments that contain the midpoint
-                        if wseg["start"] <= ts_mid <= wseg["end"]:
-                            best = wseg
-                            break
-                        # Otherwise pick the closest by midpoint distance
-                        wseg_mid = (wseg["start"] + wseg["end"]) / 2.0
-                        dist = abs(wseg_mid - ts_mid)
-                        if dist < best_dist:
-                            best_dist = dist
-                            best = wseg
-                    if best:
-                        ts.start = best["start"]
-                        ts.end = best["end"]
+        # ── AQ-01: Run full forced alignment (Q-X11) ──
+        # Previously only midpoint remapping was done. Now we run
+        # whisperx.align() for word-level timestamps, then validate.
+        try:
+            model_a, metadata = whisperx.load_align_model(
+                language_code=language, device=device
+            )
+            result = whisperx.align(
+                result["segments"], model_a, metadata, audio, device=device
+            )
+        except Exception as align_err:
+            ctx.services.console.inline_warn(
+                f"WhisperX forced alignment failed ({align_err}); "
+                f"falling back to transcript-level timestamps"
+            )
+            ctx.metadata["align_fallback"] = True
+
+        wx_segments = []
+        for wseg in result.get("segments", []):
+            start = wseg.get("start", 0.0)
+            end = wseg.get("end", 0.0)
+            text = wseg.get("text", "").strip()
+            if text:
+                wx_segments.append({"start": start, "end": end, "text": text})
+
+        if not wx_segments:
+            ctx.services.console.inline_warn(
+                "WhisperX alignment produced no usable segments; "
+                "timestamps remain TTS-estimated"
+            )
+            ctx.status.align = "skipped"
+            ctx.step_state.result = StepResult.WARNING
+            ctx.step_state.message = "WhisperX align produced no segments"
+            ctx.metadata["align_degraded"] = True
+            return ctx
+
+        # ── AQ-01: Drift detection ──
+        # If WhisperX finds only 1 segment for the entire audio, it's
+        # unreliable (likely all-silence or all-noise detected as one blob).
+        if len(wx_segments) == 1 and ctx.timed_segments:
+            total_narr_duration = sum(
+                ts.end - ts.start for ts in ctx.timed_segments
+            )
+            wx_duration = wx_segments[0]["end"] - wx_segments[0]["start"]
+            if total_narr_duration > 0:
+                drift_ratio = abs(wx_duration - total_narr_duration) / total_narr_duration
+                if drift_ratio > 0.5:
+                    ctx.services.console.inline_warn(
+                        f"WhisperX single-segment duration drift {drift_ratio:.0%} "
+                        f"(wx={wx_duration:.1f}s vs narr={total_narr_duration:.1f}s); "
+                        f"timestamps remain TTS-estimated"
+                    )
+                    ctx.status.align = "skipped"
+                    ctx.step_state.result = StepResult.WARNING
+                    ctx.step_state.message = "WhisperX drift too large"
+                    ctx.metadata["align_degraded"] = True
+                    return ctx
+
+        # ── AQ-01: Monotonic non-overlap remapping ──
+        # Match each narration segment to the WhisperX segment whose
+        # time range contains the narration midpoint. Validate that
+        # resulting timestamps are monotonically non-decreasing and
+        # non-overlapping.
+        prev_end = 0.0
+        for i, ts in enumerate(ctx.timed_segments):
+            ts_mid = (ts.start + ts.end) / 2.0
+            best = None
+            best_dist = float("inf")
+            for wseg in wx_segments:
+                if wseg["start"] <= ts_mid <= wseg["end"]:
+                    best = wseg
+                    break
+                wseg_mid = (wseg["start"] + wseg["end"]) / 2.0
+                dist = abs(wseg_mid - ts_mid)
+                if dist < best_dist:
+                    best_dist = dist
+                    best = wseg
+            if best:
+                new_start = best["start"]
+                new_end = best["end"]
+                # Enforce monotonic non-overlap: if new_start < prev_end,
+                # push it forward to prev_end (with tiny gap).
+                if new_start < prev_end:
+                    new_start = prev_end
+                if new_end <= new_start:
+                    new_end = new_start + 0.1  # minimum 100ms segment
+                ts.start = new_start
+                ts.end = new_end
+                prev_end = new_end
 
         ctx.status.align = "success"
+        ctx.metadata["align_segments"] = len(wx_segments)
         return ctx
     except Exception as e:
         ctx.step_state.result = StepResult.WARNING

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -442,14 +442,37 @@ def _match_clips_impl(
                     )
 
             scene_labels = _build_scene_captions(scenes, transcript)
-            emb_model = ctx.metadata.get("embedding_model_name", _EMBEDDING_MODEL_NAME)
-            scene_vecs = _embed_texts(scene_labels, emb_model)
-            narration_vecs = _embed_texts([seg.text for seg in ctx.timed_segments], emb_model)
-            for i, seg in enumerate(ctx.timed_segments):
-                best_idx = _cosine_top1(narration_vecs[i], scene_vecs)
-                best_scene = scenes[best_idx]
-                score = float(scene_vecs[best_idx] @ narration_vecs[i])
-                final.append((heuristic[i], score, best_scene, "embedding"))
+
+            # ── MS-02: Truth in match (Q-M1) ──────────────
+            # Detect fake captions (placeholder labels without real transcript).
+            # If too many scenes have fake captions, embedding re-rank is
+            # meaningless — it's matching narration against "scene 0 from
+            # 0.0s to 15.0s" strings that carry no semantic information.
+            # Threshold: if >70% of labels are fake, force heuristic.
+            fake_count = sum(
+                1 for label in scene_labels
+                if label.startswith("scene ") and "from" in label
+            )
+            fake_ratio = fake_count / len(scene_labels) if scene_labels else 1.0
+            if fake_ratio > 0.7:
+                ctx.services.console.inline_warn(
+                    f"Scene captions are {fake_ratio:.0%} placeholder labels "
+                    f"({fake_count}/{len(scene_labels)} scenes have no real transcript). "
+                    f"Embedding re-rank would be misleading — forcing heuristic match. "
+                    f"Install WhisperX with: pip install 'movie-narrator[ml]'"
+                )
+                ctx.metadata["match_captions_fake"] = True
+                final = [(h, 1.0, None, "heuristic") for h in heuristic]
+            else:
+                ctx.metadata["match_captions_fake"] = False
+                emb_model = ctx.metadata.get("embedding_model_name", _EMBEDDING_MODEL_NAME)
+                scene_vecs = _embed_texts(scene_labels, emb_model)
+                narration_vecs = _embed_texts([seg.text for seg in ctx.timed_segments], emb_model)
+                for i, seg in enumerate(ctx.timed_segments):
+                    best_idx = _cosine_top1(narration_vecs[i], scene_vecs)
+                    best_scene = scenes[best_idx]
+                    score = float(scene_vecs[best_idx] @ narration_vecs[i])
+                    final.append((heuristic[i], score, best_scene, "embedding"))
         except Exception as e:
             ctx.services.console.inline_warn(
                 f"embedding re-rank unavailable ({e}); using heuristic"
@@ -526,6 +549,19 @@ def _match_clips_impl(
         ),
         encoding="utf-8",
     )
+    # ── WP1: match_summary for metadata.json ─────────
+    # Records the match quality breakdown so L2 hand-test can verify
+    # the main path isn't "全 heuristic 糊弄" (O9/O10 in checklist).
+    embedding_count = sum(1 for mc in matched_clips if mc.source == "embedding")
+    heuristic_count = sum(1 for mc in matched_clips if mc.source == "heuristic")
+    ctx.metadata["match_summary"] = {
+        "total": len(matched_clips),
+        "embedding": embedding_count,
+        "heuristic": heuristic_count,
+        "heuristic_ratio": heuristic_count / len(matched_clips) if matched_clips else 1.0,
+        "captions_fake": ctx.metadata.get("match_captions_fake", False),
+    }
+
     ctx.status.match = "success"
     return ctx
 

--- a/src/movie_narrator/pipeline/scenes.py
+++ b/src/movie_narrator/pipeline/scenes.py
@@ -42,6 +42,29 @@ def detect_scenes(ctx: Context) -> Context:
                     end=end.get_seconds(),
                 )
             )
+
+        # ── MS-01: 0-scene fallback (Q-X7) ─────────────
+        # ContentDetector can return 0 scenes for low-contrast videos
+        # (black bars, static shots). Without this fallback, scenes=[]
+        # + status=success silently turns downstream into a text-only
+        # video — pure 字卡, no footage.
+        # Fix: synthesize one Scene covering the full video duration.
+        if not scenes:
+            ctx.services.console.inline_warn(
+                "Scene detection found 0 cuts — synthesizing a single "
+                "full-length scene as fallback. Video may have low visual "
+                "contrast or be mostly static."
+            )
+            # Get video duration from the opened video object
+            try:
+                duration = float(video.duration)
+            except (AttributeError, TypeError, ValueError):
+                # Fallback: probe via ffprobe
+                from ..utils.deliverable_qa import probe_media
+                duration = probe_media(ctx.source_video_path).get("duration", 60.0)
+            scenes = [Scene(index=0, start=0.0, end=duration)]
+            ctx.metadata["scene_detection_degraded"] = True
+
         ctx.scenes = scenes
         ctx.status.scene = "success"
 

--- a/src/movie_narrator/utils/deliverable_qa.py
+++ b/src/movie_narrator/utils/deliverable_qa.py
@@ -264,6 +264,20 @@ def evaluate_deliverable(
             f"mean volume {mean_vol:.1f}dB <= silence floor {max_silence_db:.1f}dB",
         ))
 
+    # ── AQ-05: fail-closed for unknown volume (Q-X10) ──
+    # If the file claims to have audio but volumedetect failed to parse
+    # (mean_volume=None), we cannot verify the audio is not silent.
+    # Previously this silently skipped the silence check, allowing
+    # near-silent or broken-audio deliverables to pass QA.
+    # Fix: treat as a warning issue so the pipeline at least surfaces it.
+    has_audio = metrics.get("has_audio", False)
+    if mean_vol is None and has_audio:
+        issues.append(QAIssue(
+            "volume_unknown",
+            "audio stream present but volumedetect failed — cannot verify "
+            "audio is not silent (ffmpeg may lack decoder or file may be corrupt)",
+        ))
+
     if metrics.get("width", 0) <= 0 or metrics.get("height", 0) <= 0:
         issues.append(QAIssue(
             "bad_resolution",

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -124,12 +124,20 @@ def test_align_unequal_segment_counts(tmp_path):
 
     assert ctx.status.align == "success"
     # All 5 segments should be assigned (not just first 2)
-    for ts in ctx.timed_segments:
-        assert ts.start in (0.0, 3.0)  # assigned to one of the 2 wx segments
+    # AQ-01 fix: timestamps are now monotonically non-decreasing
+    # and non-overlapping (multiple segments can't share the same
+    # wx segment time range without being pushed forward).
+    for prev, curr in zip(ctx.timed_segments, ctx.timed_segments[1:]):
+        assert curr.start >= prev.end  # monotonic non-overlap
+        assert curr.end > curr.start    # always positive duration
 
 
 def test_align_empty_whisperx_segments_warns(tmp_path):
-    """WhisperX returns empty segments → inline_warn, timestamps unchanged."""
+    """WhisperX returns empty segments → inline_warn, timestamps unchanged.
+
+    AQ-01 fix: empty ASR now degrades to status='skipped' (not 'success'),
+    so downstream knows alignment didn't happen.
+    """
     ctx = _make_ctx(tmp_path)
     original_starts = [ts.start for ts in ctx.timed_segments]
     original_ends = [ts.end for ts in ctx.timed_segments]
@@ -147,7 +155,9 @@ def test_align_empty_whisperx_segments_warns(tmp_path):
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
-    assert ctx.status.align == "success"
+    # AQ-01: empty ASR → skipped (not success)
+    assert ctx.status.align == "skipped"
+    assert ctx.metadata.get("align_degraded") is True
     # Timestamps should be unchanged (no alignment happened)
     for i, ts in enumerate(ctx.timed_segments):
         assert ts.start == original_starts[i]

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -494,7 +494,12 @@ def test_match_clips_whisperx_failure_falls_back(tmp_path, monkeypatch):
 
 
 def test_match_clips_embedding_reranks_when_available(tmp_path, monkeypatch):
-    """sentence_transformers available → re-rank candidates by cosine."""
+    """sentence_transformers available → re-rank candidates by cosine.
+
+    MS-02 fix: embedding path now requires real transcript (not fake
+    placeholder labels). This test provides a mock transcript so the
+    embedding path is exercised.
+    """
     ctx = _make_ctx(tmp_path)
     (tmp_path / "video.mp4").write_bytes(b"00")
     # Two scenes so the embedding path can actually pick one over the other.
@@ -510,7 +515,16 @@ def test_match_clips_embedding_reranks_when_available(tmp_path, monkeypatch):
     monkeypatch.setattr(
         match_module,
         "probe",
-        lambda name: (True, "") if name == "sentence_transformers" else (False, ""),
+        lambda name: (True, ""),  # both sentence_transformers and whisperx
+    )
+
+    # MS-02: provide mock transcript so captions are real (not placeholders)
+    mock_transcript = [
+        {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
+        {"start": 4.0, "end": 9.0, "text": "beta scene one"},
+    ]
+    monkeypatch.setattr(
+        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
     )
 
     class FakeST:


### PR DESCRIPTION
4 P0 audit hardening fixes from QUALITY_UPLIFT_METHODS.md section 13.

MS-01 (scenes.py): 0-scene fallback — synthesize full-length Scene instead of scenes=[]+success (was silently producing text-only videos).

MS-02 (match.py): fake caption detection — if >70% of scene captions are placeholder labels (no WhisperX transcript), force heuristic match instead of misleading embedding re-rank. Also adds match_summary to metadata for L2 hand-test O9/O10.

AQ-05 (deliverable_qa.py): volume_unknown fail-closed — if audio stream exists but volumedetect fails (mean_volume=None), now reports volume_unknown issue instead of silently skipping silence check.

AQ-01 (align.py): full WhisperX pipeline — now runs transcribe + align (forced alignment) instead of only midpoint remapping. Adds monotonic non-overlap validation and drift detection. Empty ASR or drift > 50% degrades to status=skipped.

Tests: 421 passed, 23 skipped, 2 pre-existing TTS .env failures. 3 tests updated for new behavior.