### PR TITLE
chore(ci): only trigger on main push, feature branches get CI via PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "feature/*", "hotfix/*"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:
@@ -11,16 +11,21 @@ on:
 # when a new push arrives. This avoids wasted CI minutes when a PR is
 # amended + force-pushed (e.g. PR #57 triggered 28 runs instead of 14).
 #
+# Trigger strategy:
+# - push: only main branch (feature/hotfix branches don't trigger CI
+#   on push — they get CI via the pull_request event instead, avoiding
+#   duplicate runs from push + PR sync)
+# - pull_request: all PRs targeting main
+# - workflow_dispatch: manual triggers
+#
 # Group strategy:
-# - PR: use pr-{number} so amend + force-push (same ref, new commit) cancels old runs
-# - push to main/feature: use ref name (one active run per branch)
+# - PR: use pr-{number} so amend + force-push cancels old runs
+# - push to main: use ref name (one active run per branch)
 # - workflow_dispatch: use run_id (never cancels manual triggers)
 #
 # cancel-in-progress: cancel for PR events AND non-main branch pushes.
 # Main-branch pushes represent "release-ready" verification — each push
 # runs to completion so we always have a final pass/fail signal on main.
-# Feature/hotfix branch pushes (including amend + force-push) cancel
-# stale runs — this closes the last gap from PR #57's 28-run runaway.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Fixes the duplicate CI runs issue: feature branch push + PR sync were triggering 2 batches of CI runs because they had different concurrency groups.

## Fix

Removed feature/* and hotfix/* from the push trigger. Now:
- push to main: triggers CI (release-ready verification)
- push to feature/hotfix: does NOT trigger CI (gets CI via pull_request event instead)
- pull_request: triggers CI (the only trigger for feature branch work)

This eliminates the duplicate run problem at the source — no need for complex concurrency group unification.

## Before vs After

| Event | Before | After |
|-------|--------|-------|
| push to main | CI runs | CI runs (unchanged) |
| push to feature/* | CI runs (batch 1) | No CI (waits for PR) |
| PR created/synced | CI runs (batch 2) | CI runs (only batch) |
| amend + force-push | 2 batches | 1 batch (PR event only) |

This is the GitHub Actions recommended pattern — feature work is validated through PRs, not direct pushes.