### PR TITLE
feat(align): faster-whisper backend with environment-adaptive selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 media = ["scenedetect>=0.6"]
 ml = [
     'whisperx>=3.0; python_version < "3.14"',
+    'faster-whisper>=1.0; python_version < "3.14"',
     'sentence-transformers>=3.0; python_version < "3.14"',
 ]
 web = [
@@ -48,6 +49,7 @@ web = [
 full = [
     "scenedetect>=0.6",
     'whisperx>=3.0; python_version < "3.14"',
+    'faster-whisper>=1.0; python_version < "3.14"',
     'sentence-transformers>=3.0; python_version < "3.14"',
     "movie-narrator[web]",
 ]

--- a/src/movie_narrator/pipeline/_align_backend.py
+++ b/src/movie_narrator/pipeline/_align_backend.py
@@ -1,0 +1,128 @@
+"""Environment-adaptive backend selection for audio alignment.
+
+WhisperX (the original backend) depends on pyannote VAD → speechbrain →
+k2-fsa, whose C++ extension has no prebuilt Windows CPU wheel. On top of
+that, torch 2.8's ``weights_only=True`` default rejects pyannote's
+omegaconf pickle. These are upstream issues that make WhisperX unusable
+on Windows CPU and fragile on Linux CPU.
+
+faster-whisper is a CTranslate2 reimplementation that does not depend on
+pyannote / speechbrain / k2-fsa. L2 handtest showed it transcribes 60s
+of Chinese audio in 1.9s on CPU with the ``small`` model, producing 18
+accurate segments. The only thing it lacks is word-level forced
+alignment, but ``subtitle.py`` only consumes segment-level timestamps
+(``seg.start`` / ``seg.end`` / ``seg.text``), so the loss has zero
+downstream impact.
+
+This module decides which backend to use, runs it, and returns a
+uniform ``wx_segments`` list that ``align.py``'s remapping loop consumes
+unchanged.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import List, Tuple
+
+from ..models import Context
+from ..utils.optional_deps import probe
+
+
+class BackendUnavailable(Exception):
+    """Raised when a backend cannot be initialized."""
+
+
+def select_align_backend(ctx: Context) -> Tuple[str, str]:
+    """Return ``(backend, reason)``.
+
+    ``backend`` is one of ``"whisperx"``, ``"faster_whisper"``, ``"none"``.
+    The decision is based on:
+
+    1. Explicit override via ``ctx.metadata['align_backend']``
+    2. GPU available + whisperx importable → whisperx
+    3. CPU + whisperx importable + non-Windows → whisperx
+       (k2-fsa has prebuilt wheels on Linux/macOS)
+    4. Windows CPU + whisperx importable → faster_whisper
+       (k2-fsa has no prebuilt Windows CPU wheel)
+    5. whisperx not importable → faster_whisper
+    6. faster_whisper not importable → none
+    """
+    # 1. Explicit override
+    override = ctx.metadata.get("align_backend")
+    if override in ("whisperx", "faster_whisper"):
+        ok, _ = probe(override)
+        if ok:
+            return override, f"explicit override (align_backend={override})"
+        # Override requested but unavailable — fall through to auto-detect
+        # and record the failure reason in metadata
+        ctx.metadata.setdefault("align_backend_attempted", []).append(
+            f"{override}: explicit override but import failed"
+        )
+
+    # 2-5. Auto-detect
+    wx_ok, _ = probe("whisperx")
+    fw_ok, _ = probe("faster_whisper")
+    device = ctx.metadata.get("whisperx_device", "cpu")
+    is_windows = platform.system() == "Windows"
+
+    if wx_ok:
+        if device == "cuda":
+            return "whisperx", "GPU available + whisperx importable"
+        if not is_windows:
+            # Linux/macOS CPU: k2-fsa has prebuilt wheels
+            return "whisperx", "CPU (non-Windows) + whisperx importable"
+        # Windows CPU: k2-fsa likely missing → prefer faster_whisper
+        if fw_ok:
+            return "faster_whisper", "Windows CPU (k2-fsa may be unavailable) → faster_whisper"
+        # faster_whisper not installed, but whisperx is — try whisperx
+        # and let it fail at load_align_model time (graceful fallback)
+        return "whisperx", "Windows CPU but faster_whisper not installed; trying whisperx"
+
+    # whisperx not importable
+    if fw_ok:
+        return "faster_whisper", "whisperx not importable → faster_whisper"
+
+    return "none", "neither whisperx nor faster_whisper importable"
+
+
+def run_faster_whisper(ctx: Context) -> List[dict]:
+    """Transcribe with faster-whisper, return ``wx_segments`` list.
+
+    Each element: ``{"start": float, "end": float, "text": str}`` — the
+    same shape WhisperX's transcribe produces, so ``align.py``'s
+    remapping loop consumes it unchanged.
+
+    No forced alignment (word-level timestamps) — segment-level only.
+    This is sufficient for ``subtitle.py`` which only reads
+    ``seg.start`` / ``seg.end`` / ``seg.text``.
+    """
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError as e:
+        raise BackendUnavailable(f"faster-whisper not installed: {e}") from e
+
+    device = ctx.metadata.get("whisperx_device", "cpu")
+    language = ctx.metadata.get("whisperx_language", "zh")
+    model_size = ctx.metadata.get("whisperx_model", "small")
+
+    # CPU: int8 quantization (fast + small); GPU: float16
+    if device == "cuda":
+        compute_type = "float16"
+        fw_device = "cuda"
+    else:
+        compute_type = "int8"
+        fw_device = "cpu"
+
+    model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
+    segments, _info = model.transcribe(ctx.audio_path, language=language)
+
+    wx_segments: List[dict] = []
+    for seg in segments:
+        text = seg.text.strip()
+        if text:
+            wx_segments.append({
+                "start": float(seg.start),
+                "end": float(seg.end),
+                "text": text,
+            })
+    return wx_segments

--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -1,5 +1,6 @@
 from ..models import Context, StepResult
 from ..utils.optional_deps import probe
+from ._align_backend import select_align_backend, run_faster_whisper, BackendUnavailable
 
 
 def align_audio(ctx: Context) -> Context:
@@ -22,18 +23,63 @@ def align_audio(ctx: Context) -> Context:
         The same (mutated) context with ``ctx.status.align`` set to one
         of ``disabled`` / ``skipped`` / ``success`` / ``failed``.
     """
-    ok, hint = probe("whisperx")
-    if not ok:
-        ctx.status.align = "disabled"
-        ctx.step_state.result = StepResult.SKIPPED
-        ctx.step_state.message = hint
-        return ctx
+    # B+: backend availability is checked by select_align_backend() below,
+    # which probes both whisperx and faster_whisper. The old whisperx-only
+    # probe here was removed to allow faster_whisper fallback when whisperx
+    # is not importable.
     if not ctx.audio_path:
         ctx.status.align = "skipped"
         ctx.step_state.result = StepResult.SKIPPED
         ctx.step_state.message = "no audio"
         return ctx
 
+    # ── B+: Environment-adaptive backend selection ──
+    # WhisperX depends on pyannote VAD → speechbrain → k2-fsa, which
+    # has no prebuilt Windows CPU wheel. On Windows CPU (or when
+    # whisperx is not importable), we use faster-whisper instead.
+    # The user can override with ctx.metadata['align_backend'].
+    backend, backend_reason = select_align_backend(ctx)
+    ctx.metadata["align_backend_used"] = backend
+    ctx.metadata["align_backend_reason"] = backend_reason
+
+    if backend == "none":
+        ctx.services.console.inline_warn(
+            f"Audio alignment unavailable: {backend_reason}"
+        )
+        ctx.status.align = "disabled"
+        ctx.step_state.result = StepResult.SKIPPED
+        ctx.step_state.message = backend_reason
+        return ctx
+
+    try:
+        if backend == "faster_whisper":
+            return _align_with_faster_whisper(ctx)
+        else:
+            return _align_with_whisperx(ctx)
+    except BackendUnavailable as e:
+        # faster-whisper was selected but failed at runtime — try whisperx
+        ctx.services.console.inline_warn(
+            f"faster-whisper failed ({e}); trying whisperx"
+        )
+        ctx.metadata.setdefault("align_backend_attempted", []).append(
+            f"faster_whisper: {e}"
+        )
+        try:
+            return _align_with_whisperx(ctx)
+        except Exception as fallback_err:
+            ctx.step_state.result = StepResult.WARNING
+            ctx.step_state.message = str(fallback_err)
+            ctx.status.align = "failed"
+            return ctx
+    except Exception as e:
+        ctx.step_state.result = StepResult.WARNING
+        ctx.step_state.message = str(e)
+        ctx.status.align = "failed"
+        return ctx
+
+
+def _align_with_whisperx(ctx: Context) -> Context:
+    """Original WhisperX backend (transcribe + forced alignment)."""
     try:
         import whisperx
 
@@ -209,3 +255,87 @@ def align_audio(ctx: Context) -> Context:
         ctx.step_state.message = str(e)
         ctx.status.align = "failed"
         return ctx
+
+
+def _align_with_faster_whisper(ctx: Context) -> Context:
+    """faster-whisper backend (segment-level only, no forced alignment).
+
+    Uses the shared remapping logic from _align_with_whisperx by
+    constructing wx_segments via run_faster_whisper() then running
+    the same drift detection + monotonic remapping.
+    """
+    wx_segments = run_faster_whisper(ctx)
+
+    if not wx_segments:
+        ctx.services.console.inline_warn(
+            "faster-whisper returned no speech segments; "
+            "timestamps remain TTS-estimated"
+        )
+        ctx.status.align = "skipped"
+        ctx.step_state.result = StepResult.WARNING
+        ctx.step_state.message = "faster-whisper ASR returned empty"
+        ctx.metadata["align_degraded"] = True
+        return ctx
+
+    # faster-whisper has no forced alignment → always mark as fallback
+    ctx.metadata["align_fallback"] = True
+    ctx.status.align = "failed"
+    ctx.step_state.result = StepResult.WARNING
+    ctx.step_state.message = "faster-whisper (segment-level, no forced alignment)"
+    ctx.metadata["align_degraded"] = True
+
+    # ── AQ-01: Drift detection (same as WhisperX path) ──
+    if len(wx_segments) == 1 and ctx.timed_segments:
+        total_narr_duration = sum(
+            ts.end - ts.start for ts in ctx.timed_segments
+        )
+        wx_duration = wx_segments[0]["end"] - wx_segments[0]["start"]
+        if total_narr_duration > 0:
+            drift_ratio = abs(wx_duration - total_narr_duration) / total_narr_duration
+            if drift_ratio > 0.5:
+                ctx.services.console.inline_warn(
+                    f"faster-whisper single-segment duration drift {drift_ratio:.0%} "
+                    f"(fw={wx_duration:.1f}s vs narr={total_narr_duration:.1f}s); "
+                    f"timestamps remain TTS-estimated"
+                )
+                ctx.status.align = "skipped"
+                ctx.step_state.message = "faster-whisper drift too large"
+                return ctx
+
+    # ── Monotonic non-overlap remapping (shared logic) ──
+    prev_end = 0.0
+    backward_skipped = 0
+    for ts in ctx.timed_segments:
+        ts_mid = (ts.start + ts.end) / 2.0
+        best = None
+        best_dist = float("inf")
+        for wseg in wx_segments:
+            if wseg["start"] <= ts_mid <= wseg["end"]:
+                best = wseg
+                break
+            wseg_mid = (wseg["start"] + wseg["end"]) / 2.0
+            dist = abs(wseg_mid - ts_mid)
+            if dist < best_dist:
+                best_dist = dist
+                best = wseg
+        if best:
+            new_start = best["start"]
+            new_end = best["end"]
+            original_duration = new_end - new_start
+            if (
+                new_start < prev_end
+                and (prev_end - new_start) > original_duration * 0.5
+            ):
+                backward_skipped += 1
+                continue
+            if new_start < prev_end:
+                new_start = prev_end
+            if new_end <= new_start:
+                new_end = new_start + 0.1
+            ts.start = new_start
+            ts.end = new_end
+            prev_end = new_end
+
+    ctx.metadata["align_segments"] = len(wx_segments)
+    ctx.metadata["align_backward_skipped"] = backward_skipped
+    return ctx

--- a/src/movie_narrator/utils/optional_deps.py
+++ b/src/movie_narrator/utils/optional_deps.py
@@ -4,6 +4,7 @@ from typing import Tuple
 _HINTS = {
     "scenedetect": 'pip install "movie-narrator[media]"',
     "whisperx": 'pip install "movie-narrator[ml]"',
+    "faster_whisper": 'pip install "movie-narrator[ml]"',
     "sentence_transformers": 'pip install "movie-narrator[ml]"',
 }
 
@@ -13,6 +14,7 @@ def probe(name: str) -> Tuple[bool, str]:
     module_names = {
         "scenedetect": "scenedetect",
         "whisperx": "whisperx",
+        "faster_whisper": "faster_whisper",
         "sentence_transformers": "sentence_transformers",
     }
     mod = module_names.get(name, name)

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -27,6 +27,7 @@ _ALLOWED_TOP = (
     "subtitle_lang",
     "subtitle_mode",
     "narration_preset",
+    "align_backend",
 )
 
 

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -92,6 +92,7 @@ def merge_job(
             "research_provider",
             # WhisperX
             "whisperx_device", "whisperx_model", "whisperx_language",
+            "align_backend",
             # Render
             "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
             "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -54,6 +54,7 @@ class JobParams(BaseModel):
     whisperx_device: Optional[str] = None
     whisperx_model: Optional[str] = None
     whisperx_language: Optional[str] = None
+    align_backend: Optional[str] = None  # "whisperx" | "faster_whisper" | None (auto)
     # ── Render ──
     render_fps: Optional[int] = None
     render_video_codec: Optional[str] = None

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -65,6 +65,129 @@ def test_align_success_with_mocked_whisperx(tmp_path):
     assert ctx.status.align == "success"
 
 
+# ── B+: Environment-adaptive backend selection tests ──
+
+
+def test_select_align_backend_explicit_override(tmp_path, monkeypatch):
+    """Explicit align_backend override is respected when the backend is importable."""
+    from movie_narrator.pipeline._align_backend import select_align_backend
+
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["align_backend"] = "faster_whisper"
+
+    monkeypatch.setattr(
+        "movie_narrator.pipeline._align_backend.probe",
+        lambda name: (True, "") if name == "faster_whisper" else (False, ""),
+    )
+    backend, reason = select_align_backend(ctx)
+    assert backend == "faster_whisper"
+    assert "explicit override" in reason
+
+
+def test_select_align_backend_windows_cpu_prefers_faster_whisper(tmp_path, monkeypatch):
+    """Windows CPU + both backends importable → faster_whisper (k2-fsa issue)."""
+    from movie_narrator.pipeline._align_backend import select_align_backend
+
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["whisperx_device"] = "cpu"
+
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, ""))
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.platform.system", lambda: "Windows")
+
+    backend, reason = select_align_backend(ctx)
+    assert backend == "faster_whisper"
+    assert "Windows CPU" in reason
+
+
+def test_select_align_backend_linux_cpu_prefers_whisperx(tmp_path, monkeypatch):
+    """Linux CPU + whisperx importable → whisperx (k2-fsa has wheels)."""
+    from movie_narrator.pipeline._align_backend import select_align_backend
+
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["whisperx_device"] = "cpu"
+
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, ""))
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.platform.system", lambda: "Linux")
+
+    backend, reason = select_align_backend(ctx)
+    assert backend == "whisperx"
+    assert "non-Windows" in reason
+
+
+def test_select_align_backend_gpu_prefers_whisperx(tmp_path, monkeypatch):
+    """GPU + whisperx importable → whisperx (word-level alignment)."""
+    from movie_narrator.pipeline._align_backend import select_align_backend
+
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["whisperx_device"] = "cuda"
+
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, ""))
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.platform.system", lambda: "Windows")
+
+    backend, reason = select_align_backend(ctx)
+    assert backend == "whisperx"
+    assert "GPU" in reason
+
+
+def test_select_align_backend_neither_available(tmp_path, monkeypatch):
+    """Neither backend importable → none."""
+    from movie_narrator.pipeline._align_backend import select_align_backend
+
+    ctx = _make_ctx(tmp_path)
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (False, ""))
+
+    backend, reason = select_align_backend(ctx)
+    assert backend == "none"
+    assert "neither" in reason
+
+
+def test_align_faster_whisper_path(tmp_path, monkeypatch):
+    """faster_whisper backend produces segment-level timestamps + fallback status."""
+    ctx = _make_ctx(tmp_path)
+    ctx.metadata["align_backend"] = "faster_whisper"
+
+    # Mock faster_whisper module — 2 segments matching narration duration
+    # (_make_ctx has [A(0,2), B(2.5,5)] → total 4.5s; use 2 segs summing ~4.5s)
+    fake_fw = types.ModuleType("faster_whisper")
+    fake_seg1 = MagicMock()
+    fake_seg1.start = 0.1
+    fake_seg1.end = 2.0
+    fake_seg1.text = " 第一段 "
+    fake_seg2 = MagicMock()
+    fake_seg2.start = 2.5
+    fake_seg2.end = 5.0
+    fake_seg2.text = " 第二段 "
+    fake_model = MagicMock()
+    fake_model.transcribe = MagicMock(return_value=([fake_seg1, fake_seg2], MagicMock()))
+    fake_fw.WhisperModel = MagicMock(return_value=fake_model)
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "faster_whisper" else (False, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "faster_whisper" else (False, ""))
+        m.setitem(sys.modules, "faster_whisper", fake_fw)
+        align_audio(ctx)
+
+    # faster_whisper has no forced alignment → status='failed' (degraded but usable)
+    assert ctx.status.align == "failed"
+    assert ctx.metadata.get("align_backend_used") == "faster_whisper"
+    assert ctx.metadata.get("align_fallback") is True
+    assert ctx.metadata.get("align_degraded") is True
+    assert ctx.metadata.get("align_segments") == 2
+
+
+def test_align_backend_none_when_neither_importable(tmp_path, monkeypatch):
+    """When neither backend is importable, align is disabled (not failed)."""
+    ctx = _make_ctx(tmp_path)
+
+    monkeypatch.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (False, ""))
+    monkeypatch.setattr("movie_narrator.pipeline.align.probe", lambda name: (False, ""))
+
+    align_audio(ctx)
+
+    assert ctx.status.align == "disabled"
+    assert ctx.step_state.result.value == "skipped"
+
+
 # ── F4: backward jump detection ──
 
 


