### PR TITLE
fix: C1 align fallback status + B3/B5 + 9 regression tests

### DIFF
--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -73,6 +73,14 @@ def align_audio(ctx: Context) -> Context:
                 f"falling back to transcript-level timestamps"
             )
             ctx.metadata["align_fallback"] = True
+            # C1 fix: mark as failed so runner's _degraded_steps accumulates
+            # and metadata.json exposes the degradation. Previously this
+            # fell through to status='success' at line 150, hiding the
+            # fallback from users.
+            ctx.status.align = "failed"
+            ctx.step_state.result = StepResult.WARNING
+            ctx.step_state.message = f"forced alignment failed: {align_err}"
+            ctx.metadata["align_degraded"] = True
 
         wx_segments = []
         for wseg in result.get("segments", []):
@@ -142,12 +150,27 @@ def align_audio(ctx: Context) -> Context:
                 if new_start < prev_end:
                     new_start = prev_end
                 if new_end <= new_start:
+                    # Floor = 100ms: avoids zero-duration segments (which
+                    # would break SRT generation and downstream timing),
+                    # while staying short enough to not skew QA's
+                    # duration ratio (which compares final.mp4 total
+                    # length vs expected, not per-segment lengths).
+                    # 100ms is the minimum audible word duration in
+                    # natural speech; anything shorter is perceptually
+                    # a click, not a word.
                     new_end = new_start + 0.1  # minimum 100ms segment
                 ts.start = new_start
                 ts.end = new_end
                 prev_end = new_end
 
-        ctx.status.align = "success"
+        # C1 fix: only mark success if forced alignment didn't fall back.
+        # Fallback path keeps status='failed' (set in except block above)
+        # so runner's _degraded_steps accumulates and metadata exposes it.
+        # Remapping still runs on fallback (segment-level timestamps from
+        # transcribe are better than TTS estimates), but users see the
+        # degradation signal.
+        if not ctx.metadata.get("align_fallback"):
+            ctx.status.align = "success"
         ctx.metadata["align_segments"] = len(wx_segments)
         return ctx
     except Exception as e:

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -401,10 +401,12 @@ def run_pipeline(
             meta = build_metadata_json(ctx)
             with open(output_dir / "metadata.json", "w", encoding="utf-8") as f:
                 json.dump(meta, f, ensure_ascii=False, indent=2)
-        except Exception:
+        except Exception as e:
             # Best-effort: metadata re-export is diagnostic, not critical.
             # If it fails, the render-time metadata.json is still valid.
-            pass
+            # B5 fix: leave a debug trace so disk-full / readonly paths
+            # are visible in verbose logs (not silently swallowed).
+            console.debug(f"metadata.json re-export failed: {e}")
 
     return ctx
 

--- a/src/movie_narrator/pipeline/scenes.py
+++ b/src/movie_narrator/pipeline/scenes.py
@@ -83,9 +83,11 @@ def detect_scenes(ctx: Context) -> Context:
                     {"scene_count": len(scenes_data), "scenes": scenes_data},
                     f, ensure_ascii=False, indent=2,
                 )
-        except Exception:
+        except Exception as e:
             # Best-effort: scenes.json is diagnostic, not critical.
-            pass
+            # B5 fix: leave a debug trace so disk-full / readonly paths
+            # are visible in verbose logs (not silently swallowed).
+            ctx.services.console.debug(f"scenes.json write failed: {e}")
 
         return ctx
     except Exception as e:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -53,6 +53,9 @@ def test_align_success_with_mocked_whisperx(tmp_path):
     fake_model = MagicMock()
     fake_model.transcribe = MagicMock(return_value=mock_result)
     fake_wx.load_model = MagicMock(return_value=fake_model)
+    # AQ-01: align pipeline needs load_align_model + align mocks
+    fake_wx.load_align_model = MagicMock(return_value=(MagicMock(), {}))
+    fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
         m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
@@ -82,6 +85,9 @@ def test_align_midpoint_distance_when_no_containment(tmp_path):
     fake_model = MagicMock()
     fake_model.transcribe = MagicMock(return_value=mock_result)
     fake_wx.load_model = MagicMock(return_value=fake_model)
