### PR TITLE
docs+test: match_summary schema doc sync + back-compat regression tests

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,6 +175,44 @@ output/<movie>/
 └── clips/                 # per-segment clip files (when --no-clips not set)
 ```
 
+### `metadata.json` → `match_summary` schema (v1, PR #56)
+
+`match_summary` records the match-quality breakdown for L2 hand-test O9/O10.
+Full schema (21 fields + 4 back-compat fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | int | schema version, currently = 1 |
+| `status` | str | "success" / "failed" |
+| `segments` | int | total matched narration segments |
+| `scenes_in` | int | original scene count (before merge/drop) |
+| `scenes_after_merge` | int | scene count after merge, before drop |
+| `scenes_after_drop` | int | final scene count after drop |
+| `merge_min_duration` | float | short-scene merge threshold (seconds) |
+| `drop_min_duration` | float | tiny-scene drop threshold (seconds) |
+| `min_score` | float | embedding low-score fallback threshold (default 0.25) |
+| `speed_clamp` | [float, float] | speed factor clamp range [min, max] |
+| `source_counts` | {embedding, heuristic} | segment count per source |
+| `heuristic_ratio` | float | heuristic segment ratio (0.0–1.0) |
+| `embedding_ratio` | float | embedding segment ratio (0.0–1.0) |
+| `score` | {min,max,avg} \| null | stats for **adopted** embedding scores (excludes fallbacks) |
+| `raw_score` | {min,max,avg,n} \| null | stats for **all attempted** embedding scores (includes fallbacks; n=attempts) |
+| `speed_factor` | {min,max,avg} \| null | speed factor stats (src_duration / narr_duration) |
+| `low_score_fallback_count` | int | segments that fell back to heuristic due to score < min_score |
+| `captioning` | {used, usable_label_ratio, cached, language, model} | WhisperX captioning status |
+| `embedding_model` | str | embedding model name used |
+| `degraded_reason` | str \| null | "fake_captions" / "all_heuristic" / null |
+| `diversity` | null | reserved for EP3 |
+| **— back-compat —** | | |
+| `total` | int | = segments (legacy consumers) |
+| `embedding` | int | = source_counts.embedding (legacy consumers) |
+| `heuristic` | int | = source_counts.heuristic (legacy consumers) |
+| `captions_fake` | bool | = (degraded_reason == "fake_captions") (legacy consumers) |
+
+`score` vs `raw_score`: `score.avg` reflects only "good" embedding hits (adopted);
+`raw_score.avg` includes "bad-but-fell-back" scores. If `score.avg=0.85` but
+`low_score_fallback_count=5`, the first N hits were accurate and 5 failed to fallback.
+
 ## Extension Points
 
 - **New pipeline step**: append to `STEPS` in `pipeline/runner.py`. Signature must be `(ctx: Context) -> Context`.

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -322,6 +322,103 @@ def test_build_scene_captions_mixed_real_and_fake():
     assert result[2][1] is False  # scene 2 has speech
 
 
+# ── F1 back-compat: old metadata_export consumers must not break ──
+
+
+def test_match_summary_keys_compatible_with_old_metadata_export(tmp_path, monkeypatch):
+    """F1 back-compat: match_summary preserves the 4 legacy fields
+    (total/embedding/heuristic/captions_fake) so existing consumers
+    (metadata_export, L2 checklist jq queries, older scripts) don't break.
+
+    This test was listed in the PR #56 review report as 'excellent' but
+    was never actually written — the report praised a non-existent test.
+    This regression test closes that gap.
+    """
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    ctx.scenes = [
+        Scene(index=0, start=0.0, end=4.0),
+        Scene(index=1, start=4.0, end=10.0),
+    ]
+    ctx.timed_segments = [
+        TimedSegment(text="alpha alpha", start=0.0, end=2.0),
+        TimedSegment(text="beta beta", start=2.5, end=5.0),
+    ]
+
+    # sentence_transformers available → embedding path runs
+    monkeypatch.setattr(match_module, "probe", lambda name: (True, ""))
+    mock_transcript = [
+        {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
+        {"start": 4.0, "end": 9.0, "text": "beta scene one"},
+    ]
+    monkeypatch.setattr(
+        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
+    )
+
+    class FakeST:
+        def __init__(self, *a, **kw):
+            pass
+
+        def encode(self, texts):
+            arr = np.zeros((len(texts), 3), dtype=float)
+            for i, t in enumerate(texts):
+                if "alpha" in t or "scene 0" in t.lower():
+                    arr[i] = np.array([1.0, 0.0, 0.0])
+                elif "beta" in t or "scene 1" in t.lower():
+                    arr[i] = np.array([0.0, 1.0, 0.0])
+            return arr
+
+    fake_mod = ModuleType("sentence_transformers")
+    fake_mod.SentenceTransformer = FakeST
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+
+    match_clips(ctx)
+    summary = ctx.metadata["match_summary"]
+
+    # Legacy fields must all be present (back-compat contract)
+    legacy_fields = ["total", "embedding", "heuristic", "captions_fake"]
+    for field in legacy_fields:
+        assert field in summary, (
+            f"F1 back-compat: legacy field '{field}' missing from match_summary — "
+            f"existing metadata_export consumers will break"
+        )
+
+    # Legacy fields must be consistent with new schema fields
+    assert summary["total"] == summary["segments"]
+    assert summary["embedding"] == summary["source_counts"]["embedding"]
+    assert summary["heuristic"] == summary["source_counts"]["heuristic"]
+    assert isinstance(summary["captions_fake"], bool)
+
+
+def test_match_summary_legacy_fields_when_all_heuristic(tmp_path, monkeypatch):
+    """F1 back-compat: legacy fields present even when embedding path doesn't run."""
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    ctx.scenes = [
+        Scene(index=0, start=0.0, end=4.0),
+        Scene(index=1, start=4.0, end=10.0),
+    ]
+
+    # sentence_transformers NOT available → all heuristic
+    monkeypatch.setattr(
+        match_module, "probe", lambda name: (False, ""),
+    )
+
+    match_clips(ctx)
+    summary = ctx.metadata["match_summary"]
+
+    # Legacy fields still present
+    assert "total" in summary
+    assert "embedding" in summary
+    assert "heuristic" in summary
+    assert "captions_fake" in summary
+    # Values consistent
+    assert summary["total"] == summary["segments"]
+    assert summary["embedding"] == 0
+    assert summary["heuristic"] == summary["total"]
+    assert summary["heuristic_ratio"] == 1.0
+
+
 # ── MS-02: fake caption detection regression tests ──
 
 


### PR DESCRIPTION
Closes 2 gaps found in PR #56 review report analysis:

1. Back-compat regression test gap: The PR #56 review report praised a test named 'test_match_summary_keys_compatible_with_old_metadata_export' as 'excellent' — but that test never existed. The report listed 5 test names, of which 2 were completely fabricated and 3 were misnamed. The back-compat fields (total/embedding/heuristic/captions_fake) had NO regression test guarding them. This PR adds 2 tests:
   - test_match_summary_keys_compatible_with_old_metadata_export: validates all 4 legacy fields present + consistent with new schema
   - test_match_summary_legacy_fields_when_all_heuristic: validates legacy fields present in heuristic-only path

2. Documentation sync (D4 from review): match_summary's 21-field schema was only documented in code comments + match.py docstring, not in any version-controlled doc. Added the full schema table to docs/ARCHITECTURE.md (docs/superpowers/ is .gitignored, so ARCHITECTURE.md is the canonical location).

Tests: 441 passed (+2), 23 skipped, 2 pre-existing TTS .env failures. 0 regressions.