### PR TITLE
fix(align): faster-whisper success path reports success not failed

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,12 +232,14 @@ Full schema (21 fields + 4 back-compat fields):
 
 **`status.align` semantics:**
 
-| Value | Meaning | Timestamps |
-|-------|---------|------------|
-| `success` | WhisperX transcribe + forced alignment both succeeded | Word-level (best precision) |
-| `failed` | Alignment ran but degraded to segment-level. **Timestamps are still usable** — subtitle.py only needs segment-level. Triggered by: (a) WhisperX `align()` raised → fallback to transcript-level, (b) faster-whisper backend (always segment-level). | Segment-level |
-| `skipped` | ASR returned empty or single-segment drift too large. Timestamps remain TTS-estimated. | TTS-estimated |
-| `disabled` | Neither whisperx nor faster_whisper importable. | TTS-estimated |
+| Value | Meaning | Timestamps | In `_degraded_steps`? |
+|-------|---------|------------|----------------------|
+| `success` | Alignment succeeded. May be word-level (WhisperX forced align) or segment-level (faster-whisper). Check `align_fallback` flag to distinguish. | Word-level or segment-level | No |
+| `failed` | WhisperX forced alignment raised — fell back to transcript-level timestamps. Timestamps are still usable (segment-level). | Segment-level | Yes |
+| `skipped` | ASR returned empty or single-segment drift too large. Timestamps remain TTS-estimated. | TTS-estimated | Yes |
+| `disabled` | Neither whisperx nor faster_whisper importable. | TTS-estimated | No (uses `skipped` step result) |
+
+**`align_fallback` flag**: When `True`, alignment used segment-level timestamps only (no word-level forced alignment). This is set when: (a) WhisperX `align()` raised → fallback to transcript-level, (b) faster-whisper backend used. **Segment-level timestamps are sufficient for subtitle.py and embedding re-rank** (L2 handtest: `embedding_ratio=1.0` with faster-whisper).
 
 `align_backward_skipped > 0` means some segments' timestamps are TTS estimates
 (not WhisperX-aligned) because the wx segment mapped far behind the previous

--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -294,12 +294,17 @@ def _align_with_faster_whisper(ctx: Context) -> Context:
         ctx.metadata["align_degraded"] = True
         return ctx
 
-    # faster-whisper has no forced alignment → always mark as fallback
+    # faster-whisper has no forced alignment → mark as fallback.
+    # But transcription + remapping DID succeed, so status='success'
+    # (not 'failed'). The align_fallback flag carries the "segment-level
+    # only" signal for metadata consumers. This prevents faster-whisper
+    # from appearing in _degraded_steps (runner.py:386 checks for
+    # 'failed'/'skipped'), since the output quality is not degraded —
+    # subtitle.py only needs segment-level timestamps, and embedding
+    # re-rank works at full ratio (L2 handtest: embedding_ratio=1.0).
     ctx.metadata["align_fallback"] = True
-    ctx.status.align = "failed"
-    ctx.step_state.result = StepResult.WARNING
+    ctx.status.align = "success"
     ctx.step_state.message = "faster-whisper (segment-level, no forced alignment)"
-    ctx.metadata["align_degraded"] = True
 
     # ── AQ-01: Drift detection (shared logic) ──
     if _detect_drift(ctx, wx_segments, "faster-whisper"):

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -142,7 +142,7 @@ def test_select_align_backend_neither_available(tmp_path, monkeypatch):
 
 
 def test_align_faster_whisper_path(tmp_path, monkeypatch):
-    """faster_whisper backend produces segment-level timestamps + fallback status."""
+    """faster_whisper backend produces segment-level timestamps + success status."""
     ctx = _make_ctx(tmp_path)
     ctx.metadata["align_backend"] = "faster_whisper"
 
@@ -167,11 +167,12 @@ def test_align_faster_whisper_path(tmp_path, monkeypatch):
         m.setitem(sys.modules, "faster_whisper", fake_fw)
         align_audio(ctx)
 
-    # faster_whisper has no forced alignment → status='failed' (degraded but usable)
-    assert ctx.status.align == "failed"
+    # faster-whisper succeeded: status='success' (not 'failed'), align_fallback
+    # signals segment-level only. NOT in _degraded_steps because output quality
+    # is not degraded (subtitle.py only needs segment-level).
+    assert ctx.status.align == "success"
     assert ctx.metadata.get("align_backend_used") == "faster_whisper"
     assert ctx.metadata.get("align_fallback") is True
-    assert ctx.metadata.get("align_degraded") is True
     assert ctx.metadata.get("align_segments") == 2
 
 


### PR DESCRIPTION
## Problem

faster-whisper 成功转录 + remap 后，`status.align` 仍报 `failed`。这导致：

1. `align_audio` 出现在 `_degraded_steps` 列表里（runner.py:386 检查 status in failed/skipped）
2. CLI 显示 "Pipeline completed with 1 degraded step: align_audio"
3. 用户以为质量降低——但 L2 handtest 证实 `embedding_ratio=1.0`，质量没降

## Fix

faster-whisper 成功路径：`failed` -> `success`

| 路径 | 改前 | 改后 | align_fallback |
|------|------|------|----------------|
| faster-whisper 成功 | failed + WARNING | success | True (segment-level) |
| faster-whisper 空/漂移 | skipped | skipped (不变) | — |
| WhisperX forced align 失败 | failed | failed (不变) | True |
| WhisperX 成功 | success | success (不变) | — |

`align_fallback=True` 仍标记 segment-level only，但不再触发 `_degraded_steps`。

## Rationale

L2 handtest #7 v3 证实 faster-whisper segment-level alignment 完全可用：
- embedding_ratio: 1.00 (18/18 段走 embedding)
- degraded_reason: null
- qa.ok: true

subtitle.py 只用 seg.start/seg.end/seg.text (segment-level)，不依赖 word-level forced alignment。faster-whisper 的输出质量不构成 degradation。

## Files changed (3 files, +22/-14)

- pipeline/align.py: faster-whisper success path to success, remove WARNING/degraded
- tests/test_align.py: update assert (failed to success, remove align_degraded check)
- docs/ARCHITECTURE.md: update semantics table (success can be segment-level, add _degraded_steps column)

Tests: 19/19 passed, 0 regressions.
