### PR TITLE
fix: M1 align comment + F3 runner degraded_steps for non-exception paths

### DIFF
--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -73,10 +73,17 @@ def align_audio(ctx: Context) -> Context:
                 f"falling back to transcript-level timestamps"
             )
             ctx.metadata["align_fallback"] = True
-            # C1 fix: mark as failed so runner's _degraded_steps accumulates
-            # and metadata.json exposes the degradation. Previously this
-            # fell through to status='success' at line 150, hiding the
-            # fallback from users.
+            # C1 fix: mark as 'failed' (vs previous secret 'success') so
+            # users, CLI summary and metadata.json all see the alignment
+            # degradation. Remapping still runs below (segment-level
+            # timestamps from transcribe are better than TTS estimates),
+            # but the degradation is visible.
+            #
+            # F3 (runner.py): the runner now also accumulates
+            # _degraded_steps for soft steps that return normally with
+            # status='failed' + step_state.result=WARNING, so this
+            # fallback is surfaced in the runner's degradation summary
+            # too (not just metadata.status.align).
             ctx.status.align = "failed"
             ctx.step_state.result = StepResult.WARNING
             ctx.step_state.message = f"forced alignment failed: {align_err}"

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -367,6 +367,27 @@ def run_pipeline(
 
         elapsed = time.time() - step_start
 
+        # ── F3: surface soft-step degradation from non-exception paths ──
+        # Some soft steps (e.g. align_audio in C1 fix) internally catch
+        # exceptions and set status.<field>='failed' + step_state.result
+        # = WARNING without re-raising. The runner's outer except block
+        # (line 336-348) only accumulates _degraded_steps for steps that
+        # raise; without this check, internal fallbacks stay invisible
+        # in the runner's degradation summary (even though metadata.json
+        # records them via align_degraded / scene_detection_degraded).
+        #
+        # Fix: after a step returns normally, if it's a soft step whose
+        # status field is 'failed' or 'skipped' AND step_state.result is
+        # WARNING, accumulate it into _degraded_steps (idempotent — the
+        # exception path may have already added it).
+        if name in SOFT_STATUS_STEPS and ctx.step_state.result is StepResult.WARNING:
+            field = STATUS_FIELD_FOR_STEP.get(name)
+            status_val = getattr(ctx.status, field, None) if field else None
+            if status_val in ("failed", "skipped"):
+                degraded_list = ctx.metadata.setdefault("_degraded_steps", [])
+                if name not in degraded_list:  # dedupe vs exception path
+                    degraded_list.append(name)
+
         # ── Render step result ───────────────────────────────
         _render_step_result(ctx, name, elapsed, console)
         _check_strict(ctx, name)

--- a/tests/test_runner_workflow_metadata.py
+++ b/tests/test_runner_workflow_metadata.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from movie_narrator.models import Context
+from movie_narrator.models import Context, StepResult, StepState
 from movie_narrator.pipeline.runner import build_context, run_pipeline
 
 
@@ -53,3 +53,125 @@ def test_run_pipeline_omits_workflow_keys_when_empty(tmp_path):
     assert "workflow_steps" not in ctx.metadata or ctx.metadata.get("workflow_steps") in (None, {})
     assert "scene_threshold" not in ctx.metadata
     assert "config_path" not in ctx.metadata
+
+
+# ── F3: runner surfaces soft-step degradation from non-exception paths ──
+
+
+def test_run_pipeline_accumulates_degraded_steps_for_internal_fallback(tmp_path):
+    """F3: soft step that internally sets status='failed'+WARNING (no raise)
+    is accumulated into _degraded_steps by the runner.
+
+    Reproduces the C1 align_fallback scenario: align_audio catches
+    whisperx.align() exception internally, sets status.align='failed'
+    + step_state.result=WARNING, and returns normally. Before F3, the
+    runner's outer except block never fired, so _degraded_steps stayed
+    empty and the degradation was invisible in the runner's summary.
+    """
+    def _passthrough(ctx: Context) -> Context:
+        return ctx
+
+    def _align_with_internal_fallback(ctx: Context) -> Context:
+        """Simulate C1 align_fallback: catch + set failed + WARNING, no raise."""
+        ctx.status.align = "failed"
+        ctx.step_state = StepState(
+            result=StepResult.WARNING,
+            message="forced alignment failed: simulated OOM",
+        )
+        ctx.metadata["align_fallback"] = True
+        ctx.metadata["align_degraded"] = True
+        return ctx
+
+    _align_with_internal_fallback.__name__ = "align_audio"
+    fake_steps = [_passthrough, _align_with_internal_fallback]
+    fake_steps[0].__name__ = "noop"
+
+    ctx = build_context(
+        movie="M",
+        style="S",
+        duration=10,
+        voice=None,
+        format="16:9",
+        output_dir=tmp_path,
+    )
+    with patch("movie_narrator.pipeline.runner.STEPS", fake_steps):
+        ctx = run_pipeline(ctx)
+
+    # F3: _degraded_steps should contain 'align_audio' even though the
+    # step returned normally (no exception propagated to runner).
+    degraded = ctx.metadata.get("_degraded_steps", [])
+    assert "align_audio" in degraded, (
+        f"F3: align_audio should be in _degraded_steps for internal fallback, "
+        f"got {degraded}"
+    )
+
+
+def test_run_pipeline_does_not_duplicate_degraded_steps(tmp_path):
+    """F3: if a soft step both raises AND sets status='failed', the runner
+    should not add it to _degraded_steps twice (idempotent)."""
+    def _passthrough(ctx: Context) -> Context:
+        return ctx
+
+    def _align_raises(ctx: Context) -> Context:
+        """Simulate a step that sets status='failed' then raises."""
+        ctx.status.align = "failed"
+        ctx.step_state = StepState(
+            result=StepResult.WARNING,
+            message="pre-raise warning",
+        )
+        raise RuntimeError("align failed after setting status")
+
+    _align_raises.__name__ = "align_audio"
+    fake_steps = [_passthrough, _align_raises]
+    fake_steps[0].__name__ = "noop"
+
+    ctx = build_context(
+        movie="M",
+        style="S",
+        duration=10,
+        voice=None,
+        format="16:9",
+        output_dir=tmp_path,
+    )
+    with patch("movie_narrator.pipeline.runner.STEPS", fake_steps):
+        ctx = run_pipeline(ctx)
+
+    degraded = ctx.metadata.get("_degraded_steps", [])
+    # Should appear exactly once (exception path adds it, F3 dedupes)
+    assert degraded.count("align_audio") == 1, (
+        f"F3: align_audio should appear exactly once in _degraded_steps, "
+        f"got {degraded}"
+    )
+
+
+def test_run_pipeline_no_degraded_when_step_succeeds(tmp_path):
+    """F3: a step that returns normally with status='success' should NOT
+    be added to _degraded_steps."""
+    def _passthrough(ctx: Context) -> Context:
+        return ctx
+
+    def _align_success(ctx: Context) -> Context:
+        ctx.status.align = "success"
+        ctx.step_state = StepState()
+        return ctx
+
+    _align_success.__name__ = "align_audio"
+    fake_steps = [_passthrough, _align_success]
+    fake_steps[0].__name__ = "noop"
+
+    ctx = build_context(
+        movie="M",
+        style="S",
+        duration=10,
+        voice=None,
+        format="16:9",
+        output_dir=tmp_path,
+    )
+    with patch("movie_narrator.pipeline.runner.STEPS", fake_steps):
+        ctx = run_pipeline(ctx)
+
+    degraded = ctx.metadata.get("_degraded_steps", [])
+    assert "align_audio" not in degraded, (
+        f"F3: align_audio should NOT be in _degraded_steps when it succeeds, "
+        f"got {degraded}"
+    )


### PR DESCRIPTION
Closes the gap left by PR #54 (C1 fix): align_fallback was visible in metadata.status.align but NOT in runner's _degraded_steps summary, because the runner only accumulated _degraded_steps via the exception path (align.py catches whisperx.align() internally without re-raising).

M1 (align.py): corrected C1 comment that falsely claimed 'runner's _degraded_steps accumulates'. Now accurately describes that remapping still runs + F3 surfaces it to runner summary.

F3 (runner.py): after a soft step returns normally, if status.<field> is 'failed' or 'skipped' AND step_state.result is WARNING, accumulate into _degraded_steps (idempotent — dedupes vs exception path). This closes the loop: C1's 'visible degradation' promise now holds in both metadata.json AND runner's CLI summary.

3 new regression tests:
- test_run_pipeline_accumulates_degraded_steps_for_internal_fallback: align_fallback scenario → _degraded_steps contains 'align_audio'
- test_run_pipeline_does_not_duplicate_degraded_steps: step that both sets status='failed' AND raises → appears exactly once (idempotent)
- test_run_pipeline_no_degraded_when_step_succeeds: normal success → NOT in _degraded_steps

Tests: 433 passed (+3), 23 skipped, 2 pre-existing TTS .env failures. 0 regressions.