### PR TITLE
chore: drop self-shaming docstring + main-push runs to completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,13 @@ on:
 # - push to main/feature: use ref name (one active run per branch)
 # - workflow_dispatch: use run_id (never cancels manual triggers)
 #
-# cancel-in-progress: true for all — main pushes are infrequent enough
-# that cancelling a stale run on rapid successive merges is desirable.
+# cancel-in-progress: only for PR events. Main-branch pushes represent
+# "release-ready" verification — each push should run to completion so
+# we always have a final pass/fail signal on main. Rapid successive
+# merges to main won't cancel each other's runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-matrix:

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -329,10 +329,6 @@ def test_match_summary_keys_compatible_with_old_metadata_export(tmp_path, monkey
     """F1 back-compat: match_summary preserves the 4 legacy fields
     (total/embedding/heuristic/captions_fake) so existing consumers
     (metadata_export, L2 checklist jq queries, older scripts) don't break.
-
-    This test was listed in the PR #56 review report as 'excellent' but
-    was never actually written — the report praised a non-existent test.
-    This regression test closes that gap.
     """
     ctx = _make_ctx(tmp_path)
     (tmp_path / "video.mp4").write_bytes(b"00")


### PR DESCRIPTION
Two minor cleanups from PR #57 + #58 review:

1. Drop self-shaming docstring (PR #57):
   test_match_summary_keys_compatible_with_old_metadata_export had 3 lines of docstring explaining it was "closing a gap left by a non-existent test praised in a previous review". This rhetoric is unnecessary — the test exists and guards the contract, that is what matters. Removed the 3 lines.

2. Main-push runs to completion (PR #58):
   cancel-in-progress was `true` for all events, including main-branch pushes. This means rapid successive merges to main would cancel each other, leaving no complete pass/fail signal on main. Changed to only cancel for PR events so:
   - PR events: stale runs cancelled (amend + force-push still deduplicates)
   - main/feature pushes: each run completes fully (release-ready verification preserved)
   - workflow_dispatch: not cancelled (manual triggers)

Tests: 27 passed (test_match.py), 0 regressions.
