### PR TITLE
feat(cli): add --output-dir/-o option to create, resolve, research commands

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -88,6 +88,10 @@ def create(
         None, "--narration-preset", "-p",
         help="解说风格预设 douyin-fast | mainstream-dry | bilibili-long / Narration style preset",
     ),
+    output_dir: Optional[str] = typer.Option(
+        None, "--output-dir", "-o",
+        help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
+    ),
 ):
     """生成解说短视频 — 从电影名到成片一站式产出.
 
@@ -172,8 +176,10 @@ def create(
             param_hint="--video",
         )
 
-    output_dir = Path("output") / _sanitize_filename(resolved.movie)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    # --output-dir / -o: user-specified output directory.
+    # Default: output/<sanitized-movie-name>
+    out_dir = Path(output_dir) if output_dir else Path("output") / _sanitize_filename(resolved.movie)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     ctx = build_context(
         movie=resolved.movie,
@@ -181,7 +187,7 @@ def create(
         duration=resolved.duration,
         voice=resolved.voice,
         format=resolved.format,
-        output_dir=output_dir,
+        output_dir=out_dir,
         keep_cache=resolved.keep_cache,
         video=resolved.video,
         library_dir=resolved.library_dir,
@@ -223,12 +229,16 @@ def resolve(
     movie: str = typer.Option(..., "--movie", "-m", help="电影名称 / Movie name to resolve"),
     library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library directory"),
     json_output: bool = typer.Option(False, "--json", help="JSON 格式输出 / Output result as JSON"),
+    output_dir: Optional[str] = typer.Option(
+        None, "--output-dir", "-o",
+        help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
+    ),
 ):
     """从影视库中查找电影 / Resolve a movie from library directory."""
-    output_dir = Path("output") / _sanitize_filename(movie)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = Path(output_dir) if output_dir else Path("output") / _sanitize_filename(movie)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    ctx = Context(movie_name=movie, output_dir=str(output_dir))
+    ctx = Context(movie_name=movie, output_dir=str(out_dir))
     if library_dir:
         ctx.library_dir = library_dir
     resolve_video(ctx)
@@ -247,19 +257,23 @@ def resolve(
 @app.command()
 def research(
     movie: str = typer.Option(..., "--movie", "-m", help="电影名称 / Movie name to research"),
+    output_dir: Optional[str] = typer.Option(
+        None, "--output-dir", "-o",
+        help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
+    ),
 ):
     """运行剧情研究并输出 research.json / Run plot research."""
-    output_dir = Path("output") / _sanitize_filename(movie)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = Path(output_dir) if output_dir else Path("output") / _sanitize_filename(movie)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    ctx = Context(movie_name=movie, output_dir=str(output_dir))
+    ctx = Context(movie_name=movie, output_dir=str(out_dir))
     ctx.metadata["research_enabled"] = True
     research_plot(ctx)
 
     if ctx.status.research == "failed":
         raise typer.Exit(1)
 
-    research_path = output_dir / "research.json"
+    research_path = out_dir / "research.json"
     if research_path.exists():
         typer.echo(f"Research written to: {research_path}")
     else:

--- a/tests/test_cli_resolve.py
+++ b/tests/test_cli_resolve.py
@@ -40,3 +40,73 @@ def test_research_writes_envelope(tmp_path, monkeypatch):
     data = json.loads(research_path.read_text(encoding="utf-8"))
     assert "status" in data
     assert "error" in data
+
+
+# ── --output-dir / -o option tests ──
+
+
+def test_resolve_output_dir_option_writes_to_user_dir(tmp_path, monkeypatch):
+    """--output-dir writes to user-specified directory instead of output/<movie>."""
+    monkeypatch.chdir(tmp_path)
+    # Place a fake video so resolve succeeds (exit_code 0)
+    (tmp_path / "Inception.mp4").write_bytes(b"00")
+    custom_dir = tmp_path / "my-custom-output"
+    result = runner.invoke(
+        app,
+        ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path),
+         "--output-dir", str(custom_dir)],
+    )
+    assert result.exit_code == 0
+    # Custom directory should exist (created by the command)
+    assert custom_dir.exists()
+    assert custom_dir.is_dir()
+
+
+def test_resolve_output_dir_short_option(tmp_path, monkeypatch):
+    """-o short option works the same as --output-dir."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Inception.mp4").write_bytes(b"00")
+    custom_dir = tmp_path / "short-opt-out"
+    result = runner.invoke(
+        app,
+        ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path),
+         "-o", str(custom_dir)],
+    )
+    assert result.exit_code == 0
+    assert custom_dir.exists()
+
+
+def test_resolve_output_dir_default_when_not_specified(tmp_path, monkeypatch):
+    """Without --output-dir, falls back to output/<sanitized-movie> (backward compat)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Inception.mp4").write_bytes(b"00")
+    result = runner.invoke(
+        app,
+        ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    # Default path: output/Inception/ (sanitized)
+    default_dir = tmp_path / "output" / "Inception"
+    assert default_dir.exists()
+
+
+def test_research_output_dir_option_writes_to_user_dir(tmp_path, monkeypatch):
+    """research --output-dir creates the user-specified directory.
+
+    Note: we don't assert exit_code==0 because research requires an LLM API
+    key which is not available in CI. We only verify that --output-dir is
+    parsed and the custom directory is created (the CLI-level contract).
+    The research.json write itself is tested by test_research_writes_envelope.
+    """
+    monkeypatch.chdir(tmp_path)
+    custom_dir = tmp_path / "research-custom"
+    result = runner.invoke(
+        app,
+        ["research", "--movie", "Inception", "--output-dir", str(custom_dir)],
+    )
+    # Custom directory should be created regardless of research success/failure
+    # (mkdir happens before research_plot is called)
+    assert custom_dir.exists()
+    assert custom_dir.is_dir()
+    # Default path should NOT exist
+    assert not (tmp_path / "output" / "Inception").exists()


### PR DESCRIPTION
Adds `--output-dir` / `-o` option to the 3 core CLI commands (`create`, `resolve`, `research`), fixing the architecture inconsistency where debug commands (`debug-match`, `debug-render`, `debug-voices`) had `--output` but core commands hardcoded `output/<sanitized-movie>`.

## Problem

`mn create` had no way to control output location — it always wrote to `output/<sanitized-movie>/`. This forced users to manually `mv` results for:
- Batch processing different movies (results scattered in `output/`)
- Versioning multiple runs of the same movie (overwrites previous)
- Outputting to external directories (NAS, project workspace)

Meanwhile `debug-*` commands already had `--output` — core commands were less flexible than debug commands (anti-pattern).

## Fix

Added `--output-dir` / `-o` to `create`, `resolve`, `research`:

```bash
mn create -m "Inception" --output-dir ~/my-videos/inception-v2
mn create -m "Inception" -o ./out
mn resolve -m "Inception" --library-dir ./movies -o ./resolved
mn research -m "Inception" -o ./research-out
```

**Backward compatible**: when `--output-dir` is not specified, falls back to the original `output/<sanitized-movie>` behavior. Zero breaking change.

## Implementation

Each command now does:
```python
out_dir = Path(output_dir) if output_dir else Path("output") / _sanitize_filename(movie)
out_dir.mkdir(parents=True, exist_ok=True)
```

## Tests

4 new CLI tests in `test_cli_resolve.py`:
- `test_resolve_output_dir_option_writes_to_user_dir`: `--output-dir` creates custom dir
- `test_resolve_output_dir_short_option`: `-o` short option works
- `test_resolve_output_dir_default_when_not_specified`: default `output/<movie>` preserved
- `test_research_output_dir_option_writes_to_user_dir`: `research --output-dir` writes to custom dir, default path NOT created

Tests: 448 passed (+4), 23 skipped, 2 pre-existing TTS .env failures. 0 regressions.
