### PR TITLE
feat(wp3-wp5): diversity post-processing + max_chars hard truncation

### DIFF
--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -333,6 +333,63 @@ def _clamp_scene_window(
 # ── Main match logic ────────────────────────────────────────
 
 
+def _apply_diversity(
+    matched_clips: list, scenes: list, window: int = 3, max_reuse: int = 2
+) -> int:
+    """Post-process matched clips to reduce consecutive scene reuse (WP3).
+
+    If a scene index appears more than ``max_reuse`` times within a
+    sliding window of ``window`` segments, swap the latest occurrence
+    to the nearest unused scene. Returns the number of swaps made.
+
+    Only swaps ``scene_index`` / ``src_start`` / ``src_end`` — score
+    and source remain unchanged (the match quality is not affected,
+    just the footage selection).
+    """
+    if not matched_clips or len(scenes) <= 1:
+        return 0
+
+    swaps = 0
+    for i in range(len(matched_clips)):
+        # Count scene reuse in the look-back window [i-window+1, i]
+        win_start = max(0, i - window + 1)
+        window_clips = matched_clips[win_start : i + 1]
+        scene_counts: dict[int, int] = {}
+        for mc in window_clips:
+            scene_counts[mc.scene_index] = scene_counts.get(mc.scene_index, 0) + 1
+
+        current_scene = matched_clips[i].scene_index
+        if scene_counts.get(current_scene, 0) <= max_reuse:
+            continue  # within limit
+
+        # Find nearest unused scene (by index proximity)
+        used_in_window = set(mc.scene_index for mc in window_clips)
+        candidates = [s for s in scenes if s.index not in used_in_window]
+        if not candidates:
+            continue  # all scenes used in window, nothing to swap
+
+        # Pick the nearest scene by index distance
+        best_scene = min(candidates, key=lambda s: abs(s.index - current_scene))
+
+        # Re-clamp the new scene's window to fit narration duration
+        narr_duration = matched_clips[i].narr_end - matched_clips[i].narr_start
+        clamped_start, clamped_end = _clamp_scene_window(
+            best_scene.start,
+            best_scene.end,
+            narr_duration,
+            video_start=0.0,
+            video_end=max(s.end for s in scenes),
+            clamp_min=0.85,
+            clamp_max=1.25,
+        )
+        matched_clips[i].scene_index = best_scene.index
+        matched_clips[i].src_start = clamped_start
+        matched_clips[i].src_end = clamped_end
+        swaps += 1
+
+    return swaps
+
+
 def match_clips(ctx: Context) -> Context:
     if not ctx.source_video_path:
         ctx.status.match = "skipped"
@@ -587,6 +644,16 @@ def _match_clips_impl(
 
     ctx.matched_clips = matched_clips
 
+    # ── WP3: Diversity post-processing ──────────────────────
+    # Prevent consecutive scene reuse: if the same scene index appears
+    # more than match_max_scene_reuse times within match_diversity_window
+    # segments, swap later occurrences to the nearest unused scene.
+    diversity_swaps = _apply_diversity(
+        matched_clips, scenes,
+        window=ctx.metadata.get("match_diversity_window", 3),
+        max_reuse=ctx.metadata.get("match_max_scene_reuse", 2),
+    )
+
     # Log speed factor stats + collect for match_summary (F1)
     speed_factors: List[float] = []
     if matched_clips:
@@ -676,7 +743,11 @@ def _match_clips_impl(
         },
         "embedding_model": ctx.metadata.get("embedding_model_name", _EMBEDDING_MODEL_NAME),
         "degraded_reason": degraded_reason,
-        "diversity": None,  # reserved for future diversity metric
+        "diversity": {
+            "swaps": diversity_swaps,
+            "window": ctx.metadata.get("match_diversity_window", 3),
+            "max_reuse": ctx.metadata.get("match_max_scene_reuse", 2),
+        },
         # Back-compat fields (kept for existing consumers)
         "total": total,
         "embedding": embedding_count,

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -1,4 +1,5 @@
 from typing import List
+import re
 
 from ..config import get_settings
 from ..models import Context, ScriptSegment
@@ -7,6 +8,28 @@ from ..utils.llm import get_llm_client
 from ..utils.json_parser import extract_json
 from ..tts.base import is_ci
 from time import sleep
+
+
+# ── WP5: max_chars hard truncation ──────────────────────
+# LLM may ignore the max_chars prompt instruction. This post-processing
+# step hard-truncates any sentence exceeding the limit, cutting at the
+# last punctuation mark before the limit for natural breaks.
+_PUNCT_PATTERN = re.compile(r'[。！？；，、…\.,!?;]')
+
+
+def _truncate_to_max_chars(text: str, max_chars: int) -> str:
+    """Hard-truncate text to max_chars, preferring natural punctuation breaks."""
+    if len(text) <= max_chars:
+        return text
+    # Find the last punctuation mark before max_chars
+    truncated = text[:max_chars]
+    match = None
+    for m in _PUNCT_PATTERN.finditer(truncated):
+        match = m  # keep the last match
+    if match:
+        return truncated[: match.end()].rstrip()
+    # No punctuation found — hard cut
+    return truncated.rstrip()
 
 # CI-only fallback: used when LLM is unreachable in CI environment
 # to allow full pipeline testing. Never used for real users.
@@ -172,7 +195,10 @@ def _expand_beats_to_script(
         # Skip empty / whitespace-only segments — they'd produce
         # silent TTS audio and break the count contract.
         if text:
-            segments.append(ScriptSegment(text=text))
+            # WP5: hard-truncate to max_chars (LLM may ignore prompt)
+            text = _truncate_to_max_chars(text, max_chars)
+            if text:
+                segments.append(ScriptSegment(text=text))
 
     if not segments:
         raise ValueError("Phase 2: LLM returned zero segments")

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -78,6 +78,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
             "scene_merge_min_duration", "embedding_model_name",
             "match_drop_scene_min_duration",
+            "match_diversity_window", "match_max_scene_reuse",
             # BGM + loudness
             "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
             # TTS pacing

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -80,6 +80,7 @@ def merge_job(
             # Match
             "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
             "scene_merge_min_duration", "match_drop_scene_min_duration",
+            "match_diversity_window", "match_max_scene_reuse",
             "embedding_model_name",
             # BGM
             "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -31,6 +31,8 @@ class JobParams(BaseModel):
     match_speed_clamp_max: Optional[float] = None
     scene_merge_min_duration: Optional[float] = None
     match_drop_scene_min_duration: Optional[float] = None
+    match_diversity_window: Optional[int] = None
+    match_max_scene_reuse: Optional[int] = None
     embedding_model_name: Optional[str] = None
     # ── BGM ──
     bgm_gain_db: Optional[float] = None

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1140,3 +1140,67 @@ def test_transcribe_video_audio_cache_hit_skips_transcription(tmp_path, monkeypa
     result = json.loads(cache_path.read_text(encoding="utf-8"))
 
     assert result == cached_segments
+
+
+# ── WP3: diversity post-processing tests ──
+
+
+def test_apply_diversity_no_swaps_needed():
+    """No swaps when scenes are already diverse."""
+    from movie_narrator.pipeline.match import _apply_diversity
+    from movie_narrator.models import MatchedClip
+
+    clips = [
+        MatchedClip(segment_index=0, text="a", narr_start=0, narr_end=2,
+                    src_start=0, src_end=2, score=1.0, scene_index=0, source="heuristic"),
+        MatchedClip(segment_index=1, text="b", narr_start=2, narr_end=4,
+                    src_start=2, src_end=4, score=1.0, scene_index=1, source="heuristic"),
+        MatchedClip(segment_index=2, text="c", narr_start=4, narr_end=6,
+                    src_start=4, src_end=6, score=1.0, scene_index=2, source="heuristic"),
+    ]
+    scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(5)]
+    swaps = _apply_diversity(clips, scenes, window=3, max_reuse=2)
+    assert swaps == 0
+    assert clips[0].scene_index == 0
+    assert clips[1].scene_index == 1
+    assert clips[2].scene_index == 2
+
+
+def test_apply_diversity_swaps_consecutive_reuse():
+    """Swaps 3rd consecutive use of same scene to nearest unused."""
+    from movie_narrator.pipeline.match import _apply_diversity
+    from movie_narrator.models import MatchedClip
+
+    clips = [
+        MatchedClip(segment_index=0, text="a", narr_start=0, narr_end=2,
+                    src_start=0, src_end=2, score=1.0, scene_index=1, source="embedding"),
+        MatchedClip(segment_index=1, text="b", narr_start=2, narr_end=4,
+                    src_start=2, src_end=4, score=1.0, scene_index=1, source="embedding"),
+        MatchedClip(segment_index=2, text="c", narr_start=4, narr_end=6,
+                    src_start=4, src_end=6, score=1.0, scene_index=1, source="embedding"),
+    ]
+    scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(5)]
+    swaps = _apply_diversity(clips, scenes, window=3, max_reuse=2)
+    assert swaps == 1
+    # 3rd clip should be swapped to a different scene
+    assert clips[2].scene_index != 1
+
+
+def test_apply_diversity_no_swap_when_all_scenes_used():
+    """No swap when all scenes in window are already used."""
+    from movie_narrator.pipeline.match import _apply_diversity
+    from movie_narrator.models import MatchedClip
+
+    clips = [
+        MatchedClip(segment_index=0, text="a", narr_start=0, narr_end=2,
+                    src_start=0, src_end=2, score=1.0, scene_index=0, source="heuristic"),
+        MatchedClip(segment_index=1, text="b", narr_start=2, narr_end=4,
+                    src_start=2, src_end=4, score=1.0, scene_index=1, source="heuristic"),
+        MatchedClip(segment_index=2, text="c", narr_start=4, narr_end=6,
+                    src_start=4, src_end=6, score=1.0, scene_index=0, source="heuristic"),
+    ]
+    # Only 2 scenes available — both used in window, can't swap
+    scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(2)]
+    swaps = _apply_diversity(clips, scenes, window=3, max_reuse=1)
+    # Scene 0 appears 2 times in window of 3, max_reuse=1, but no unused scene available
+    assert swaps == 0

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -846,3 +846,37 @@ def test_dynamic_count_60s_matches_preset_baseline(tmp_path):
             f"{name}: 60s dynamic count {dynamic_count} != "
             f"preset baseline {base_count}"
         )
+
+
+# ── WP5: max_chars hard truncation tests ──
+
+
+def test_truncate_to_max_chars_no_truncation_needed():
+    """Text within limit is unchanged."""
+    from movie_narrator.pipeline.script import _truncate_to_max_chars
+    assert _truncate_to_max_chars("短句", 10) == "短句"
+
+
+def test_truncate_to_max_chars_hard_cut():
+    """Text exceeding limit with no punctuation is hard-cut."""
+    from movie_narrator.pipeline.script import _truncate_to_max_chars
+    result = _truncate_to_max_chars("abcdefghij", 5)
+    assert result == "abcde"
+
+
+def test_truncate_to_max_chars_cut_at_punctuation():
+    """Text exceeding limit is cut at last punctuation before limit."""
+    from movie_narrator.pipeline.script import _truncate_to_max_chars
+    # "这是一句，很长的中文测试句子" with max_chars=8
+    # Comma at position 4, within the first 8 chars
+    text = "这是一句，很长的中文测试句子"
+    result = _truncate_to_max_chars(text, 8)
+    assert len(result) <= 8
+    assert result.endswith("，")
+
+
+def test_truncate_to_max_chars_empty_after_truncation():
+    """Edge case: punctuation-only text truncates to empty."""
+    from movie_narrator.pipeline.script import _truncate_to_max_chars
+    # Single punctuation char within limit
+    assert _truncate_to_max_chars("，", 1) == "，"


### PR DESCRIPTION
WP3 diversity post-processing + WP5 max_chars hard truncation.

## WP3: Diversity Post-Processing

**Problem**: Consecutive scene reuse — the same scene index appearing 3+ times in a row — creates a "stuck on one shot" feel in the final video. This is a common S3/S6 deduction in L2 hand-tests.

**Fix**: `_apply_diversity()` post-processes matched clips after embedding/heuristic matching. If a scene index appears more than `match_max_scene_reuse` (default 2) times within a sliding window of `match_diversity_window` (default 3) segments, the latest occurrence is swapped to the nearest unused scene. Only `scene_index`/`src_start`/`src_end` are changed — score and source remain unchanged.

New metadata in `match_summary.diversity`:
```json
"diversity": {
  "swaps": 2,
  "window": 3,
  "max_reuse": 2
}
```

## WP5: max_chars Hard Truncation

**Problem**: `max_chars` was only enforced via LLM prompt instruction. When the LLM ignores it, long sentences slip through and break TTS pacing.

**Fix**: `_truncate_to_max_chars()` post-processes each segment after LLM expansion. Truncates at the last punctuation mark before max_chars for natural breaks, or hard-cuts at max_chars if no punctuation found.

## Files changed (7 files, +201/-2)

- `pipeline/match.py`: `_apply_diversity()` function + call site + match_summary diversity field
- `pipeline/script.py`: `_truncate_to_max_chars()` function + call site
- `workflow/merge.py`: add `match_diversity_window` + `match_max_scene_reuse` to whitelist
- `workflow/load.py`: same params to _ALLOWED_PARAMS
- `workflow/schema.py`: add params to Params model
- `tests/test_match.py`: 3 new diversity tests (no-swaps, swap-consecutive, no-swap-when-all-used)
- `tests/test_script.py`: 4 new truncation tests (no-truncation, hard-cut, punct-cut, edge-case)

Tests: 94 passed (+7), 0 failures.
