### PR TITLE
chore(ci): cancel stale runs on feature/hotfix branch pushes too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ on:
 # - push to main/feature: use ref name (one active run per branch)
 # - workflow_dispatch: use run_id (never cancels manual triggers)
 #
-# cancel-in-progress: only for PR events. Main-branch pushes represent
-# "release-ready" verification — each push should run to completion so
-# we always have a final pass/fail signal on main. Rapid successive
-# merges to main won't cancel each other's runs.
+# cancel-in-progress: cancel for PR events AND non-main branch pushes.
+# Main-branch pushes represent "release-ready" verification — each push
+# runs to completion so we always have a final pass/fail signal on main.
+# Feature/hotfix branch pushes (including amend + force-push) cancel
+# stale runs — this closes the last gap from PR #57's 28-run runaway.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
 
 jobs:
   test-matrix:


### PR DESCRIPTION
Closes the last CI concurrency gap from PR #57's 28-run runaway.

## Problem

PR #59 changed `cancel-in-progress` to `${{ github.event_name == 'pull_request' }}` — only PR events cancel stale runs. But feature/hotfix branch pushes (including amend + force-push) still run to completion. PR #60 demonstrated this: it triggered 2 batches of CI runs (feature push + PR sync), wasting 7 jobs.

## Fix

Changed to `${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}`:

| Event | Old | New |
|-------|-----|-----|
| PR (pull_request) | cancel | cancel |
| push to main | run to completion | run to completion (unchanged) |
| push to feature/* | run to completion | **cancel** (fixed) |
| push to hotfix/* | run to completion | **cancel** (fixed) |
| workflow_dispatch | run to completion | run to completion (unchanged) |

Main-branch pushes still run to completion — "release-ready" verification must always produce a final pass/fail signal.

## What this closes

This is the last gap from PR #57 (which triggered 28 runs via amend + force-push). After this PR:
- PR amend + force-push: 1 batch (old cancelled)
- Feature branch amend + force-push: 1 batch (old cancelled)
- Main push: 1 batch (run to completion)
