### PR TITLE
fix(wp3-wp5-wp4): diversity_swaps_log + script_truncated audit + WP4 warn-only docstring

### DIFF
--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -335,21 +335,27 @@ def _clamp_scene_window(
 
 def _apply_diversity(
     matched_clips: list, scenes: list, window: int = 3, max_reuse: int = 2
-) -> int:
+) -> tuple[int, list[dict]]:
     """Post-process matched clips to reduce consecutive scene reuse (WP3).
 
     If a scene index appears more than ``max_reuse`` times within a
     sliding window of ``window`` segments, swap the latest occurrence
-    to the nearest unused scene. Returns the number of swaps made.
+    to the nearest unused scene.
+
+    Returns ``(swaps_count, swaps_log)`` where ``swaps_log`` is a list
+    of ``{"segment_index": int, "old_scene": int, "new_scene": int}``
+    dicts for auditability — downstream consumers can distinguish
+    original embedding scores from post-swap scores.
 
     Only swaps ``scene_index`` / ``src_start`` / ``src_end`` — score
     and source remain unchanged (the match quality is not affected,
     just the footage selection).
     """
     if not matched_clips or len(scenes) <= 1:
-        return 0
+        return 0, []
 
     swaps = 0
+    swaps_log: list[dict] = []
     for i in range(len(matched_clips)):
         # Count scene reuse in the look-back window [i-window+1, i]
         win_start = max(0, i - window + 1)
@@ -382,12 +388,18 @@ def _apply_diversity(
             clamp_min=0.85,
             clamp_max=1.25,
         )
+        old_scene = matched_clips[i].scene_index
         matched_clips[i].scene_index = best_scene.index
         matched_clips[i].src_start = clamped_start
         matched_clips[i].src_end = clamped_end
         swaps += 1
+        swaps_log.append({
+            "segment_index": matched_clips[i].segment_index,
+            "old_scene": old_scene,
+            "new_scene": best_scene.index,
+        })
 
-    return swaps
+    return swaps, swaps_log
 
 
 def match_clips(ctx: Context) -> Context:
@@ -648,7 +660,7 @@ def _match_clips_impl(
     # Prevent consecutive scene reuse: if the same scene index appears
     # more than match_max_scene_reuse times within match_diversity_window
     # segments, swap later occurrences to the nearest unused scene.
-    diversity_swaps = _apply_diversity(
+    diversity_swaps, diversity_swaps_log = _apply_diversity(
         matched_clips, scenes,
         window=ctx.metadata.get("match_diversity_window", 3),
         max_reuse=ctx.metadata.get("match_max_scene_reuse", 2),
@@ -745,6 +757,7 @@ def _match_clips_impl(
         "degraded_reason": degraded_reason,
         "diversity": {
             "swaps": diversity_swaps,
+            "swaps_log": diversity_swaps_log,
             "window": ctx.metadata.get("match_diversity_window", 3),
             "max_reuse": ctx.metadata.get("match_max_scene_reuse", 2),
         },

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -279,11 +279,17 @@ def render_video(ctx: Context) -> Context:
 
     ctx.video_path = str(video_path)
 
-    # ── WP4: footage coverage ────────────────────────────
+    # ── WP4: footage coverage (warn-only gate) ───────────
     # Calculate what fraction of narration segments have real footage
     # (vs text-only fallback). This catches the failure mode where
     # detect_scenes found 0 scenes or match_clips produced no usable
     # matches — the final video would be all text cards.
+    #
+    # NOTE: This is a WARN-ONLY gate, not an abort gate. The video is
+    # already rendered by this point — we can only flag the issue in
+    # metadata and _degraded_steps. To enforce footage coverage as a
+    # hard requirement, check metadata.footage_coverage.ratio in a
+    # post-pipeline script or use --strict with custom logic.
     total_segments = len(ctx.timed_segments)
     footage_segments_count = len(footage_segments)
     coverage_ratio = (

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -185,6 +185,8 @@ def _expand_beats_to_script(
     raw_segments = data.get("segments", [])
 
     segments = []
+    truncated_count = 0
+    truncated_details: list[dict] = []
     for item in raw_segments:
         if isinstance(item, str):
             text = item.strip()
@@ -195,10 +197,25 @@ def _expand_beats_to_script(
         # Skip empty / whitespace-only segments — they'd produce
         # silent TTS audio and break the count contract.
         if text:
+            original_len = len(text)
             # WP5: hard-truncate to max_chars (LLM may ignore prompt)
             text = _truncate_to_max_chars(text, max_chars)
+            if len(text) < original_len:
+                truncated_count += 1
+                truncated_details.append({
+                    "original_len": original_len,
+                    "truncated_len": len(text),
+                })
             if text:
                 segments.append(ScriptSegment(text=text))
+
+    # WP5: audit metadata — track truncation for diagnostics
+    if truncated_count > 0:
+        ctx.metadata["script_truncated"] = {
+            "count": truncated_count,
+            "max_chars": max_chars,
+            "details": truncated_details,
+        }
 
     if not segments:
         raise ValueError("Phase 2: LLM returned zero segments")

--- a/src/movie_narrator/utils/metadata_export.py
+++ b/src/movie_narrator/utils/metadata_export.py
@@ -66,5 +66,7 @@ def build_metadata_json(ctx: Context) -> Dict[str, Any]:
         "footage_coverage": ctx.metadata.get("footage_coverage"),
         # ── WP5: duration metrics (target vs actual) ──
         "duration_metrics": ctx.metadata.get("duration_metrics"),
+        # ── WP5: script truncation audit ──
+        "script_truncated": ctx.metadata.get("script_truncated"),
     }
     return meta

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1159,8 +1159,9 @@ def test_apply_diversity_no_swaps_needed():
                     src_start=4, src_end=6, score=1.0, scene_index=2, source="heuristic"),
     ]
     scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(5)]
-    swaps = _apply_diversity(clips, scenes, window=3, max_reuse=2)
+    swaps, swaps_log = _apply_diversity(clips, scenes, window=3, max_reuse=2)
     assert swaps == 0
+    assert swaps_log == []
     assert clips[0].scene_index == 0
     assert clips[1].scene_index == 1
     assert clips[2].scene_index == 2
@@ -1180,8 +1181,12 @@ def test_apply_diversity_swaps_consecutive_reuse():
                     src_start=4, src_end=6, score=1.0, scene_index=1, source="embedding"),
     ]
     scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(5)]