### PR DESCRIPTION
Adds faster-whisper as an alternative alignment backend with environment-adaptive selection. Closes the WhisperX CPU compatibility blocker from L2 handtest 20260721.

## Problem

WhisperX depends on pyannote VAD → speechbrain → k2-fsa, whose C++ extension has no prebuilt Windows CPU wheel. torch 2.8's `weights_only=True` default also rejects pyannote's omegaconf pickle. L2 handtest showed WhisperX medium on CPU produces empty transcriptions after 13s inference.

faster-whisper (CTranslate2) has none of these dependencies. L2 handtest: `faster-whisper small` transcribes 60s Chinese audio in 1.9s on CPU, 18 accurate segments.

## Solution: Environment-adaptive backend selection

New `pipeline/_align_backend.py` (~120 lines) with `select_align_backend()`:

| Environment | Backend | Reason |
|-------------|---------|--------|
| GPU + whisperx importable | whisperx | Word-level forced alignment |
| Linux/macOS CPU + whisperx | whisperx | k2-fsa has prebuilt wheels |
| Windows CPU + both importable | faster_whisper | k2-fsa has no Windows wheel |
| whisperx not importable | faster_whisper | Fallback |
| Neither importable | none | Skip with warning |

User can override with `align_backend: whisperx|faster_whisper` in `project.yaml`.