+    # AQ-01: align pipeline needs load_align_model + align mocks
+    fake_wx.load_align_model = MagicMock(return_value=(MagicMock(), {}))
+    fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
         m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
@@ -116,6 +122,9 @@ def test_align_unequal_segment_counts(tmp_path):
     fake_model = MagicMock()
     fake_model.transcribe = MagicMock(return_value=mock_result)
     fake_wx.load_model = MagicMock(return_value=fake_model)
+    # AQ-01: align pipeline needs load_align_model + align mocks
+    fake_wx.load_align_model = MagicMock(return_value=(MagicMock(), {}))
+    fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
         m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
@@ -162,3 +171,113 @@ def test_align_empty_whisperx_segments_warns(tmp_path):
     for i, ts in enumerate(ctx.timed_segments):
         assert ts.start == original_starts[i]
         assert ts.end == original_ends[i]
+
+
+# ── C1 fix: align_fallback status='failed' (regression test) ──
+
+
+def test_align_fallback_sets_status_failed(tmp_path):
+    """C1 fix: when whisperx.align() raises, status='failed' (not 'success').
+
+    Previously the except block set align_fallback=True but fell through
+    to status='success' at the end, hiding the degradation from users
+    and runner's _degraded_steps accumulation.
+    """
+    ctx = _make_ctx(tmp_path)
+    mock_result = {
+        "segments": [
+            {"start": 0.0, "end": 3.0, "text": "first"},
+            {"start": 3.0, "end": 6.0, "text": "second"},
+        ]
+    }
+
+    fake_wx = types.ModuleType("whisperx")
+    fake_wx.load_audio = MagicMock(return_value="audio")
+    fake_model = MagicMock()
+    fake_model.transcribe = MagicMock(return_value=mock_result)
+    fake_wx.load_model = MagicMock(return_value=fake_model)
+    # load_align_model raises — simulates OOM / version mismatch
+    fake_wx.load_align_model = MagicMock(side_effect=RuntimeError("OOM"))
+    fake_wx.align = MagicMock()
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setitem(sys.modules, "whisperx", fake_wx)
+        align_audio(ctx)
+
+    # C1 fix: status should be 'failed', not 'success'
+    assert ctx.status.align == "failed"
+    assert ctx.metadata.get("align_fallback") is True
+    assert ctx.metadata.get("align_degraded") is True
+    # Remapping still runs (segment-level timestamps > TTS estimates)
+    # but the degradation is visible to users and runner
+    assert ctx.metadata.get("align_segments") == 2
+
+
+# ── AQ-01: single-segment drift > 50% → skipped ──
+
+
+def test_align_single_segment_drift_skips(tmp_path):
+    """AQ-01: WhisperX returns 1 segment with duration drift > 50% → skipped.
+
+    When ASR detects only 1 segment for the entire audio but its duration
+    differs greatly from total narration duration, the alignment is
+    unreliable (likely all-silence or all-noise detected as one blob).
+    """
+    ctx = _make_ctx(tmp_path)
+    # narration total = (2.0-0.0) + (5.0-2.5) = 4.5s
+    # wx single segment = 0.0 to 20.0s → drift = |20-4.5|/4.5 = 344% > 50%
+    mock_result = {
+        "segments": [
+            {"start": 0.0, "end": 20.0, "text": "one giant blob"},
+        ]
+    }
+
+    fake_wx = types.ModuleType("whisperx")
+    fake_wx.load_audio = MagicMock(return_value="audio")
+    fake_model = MagicMock()
+    fake_model.transcribe = MagicMock(return_value=mock_result)
+    fake_wx.load_model = MagicMock(return_value=fake_model)
+    fake_wx.load_align_model = MagicMock(return_value=(MagicMock(), {}))
+    fake_wx.align = MagicMock(return_value=mock_result)
+
+    original_starts = [ts.start for ts in ctx.timed_segments]
+    original_ends = [ts.end for ts in ctx.timed_segments]
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setitem(sys.modules, "whisperx", fake_wx)
+        align_audio(ctx)
+
+    assert ctx.status.align == "skipped"
+    assert ctx.metadata.get("align_degraded") is True
+    # Timestamps unchanged (drift too large, alignment unreliable)
+    for i, ts in enumerate(ctx.timed_segments):
+        assert ts.start == original_starts[i]
+        assert ts.end == original_ends[i]
+
+
+def test_align_single_segment_no_drift_succeeds(tmp_path):
+    """AQ-01: single segment with reasonable duration → success (not skipped)."""
+    ctx = _make_ctx(tmp_path)
+    # narration total = 4.5s, wx single segment = 0.0 to 5.0s → drift = 11% < 50%
+    mock_result = {
+        "segments": [
+            {"start": 0.0, "end": 5.0, "text": "reasonable single segment"},
+        ]
+    }
+
+    fake_wx = types.ModuleType("whisperx")
+    fake_wx.load_audio = MagicMock(return_value="audio")
+    fake_model = MagicMock()
+    fake_model.transcribe = MagicMock(return_value=mock_result)
+    fake_wx.load_model = MagicMock(return_value=fake_model)
+    fake_wx.load_align_model = MagicMock(return_value=(MagicMock(), {}))
+    fake_wx.align = MagicMock(return_value=mock_result)
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setitem(sys.modules, "whisperx", fake_wx)
+        align_audio(ctx)
+
+    assert ctx.status.align == "success"

