### PR TITLE
feat(web-api): collect per-segment clips in collect_artifacts + cleanup stale branches

### DIFF
--- a/src/movie_narrator/web_api/utils.py
+++ b/src/movie_narrator/web_api/utils.py
@@ -132,6 +132,11 @@ def collect_artifacts(ctx, output_dir: Path) -> List[str]:
     meta_path = output_dir / "metadata.json"
     if meta_path.exists():
         artifacts.append(str(meta_path))
+    # Clips directory (per-segment .mp4 files from export_clips step)
+    clips_dir = Path(ctx.clips_dir) if ctx.clips_dir else output_dir / "clips"
+    if clips_dir.is_dir():
+        for clip in sorted(clips_dir.glob("*.mp4")):
+            artifacts.append(str(clip))
     return artifacts
 
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -342,9 +342,49 @@ def test_validate_form_bilingual_no_lang():
 
 def test_collect_artifacts_empty(tmp_path):
     """A ctx with no outputs yields an empty artifact list."""
-    ctx = SimpleNamespace(video_path=None, audio_path=None, subtitle_paths=None)
+    ctx = SimpleNamespace(video_path=None, audio_path=None, subtitle_paths=None, clips_dir=None)
     artifacts = collect_artifacts(ctx, tmp_path)
     assert artifacts == []
+
+
+def test_collect_artifacts_includes_clips(tmp_path):
+    """collect_artifacts includes per-segment .mp4 clips from clips_dir."""
+    clips_dir = tmp_path / "clips"
+    clips_dir.mkdir()
+    (clips_dir / "scene_0000.mp4").write_bytes(b"clip0")
+    (clips_dir / "scene_0001.mp4").write_bytes(b"clip1")
+    # Non-mp4 file should be ignored
+    (clips_dir / "notes.txt").write_text("ignore me", encoding="utf-8")
+
+    ctx = SimpleNamespace(
+        video_path=None,
+        audio_path=None,
+        subtitle_paths=None,
+        clips_dir=str(clips_dir),
+    )
+    artifacts = collect_artifacts(ctx, tmp_path)
+    clip_artifacts = [a for a in artifacts if "scene_" in a and a.endswith(".mp4")]
+    assert len(clip_artifacts) == 2
+    # Clips should be sorted
+    assert "scene_0000" in clip_artifacts[0]
+    assert "scene_0001" in clip_artifacts[1]
+
+
+def test_collect_artifacts_clips_default_dir(tmp_path):
+    """When ctx.clips_dir is None, falls back to output_dir/clips."""
+    clips_dir = tmp_path / "clips"
+    clips_dir.mkdir()
+    (clips_dir / "scene_0000.mp4").write_bytes(b"clip0")
+
+    ctx = SimpleNamespace(
+        video_path=None,
+        audio_path=None,
+        subtitle_paths=None,
+        clips_dir=None,
+    )
+    artifacts = collect_artifacts(ctx, tmp_path)
+    clip_artifacts = [a for a in artifacts if "scene_" in a and a.endswith(".mp4")]
+    assert len(clip_artifacts) == 1
 
 
 def test_zip_artifacts(tmp_path):


### PR DESCRIPTION
Cherry-picks the only valuable unmerged change from `feature/docs-sync-with-code` branch, then cleans up 3 stale remote branches.

## What this does

1. **collect_artifacts clips collection** (5 lines): `collect_artifacts()` now collects per-segment `.mp4` files from the clips directory. When `ctx.clips_dir` is set (by `export_clips` step), uses it; otherwise falls back to `output_dir/clips`. This lets Web UI users download individual segment clips alongside the final video.

2. **Deletes 3 stale remote branches** (all fully merged into main via prior PRs):
   - `feature/core-engine-production-quality` — merged via PR #37
   - `feature/docs-sync-with-code` — merged via PR #51 (clips collection was the only unmerged piece, now cherry-picked here)
   - `release/v0.4.11` — merged via PR #32, version long superseded

## Tests

2 new tests:
- `test_collect_artifacts_includes_clips`: clips collected from `ctx.clips_dir`, sorted, non-mp4 ignored
- `test_collect_artifacts_clips_default_dir`: falls back to `output_dir/clips` when `ctx.clips_dir` is None

1 existing test updated (`test_collect_artifacts_empty`): added `clips_dir=None` to SimpleNamespace.

Tests: 36 passed (+2), 0 regressions.