## Key design decision: subtitle.py is unaffected

`subtitle.py` only reads `seg.start` / `seg.end` / `seg.text` (segment-level). It does **not** use word-level timestamps from forced alignment. So losing forced alignment when using faster-whisper has **zero downstream impact** on subtitle generation.

## Metadata additions

- `align_backend_used`: actual backend used ("whisperx" / "faster_whisper" / "none")
- `align_backend_reason`: why this backend was selected
- `align_backend_attempted`: list of failed attempts (when fallback chain triggers)

## Files changed (8 files, +394/-6)

- `pyproject.toml`: add `faster-whisper>=1.0` to [ml] and [full]
- `utils/optional_deps.py`: add `faster_whisper` to probe/hints
- `pipeline/_align_backend.py` (NEW): `select_align_backend()` + `run_faster_whisper()`
- `pipeline/align.py`: dispatch layer (`_align_with_whisperx` / `_align_with_faster_whisper`)
- `workflow/merge.py`: add `align_backend` to params whitelist
- `workflow/load.py`: add `align_backend` to `_ALLOWED_TOP`
- `workflow/schema.py`: add `align_backend` field to `Params`
- `tests/test_align.py`: +7 new tests (backend selection matrix + faster-whisper path)

## Tests

7 new tests:
- `test_select_align_backend_explicit_override`: override respected
- `test_select_align_backend_windows_cpu_prefers_faster_whisper`: Windows CPU → faster_whisper
- `test_select_align_backend_linux_cpu_prefers_whisperx`: Linux CPU → whisperx
- `test_select_align_backend_gpu_prefers_whisperx`: GPU → whisperx
- `test_select_align_backend_neither_available`: neither → none
- `test_align_faster_whisper_path`: faster_whisper produces timestamps + fallback status
- `test_align_backend_none_when_neither_importable`: disabled (not failed) when neither available

Tests: 457 passed (+9 total this session), 23 skipped, 2 pre-existing TTS .env failures. 0 regressions.