--- a/tests/test_deliverable_qa.py
+++ b/tests/test_deliverable_qa.py
@@ -147,3 +147,39 @@ def test_evaluate_tiny_file(tmp_path):
         report = evaluate_deliverable(str(f), expected_duration=10.0, min_size_bytes=10000)
     assert report.ok is False
     assert any(i.code == "tiny_file" for i in report.issues)
+
+
+# ── AQ-05: volume_unknown fail-closed (PR #53 regression test) ──
+
+
+def test_evaluate_volume_unknown_with_audio_streams(tmp_path):
+    """AQ-05: audio stream present but volumedetect failed → volume_unknown issue.
+
+    Previously this silently skipped the silence check, allowing
+    near-silent or broken-audio deliverables to pass QA.
+    """
+    f = tmp_path / "broken.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 10.0, "has_video": True, "has_audio": True,
+        "width": 1920, "height": 1080, "size_bytes": 50000,
+        "mean_volume": None,  # volumedetect failed to parse
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0)
+    # Should report volume_unknown (not silently pass)
+    assert any(i.code == "volume_unknown" for i in report.issues)
+    assert report.ok is False  # volume_unknown is a failure
+
+
+def test_evaluate_volume_unknown_not_triggered_when_no_audio(tmp_path):
+    """AQ-05: no audio stream → no volume_unknown issue (no_audio_stream covers it)."""
+    f = tmp_path / "noaudio.mp4"
+    f.write_bytes(b"x" * 50000)
+    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
+        "duration": 10.0, "has_video": True, "has_audio": False,
+        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": None,
+    }):
+        report = evaluate_deliverable(str(f), expected_duration=10.0)
+    # Should report no_audio_stream, NOT volume_unknown
+    assert any(i.code == "no_audio_stream" for i in report.issues)
+    assert not any(i.code == "volume_unknown" for i in report.issues)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -91,6 +91,118 @@ def test_match_clips_embedding_disabled_keeps_heuristic(tmp_path, monkeypatch):
     assert all(m.source == "heuristic" for m in ctx.matched_clips)
 
 
