### PR TITLE
fix(test): isolate faster_whisper probe and .env pollution in align/tts/cli tests

### DIFF
--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -33,7 +33,8 @@ def test_align_disabled_without_whisperx(tmp_path):
 def test_align_skipped_no_audio(tmp_path):
     ctx = _make_ctx(tmp_path, audio=False)
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         align_audio(ctx)
     assert ctx.status.align == "skipped"
 
@@ -58,7 +59,8 @@ def test_align_success_with_mocked_whisperx(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -232,7 +234,8 @@ def test_align_backward_jump_extreme_skips_segment(tmp_path):
     original_seg2_end = ctx.timed_segments[1].end
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -283,7 +286,8 @@ def test_align_backward_jump_small_clamp_keeps_segment(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -314,7 +318,8 @@ def test_align_no_backward_jumps_zero_skipped(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -347,7 +352,8 @@ def test_align_midpoint_distance_when_no_containment(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -384,7 +390,8 @@ def test_align_unequal_segment_counts(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -431,7 +438,8 @@ def test_align_empty_whisperx_segments_warns(tmp_path):
     fake_wx.load_model = MagicMock(return_value=fake_model)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -472,7 +480,8 @@ def test_align_fallback_sets_status_failed(tmp_path):
     fake_wx.align = MagicMock()
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -516,7 +525,8 @@ def test_align_single_segment_drift_skips(tmp_path):
     original_ends = [ts.end for ts in ctx.timed_segments]
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -547,7 +557,8 @@ def test_align_single_segment_no_drift_succeeds(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, ""))
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 

--- a/tests/test_cli_debug.py
+++ b/tests/test_cli_debug.py
@@ -21,6 +21,10 @@ def _make_missing_probe(monkeypatch, module_name: str):
     """Patch ``probe`` inside ``movie_narrator.pipeline.<step_module>`` to
     report the given module as unavailable, simulating a fresh install
     without the ``[media]`` or ``[ml]`` extra.
+
+    Also patches ``_align_backend.probe`` so that ``select_align_backend``
+    sees the same unavailability — otherwise faster_whisper (if installed)
+    would be selected instead of returning "none".
     """
     step_to_module = {
         "scenedetect": "movie_narrator.pipeline.scenes",
@@ -36,6 +40,17 @@ def _make_missing_probe(monkeypatch, module_name: str):
             'pip install "movie-narrator[ml]"' if name == module_name else (True, ""),
         ),
     )
+    # Also patch _align_backend.probe so select_align_backend sees the same
+    _backend_mod = sys.modules.get("movie_narrator.pipeline._align_backend")
+    if _backend_mod:
+        monkeypatch.setattr(
+            _backend_mod,
+            "probe",
+            lambda name: (
+                False,
+                'pip install "movie-narrator[ml]"' if name == module_name else (True, ""),
+            ),
+        )
 
 
 def test_mn_scenes_exits_nonzero_when_dep_missing(tmp_path, monkeypatch):

--- a/tests/test_tts_providers.py
+++ b/tests/test_tts_providers.py
@@ -553,6 +553,11 @@ class TestGenerateVoiceCI:
     def test_ci_produces_narration_and_timed_segments(self, tmp_path, monkeypatch):
         from movie_narrator.models import Context, ScriptSegment
         from movie_narrator.pipeline.tts import generate_voice
+        from movie_narrator.config import get_settings
+
+        # Clear lru_cache so .env (MN_TTS_PROVIDER=mimo) doesn't leak in
+        get_settings.cache_clear()
+        monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
 
         monkeypatch.setenv("CI", "1")
         ctx = self._make_ctx(tmp_path)
@@ -567,6 +572,11 @@ class TestGenerateVoiceCI:
 
     def test_ci_does_not_write_to_cache(self, tmp_path, monkeypatch):
         from movie_narrator.pipeline.tts import generate_voice
+        from movie_narrator.config import get_settings
+
+        # Clear lru_cache so .env (MN_TTS_PROVIDER=mimo) doesn't leak in
+        get_settings.cache_clear()
+        monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
 
         monkeypatch.setenv("CI", "1")
         ctx = self._make_ctx(tmp_path)
@@ -580,6 +590,10 @@ class TestGenerateVoiceCI:
 
     def test_ci_temp_files_cleaned_up(self, tmp_path, monkeypatch):
         from movie_narrator.pipeline.tts import generate_voice
+        from movie_narrator.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
 
         monkeypatch.setenv("CI", "1")
         ctx = self._make_ctx(tmp_path)
@@ -590,6 +604,10 @@ class TestGenerateVoiceCI:
 
     def test_ci_sets_tts_provider_metadata(self, tmp_path, monkeypatch):
         from movie_narrator.pipeline.tts import generate_voice
+        from movie_narrator.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
 
         monkeypatch.setenv("CI", "1")
         ctx = self._make_ctx(tmp_path)
@@ -598,6 +616,10 @@ class TestGenerateVoiceCI:
 
     def test_ci_sets_voice_used_metadata(self, tmp_path, monkeypatch):
         from movie_narrator.pipeline.tts import generate_voice
+        from movie_narrator.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
 
         monkeypatch.setenv("CI", "1")
         ctx = self._make_ctx(tmp_path)
@@ -618,6 +640,11 @@ class TestGenerateVoiceCache:
     @requires_mp3
     def test_cache_hit_skips_synthesize(self, tmp_path, monkeypatch):
         from movie_narrator.pipeline.tts import generate_voice
+        from movie_narrator.config import get_settings
+
+        # Clear lru_cache so .env (MN_TTS_PROVIDER=mimo) doesn't leak in
+        get_settings.cache_clear()
+        monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
 
         monkeypatch.delenv("CI", raising=False)
         ctx = self._make_ctx(tmp_path)


### PR DESCRIPTION
Fix 14 test failures that occur on Windows machines with faster_whisper installed and .env with MN_TTS_PROVIDER=mimo.

## Root Cause

Two distinct isolation gaps:

### A. align tests (11 + 1 = 12 failures)

`select_align_backend()` in `_align_backend.py` uses its own `probe` import. Tests only patched `align.probe` (a dead import — never called). On machines with faster_whisper installed, `_align_backend.probe("faster_whisper")` returns True, so `select_align_backend` picks faster_whisper instead of whisperx. Tests mock whisperx but not faster_whisper → failures.

On CI (Ubuntu, no deps installed), both probes return False → backend="none" → tests pass via disabled path.

**Fix**: Each whisperx test now also patches `_align_backend.probe` to return True only for whisperx, ensuring `select_align_backend` picks whisperx regardless of installed deps.

### B. tts tests (5 tests, 2 reported as failing)

`generate_voice()` calls `get_settings()` which is `lru_cached` and reads `.env` via pydantic-settings. Tests set `CI=1` but didn't clear the cache or override `MN_TTS_PROVIDER`. If `.env` has `MN_TTS_PROVIDER=mimo`, the cached Settings returns mimo, not edge.

**Fix**: Each CI/cache test now calls `get_settings.cache_clear()` + `monkeypatch.setenv("MN_TTS_PROVIDER", "edge")` before `generate_voice()`.

## Files changed (3 files, +64/-11)

- `tests/test_align.py`: 11 tests — added `_align_backend.probe` patch alongside existing `align.probe` patch
- `tests/test_cli_debug.py`: `_make_missing_probe` helper — also patches `_align_backend.probe`
- `tests/test_tts_providers.py`: 5 tests — added `get_settings.cache_clear()` + `MN_TTS_PROVIDER=edge` env override

Tests: 473 passed, 23 skipped, 0 failures.