-    swaps = _apply_diversity(clips, scenes, window=3, max_reuse=2)
+    swaps, swaps_log = _apply_diversity(clips, scenes, window=3, max_reuse=2)
     assert swaps == 1
+    assert len(swaps_log) == 1
+    assert swaps_log[0]["old_scene"] == 1
+    assert swaps_log[0]["new_scene"] != 1
+    assert swaps_log[0]["segment_index"] == 2
     # 3rd clip should be swapped to a different scene
     assert clips[2].scene_index != 1
 
@@ -1201,6 +1206,7 @@ def test_apply_diversity_no_swap_when_all_scenes_used():
     ]
     # Only 2 scenes available — both used in window, can't swap
     scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(2)]
-    swaps = _apply_diversity(clips, scenes, window=3, max_reuse=1)
+    swaps, swaps_log = _apply_diversity(clips, scenes, window=3, max_reuse=1)
     # Scene 0 appears 2 times in window of 3, max_reuse=1, but no unused scene available
     assert swaps == 0
+    assert swaps_log == []


### PR DESCRIPTION
Addresses 3 auditability gaps identified in Stage D code review.

## Finding 1: WP3 diversity swaps_log (score semantic pollution)

**Problem**: `_apply_diversity` swapped `scene_index`/`src_start`/`src_end` but left `score` unchanged. The score still described the original narration-to-scene-A embedding similarity, but src now pointed to scene B. `match_summary.score` (built from `adopted_embedding_scores` post-swap) was a mix of real and stale scores. No audit trail of which clips were swapped.

**Fix**: `_apply_diversity` now returns `(swaps_count, swaps_log)` where `swaps_log` is a list of `{"segment_index", "old_scene", "new_scene"}` dicts. Written to `match_summary.diversity.swaps_log`.

Downstream consumers can now:
- Exclude swapped clips from score statistics
- Audit which scenes were displaced
- Debug diversity behavior

## Finding 2: WP5 script truncation audit (silent content loss)

**Problem**: `_truncate_to_max_chars` silently cut LLM output. If LLM produced 3x-length text, all segments would be hard-truncated with zero metadata trace. L2 hand-test wouldn't notice (LLM was well-behaved).

**Fix**: Track truncation in `ctx.metadata["script_truncated"]`:
```json
"script_truncated": {
  "count": 2,
  "max_chars": 15,
  "details": [
    {"original_len": 25, "truncated_len": 14},
    {"original_len": 20, "truncated_len": 15}
  ]
}
```
Exported via `metadata_export.py`. Only written when truncation actually occurs (zero overhead when LLM obeys max_chars).

## Finding 3: WP4 warn-only gate docstring

**Problem**: `render_require_footage` parameter name implied a hard gate, but implementation was warn-only (video already rendered, can only flag). No docstring clarified this.

**Fix**: Updated render.py comment block to explicitly state "WARN-ONLY gate, not an abort gate" with guidance on how to enforce hard requirements.

## Files changed (5 files, +53/-9)

- `pipeline/match.py`: `_apply_diversity` returns tuple, swaps_log in match_summary
- `pipeline/script.py`: truncation tracking + metadata write
- `pipeline/render.py`: WP4 warn-only docstring
- `utils/metadata_export.py`: add script_truncated field
- `tests/test_match.py`: 3 tests updated for tuple return + swaps_log assertions

Tests: 85 passed, 0 failures.