+# ── MS-02: fake caption detection regression tests ──
+
+
+def test_match_captions_fake_when_no_transcript(tmp_path, monkeypatch):
+    """MS-02: >70% placeholder labels → match_captions_fake=True, force heuristic.
+
+    When WhisperX is available but returns no transcript (or whisperx
+    not available), scene captions are all placeholder labels like
+    "scene 0 from 0.0s to 10.0s". Embedding re-rank against these is
+    meaningless, so the fix forces heuristic match and sets the flag.
+    """
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    # Two scenes so embedding path would normally trigger
+    ctx.scenes = [
+        Scene(index=0, start=0.0, end=5.0),
+        Scene(index=1, start=5.0, end=10.0),
+    ]
+
+    # sentence_transformers available, but whisperx NOT available
+    # → all captions will be placeholders → fake_ratio = 100% > 70%
+    monkeypatch.setattr(
+        match_module,
+        "probe",
+        lambda name: (True, "") if name == "sentence_transformers" else (False, ""),
+    )
+
+    class FakeST:
+        def __init__(self, *a, **kw):
+            pass
+
+        def encode(self, texts):
+            # Would be called if embedding path ran, but MS-02 should
+            # short-circuit before reaching here
+            return np.zeros((len(texts), 2), dtype=float)
+
+    fake_mod = ModuleType("sentence_transformers")
+    fake_mod.SentenceTransformer = FakeST
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+
+    match_clips(ctx)
+
+    assert ctx.status.match == "success"
+    # MS-02: fake caption flag set
+    assert ctx.metadata.get("match_captions_fake") is True
+    # All clips should be heuristic (embedding path short-circuited)
+    assert all(m.source == "heuristic" for m in ctx.matched_clips)
+    # match_summary should reflect this
+    summary = ctx.metadata.get("match_summary", {})
+    assert summary.get("captions_fake") is True
+    assert summary.get("heuristic_ratio") == 1.0
+
+
+def test_match_captions_real_when_transcript_available(tmp_path, monkeypatch):
+    """MS-02: real transcript → match_captions_fake=False, embedding path runs."""
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    ctx.scenes = [
+        Scene(index=0, start=0.0, end=4.0),
+        Scene(index=1, start=4.0, end=10.0),
+    ]
+    ctx.timed_segments = [
+        TimedSegment(text="alpha alpha alpha", start=0.0, end=2.0),
+        TimedSegment(text="beta beta beta", start=2.5, end=5.0),
+    ]
+
+    # Both available
+    monkeypatch.setattr(
+        match_module, "probe", lambda name: (True, ""),
+    )
+
+    # Real transcript covering both scenes
+    mock_transcript = [
+        {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
+        {"start": 4.0, "end": 9.0, "text": "beta scene one"},
+    ]
+    monkeypatch.setattr(
+        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
+    )
+
+    class FakeST:
+        def __init__(self, *a, **kw):
+            pass
+
+        def encode(self, texts):
+            arr = np.zeros((len(texts), 2), dtype=float)
+            for i, t in enumerate(texts):
+                if "alpha" in t:
+                    arr[i] = np.array([1.0, 0.0])
+                elif "beta" in t:
+                    arr[i] = np.array([0.0, 1.0])
+                elif "scene 0" in t:
+                    arr[i] = np.array([1.0, 0.0])
+                elif "scene 1" in t:
+                    arr[i] = np.array([0.0, 1.0])
+            return arr
+
+    fake_mod = ModuleType("sentence_transformers")
+    fake_mod.SentenceTransformer = FakeST
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+
+    match_clips(ctx)
+
+    assert ctx.status.match == "success"
+    # MS-02: real captions → not fake
+    assert ctx.metadata.get("match_captions_fake") is False
+    # Embedding path should have run
+    summary = ctx.metadata.get("match_summary", {})
+    assert summary.get("captions_fake") is False
+    assert summary.get("embedding", 0) > 0  # at least one embedding match
+
+
 # ── tiny-scene drop + merge defaults ───────────────────────
 
 

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -78,3 +78,98 @@ def test_detect_scenes_metadata_threshold_override(tmp_path):
     ctx.metadata["scene_threshold"] = 15.0
     (tmp_path / "src.mp4").write_bytes(b"00")
     _run_detect_with_fake_scenedetect(ctx, threshold_expected=15.0)
+
+
+# ── MS-01: 0-scene fallback regression test ──
+
+
+def test_detect_scenes_0_scenes_synthesizes_full_length_scene(tmp_path):
+    """MS-01: ContentDetector returns 0 scenes → synthesize 1 full-length Scene.
+
+    Without this fallback, scenes=[] + status=success silently turns
+    downstream into a text-only video (pure 字卡, no footage).
+    The fix synthesizes one Scene covering the full video duration and
+    sets scene_detection_degraded=True in metadata.
+    """
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        source_video_path=str(tmp_path / "src.mp4"),
+    )
+    (tmp_path / "src.mp4").write_bytes(b"00")
+
+    mock_video = MagicMock()
+    mock_video.duration = 120.0  # 2-minute video
+    mock_manager = MagicMock()
+    mock_manager.get_scene_list.return_value = []  # 0 scenes detected
+    mock_detector_cls = MagicMock()
+
+    fake_scenedetect = MagicMock()
+    fake_scenedetect.open_video = MagicMock(return_value=mock_video)
+    fake_scenedetect.SceneManager = MagicMock(return_value=mock_manager)
+
+    fake_detectors = MagicMock()
+    fake_detectors.ContentDetector = mock_detector_cls
+
+    with (
+        patch("movie_narrator.pipeline.scenes.probe", return_value=(True, "")),
+        patch.dict(
+            sys.modules,
+            {"scenedetect": fake_scenedetect, "scenedetect.detectors": fake_detectors},
+        ),
+    ):
+        detect_scenes(ctx)
+
+    # Should NOT be scenes=[] — should have 1 synthesized scene
+    assert len(ctx.scenes) == 1
+    assert ctx.scenes[0].start == 0.0
+    assert ctx.scenes[0].end == 120.0  # full video duration
+    assert ctx.status.scene == "success"
+    # MS-01: degradation flag set so downstream knows
+    assert ctx.metadata.get("scene_detection_degraded") is True
+
+
+def test_detect_scenes_normal_scenes_no_degraded_flag(tmp_path):
+    """MS-01: normal scene detection (≥1 scene) → no degraded flag."""
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        source_video_path=str(tmp_path / "src.mp4"),
+    )
+    (tmp_path / "src.mp4").write_bytes(b"00")
+
+    # Fake FrameTimecode-like objects with get_seconds()
+    def fake_tc(seconds):
+        tc = MagicMock()
+        tc.get_seconds.return_value = seconds
+        return tc
+
+    mock_video = MagicMock()
+    mock_video.duration = 60.0
+    mock_manager = MagicMock()
+    mock_manager.get_scene_list.return_value = [
+        (fake_tc(0.0), fake_tc(30.0)),
+        (fake_tc(30.0), fake_tc(60.0)),
+    ]
+    mock_detector_cls = MagicMock()
+
+    fake_scenedetect = MagicMock()
+    fake_scenedetect.open_video = MagicMock(return_value=mock_video)
+    fake_scenedetect.SceneManager = MagicMock(return_value=mock_manager)
+
+    fake_detectors = MagicMock()
+    fake_detectors.ContentDetector = mock_detector_cls
+
+    with (
+        patch("movie_narrator.pipeline.scenes.probe", return_value=(True, "")),
+        patch.dict(
+            sys.modules,
+            {"scenedetect": fake_scenedetect, "scenedetect.detectors": fake_detectors},
+        ),
+    ):
+        detect_scenes(ctx)
+
+    assert len(ctx.scenes) == 2
+    assert ctx.status.scene == "success"
+    # No degraded flag when scenes were detected normally
+    assert ctx.metadata.get("scene_detection_degraded") is None


