### PR TITLE
fix(test): patch probe in test_align_disabled_without_whisperx (PR #74 leftover)

### DIFF
--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -26,7 +26,12 @@ def _make_ctx(tmp_path, audio=True):
 
 def test_align_disabled_without_whisperx(tmp_path):
     ctx = _make_ctx(tmp_path)
-    align_audio(ctx)
+    with pytest.MonkeyPatch.context() as m:
+        # Patch both probe references so select_align_backend returns "none"
+        # regardless of what's installed in the environment.
+        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (False, ""))
+        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (False, ""))
+        align_audio(ctx)
     assert ctx.status.align == "disabled"
 
 


### PR DESCRIPTION
## Problem

PR #74 patched 11 align tests + 1 cli_debug test for _align_backend.probe isolation, but missed 	est_align_disabled_without_whisperx (line 27-30).

This test had no probe patch at all. On environments with faster_whisper installed:
- _align_backend.probe('faster_whisper') returns True
- select_align_backend returns 'faster_whisper' instead of 'none'
- align_audio attempts transcription → fails → status='failed'
- Test expects 'disabled' → fails

On CI (Ubuntu, no deps) and my env (no deps), both probes return False → 'none' → 'disabled' → passes.

## Fix

Add dual probe patch (both lign.probe and _align_backend.probe return False for all backends) so select_align_backend returns 'none' regardless of installed deps.

Test-only change — zero production impact.

Tests: 19/19 align tests pass.