### PR TITLE
fix(test): isolate .env pollution in TestSettingsTTS

### DIFF
--- a/tests/test_tts_providers.py
+++ b/tests/test_tts_providers.py
@@ -661,7 +661,8 @@ class TestGenerateVoiceCache:
 class TestSettingsTTS:
     def test_default_tts_provider_is_edge(self):
         from movie_narrator.config import Settings, TTSProviderType
-        s = Settings()
+        # Use _env_file=None to prevent .env from overriding defaults
+        s = Settings(_env_file=None)
         assert s.tts_provider is TTSProviderType.EDGE
 
     def test_openai_tts_model_default(self):
@@ -694,7 +695,8 @@ class TestSettingsTTS:
 
     def test_mimo_defaults(self):
         from movie_narrator.config import Settings
-        s = Settings()
+        # Use _env_file=None to prevent .env from overriding defaults
+        s = Settings(_env_file=None)
         assert s.mimo_tts_model == "mimo-v2.5-tts"
         assert s.mimo_api_key is None
         assert s.mimo_base_url == "https://api.xiaomimimo.com/v1"


### PR DESCRIPTION
## Problem

2 tests in TestSettingsTTS fail locally when .env sets MN_TTS_PROVIDER=mimo:
- test_default_tts_provider_is_edge: expects EDGE, gets MIMO
- test_mimo_defaults: expects mimo_api_key=None, gets key from .env

Root cause: Settings() reads .env via pydantic-settings env_file config. Tests that assert defaults don't isolate .env, so any developer with MN_TTS_PROVIDER set in .env sees failures.

CI is unaffected (containers have no .env file).

## Fix

Pass _env_file=None to Settings() in the 2 affected tests. This is the standard pydantic-settings pattern for testing defaults in isolation.

Only test code changed — zero production impact.

Tests: 2/2 previously failing now pass.