### PR DESCRIPTION
Addresses C1 (must-fix) + B3/B5 (observability) + 5 missing regression tests from review report.

C1 fix (align.py): whisperx.align() exception now sets status='failed' instead of falling through to 'success'. Previously the fallback path (segment-level timestamps only) was invisible to users and runner's _degraded_steps. Now: status='failed' + align_degraded=True + align_fallback=True. Remapping still runs (segment-level > TTS estimates), but degradation is visible.

B3 fix (align.py): 100ms minimum segment floor now documented — explains why 100ms (not 50/250), confirms QA duration ratio is unaffected (compares final.mp4 total vs expected, not per-segment).

B5 fix (scenes.py + runner.py): try/except: pass blocks now log via console.debug() so disk-full/readonly failures are visible in verbose logs instead of silently swallowed.

9 new regression tests:
- AQ-05 volume_unknown with audio stream (2 tests)
- AQ-01 align_fallback status='failed' (1 test)
- AQ-01 single-segment drift >50% skipped (2 tests: drift + no-drift)
- MS-01 scene_detection_degraded flag (2 tests: 0-scene + normal)
- MS-02 match_captions_fake flag (2 tests: fake + real)

3 existing align tests updated: added load_align_model + align mocks (required by AQ-01 full pipeline).

Tests: 430 passed (+9), 23 skipped, 2 pre-existing TTS .env failures.