### PR TITLE
feat(stage-d): WP5 pause feedback + ST-06 tail trim + WP7 draft profile

### DIFF
--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -81,7 +81,7 @@ narration_preset: ""        # douyin-fast | mainstream-dry | bilibili-long
 #          render_fit_mode / render_crf / render_preset / render_faststart
 #          render_subtitle_position / render_subtitle_max_width_ratio
 #          render_subtitle_bottom_margin_ratio
-#          render_require_footage / render_min_footage_coverage
+#          render_require_footage / render_min_footage_coverage / render_profile
 #   质检: qa_enabled / qa_max_silence_db / qa_min_duration_ratio / qa_max_duration_ratio
 #   文案: prompt_target_sentences / prompt_target_segment_duration
 #         prompt_max_chars_per_sentence / prompt_hook_seconds
@@ -152,6 +152,7 @@ params:
   # render_subtitle_bottom_margin_ratio: 0.08  # 底部留白比例
   # render_require_footage: false    # true=覆盖率低于阈值时 warn + 标记 _degraded_steps
   # render_min_footage_coverage: 0.5 # footage 覆盖率阈值（0-1）
+  # render_profile: publish          # publish（默认，crf=18/preset=slow）| draft（crf=28/preset=ultrafast，快速迭代）
 
   # ---- 成片质检（v0.4.13 新增硬步骤 validate_deliverable）----
   # qa_enabled: true              # false=显式关闭；CI 默认跳过，本地默认开启

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -264,6 +264,24 @@ def build_context(
         for key in PARAM_WHITELIST:
             if key in effective_params and effective_params[key] is not None:
                 ctx.metadata[key] = effective_params[key]
+
+    # ── WP7: Draft profile — fast iteration override ──
+    # When render_profile=draft, override render params for speed.
+    # User-supplied params (via job.yaml or preset) always take precedence
+    # over draft defaults — draft only fills gaps.
+    render_profile = (params or {}).get("render_profile") or (effective_params.get("render_profile"))
+    if render_profile == "draft":
+        _DRAFT_RENDER_DEFAULTS = {
+            "render_crf": 28,
+            "render_preset": "ultrafast",
+            "render_faststart": True,
+        }
+        for dk, dv in _DRAFT_RENDER_DEFAULTS.items():
+            # Only set if user didn't explicitly set this param
+            if dk not in effective_params or effective_params.get(dk) is None:
+                ctx.metadata[dk] = dv
+        ctx.metadata["render_profile"] = "draft"
+
     if config_path:
         ctx.metadata["config_path"] = config_path
 

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -47,10 +47,11 @@ _CI_MOCK_SEGMENTS = [
 def _trim_segments(segments: List[ScriptSegment], target: int) -> List[ScriptSegment]:
     """Trim segments to exactly *target* count if over.
 
-    Strategy: preserve the first ``hook_count`` segments (hooks must stay),
-    then from the remaining pool select those whose length is closest to
-    the median.  This avoids outlier sentences (very short or very long)
-    and keeps the most "normal" content.
+    Strategy: preserve the first ``hook_count`` segments (hooks must stay)
+    and the last segment (tail climax/outro must stay), then from the
+    remaining pool select those whose length is closest to the median.
+    This avoids outlier sentences (very short or very long) and keeps
+    the most "normal" content.
 
     If ``len(segments) <= target``, returns as-is (no padding).
     """
@@ -59,10 +60,18 @@ def _trim_segments(segments: List[ScriptSegment], target: int) -> List[ScriptSeg
 
     # Lock the first hook_count segments (hooks must be preserved)
     hook_count = min(3, target)
-    locked = list(segments[:hook_count])
-    pool = list(segments[hook_count:])
+    # ST-06: Also lock the last segment (tail climax/outro protection)
+    # Only lock tail if we have enough segments to spare.
+    lock_tail = target > hook_count + 1 and len(segments) > target + 1
 
-    need = target - hook_count
+    locked = list(segments[:hook_count])
+    if lock_tail:
+        locked.append(segments[-1])
+        pool = list(segments[hook_count:-1])
+    else:
+        pool = list(segments[hook_count:])
+
+    need = target - len(locked)
     if need <= 0:
         return locked[:target]
 

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -21,6 +21,31 @@ _TTS_SEGMENT_RETRIES = 3
 _TTS_RETRY_DELAY = 1.0  # seconds
 
 
+def _build_audio(
+    results: list[tuple[AudioSegment, float]],
+    segments: list,
+    pause_ms: int,
+) -> tuple[AudioSegment, list[TimedSegment]]:
+    """Assemble per-segment audio into a single track with inter-segment pauses.
+
+    Returns (combined_audio, timed_segments) where timed_segments[i] has
+    start/end timestamps relative to the combined track.
+    """
+    combined = AudioSegment.empty()
+    timed_segments: list[TimedSegment] = []
+    current_time = 0.0
+    for i, (audio, duration) in enumerate(results):
+        combined += audio
+        pause = (pause_ms / 1000.0) if i < len(segments) - 1 else 0
+        if pause > 0:
+            combined += AudioSegment.silent(duration=pause_ms)
+        timed_segments.append(
+            TimedSegment(text=segments[i].text, start=current_time, end=current_time + duration)
+        )
+        current_time += duration + pause
+    return combined, timed_segments
+
+
 def generate_voice(ctx: Context) -> Context:
     settings = get_settings()
     output_dir = Path(ctx.output_dir)
@@ -34,7 +59,6 @@ def generate_voice(ctx: Context) -> Context:
     audio_fmt = ctx.metadata.get("tts_audio_format", "mp3")
     audio_bitrate = ctx.metadata.get("tts_audio_bitrate", "128k")
     console = ctx.services.console
-
     def _key(seg_text: str) -> TTSCacheKey:
         return TTSCacheKey(
             schema_version=CACHE_SCHEMA_VERSION,
@@ -100,18 +124,62 @@ def generate_voice(ctx: Context) -> Context:
 
     results = run_async(_run_all())
 
-    combined = AudioSegment.empty()
-    timed_segments = []
-    current_time = 0.0
-    for i, (audio, duration) in enumerate(results):
-        combined += audio
-        pause = (pause_ms / 1000.0) if i < len(ctx.segments) - 1 else 0
-        if pause > 0:
-            combined += AudioSegment.silent(duration=pause_ms)
-        timed_segments.append(
-            TimedSegment(text=ctx.segments[i].text, start=current_time, end=current_time + duration)
-        )
-        current_time += duration + pause
+    combined, timed_segments = _build_audio(
+        results, ctx.segments, pause_ms
+    )
+
+    # ── WP5: duration pause feedback ─────────────────────────
+    # If narration exceeds target duration by >15%, try reducing pause_ms
+    # and rebuilding.  This is a v1 approach: only adjusts pause, does NOT
+    # re-run TTS or trim sentences.
+    target_duration = ctx.metadata.get("duration") or ctx.duration
+    if target_duration and pause_ms > 50:
+        actual_duration = timed_segments[-1].end if timed_segments else 0
+        ratio = actual_duration / target_duration if target_duration else 1.0
+        if ratio > 1.15:
+            # Calculate a pause that should bring us closer to target
+            # total = sum(audio) + (n-1) * pause
+            # We want: sum(audio) + (n-1) * new_pause ≈ target
+            audio_only = sum(d for _, d in results)
+            n_pause = max(1, len(results) - 1)
+            new_pause_ms = max(50, int((target_duration - audio_only) * 1000 / n_pause))
+            if new_pause_ms < pause_ms:
+                console.inline_warn(
+                    f"Narration {actual_duration:.1f}s exceeds target {target_duration:.1f}s "
+                    f"(ratio {ratio:.2f}). Reducing pause {pause_ms}ms → {new_pause_ms}ms."
+                )
+                combined, timed_segments = _build_audio(
+                    results, ctx.segments, new_pause_ms
+                )
+                ctx.metadata["duration_metrics"] = {
+                    "target_sec": target_duration,
+                    "narration_sec": round(timed_segments[-1].end, 2) if timed_segments else 0,
+                    "ratio_vs_target": round(
+                        (timed_segments[-1].end / target_duration) if timed_segments and target_duration else 0, 3
+                    ),
+                    "pause_ms_original": pause_ms,
+                    "pause_ms_applied": new_pause_ms,
+                    "adjusted": True,
+                }
+            else:
+                ctx.metadata["duration_metrics"] = {
+                    "target_sec": target_duration,
+                    "narration_sec": round(actual_duration, 2),
+                    "ratio_vs_target": round(ratio, 3),
+                    "pause_ms_original": pause_ms,
+                    "pause_ms_applied": pause_ms,
+                    "adjusted": False,
+                    "reason": "pause_already_at_floor",
+                }
+        else:
+            ctx.metadata["duration_metrics"] = {
+                "target_sec": target_duration,
+                "narration_sec": round(actual_duration, 2),
+                "ratio_vs_target": round(ratio, 3),
+                "pause_ms_original": pause_ms,
+                "pause_ms_applied": pause_ms,
+                "adjusted": False,
+            }
 
     audio_path = output_dir / f"narration.{audio_fmt}"
     # Explicit bitrate prevents pydub's default 32 kbps export, which

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -99,6 +99,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             "render_subtitle_position", "render_subtitle_max_width_ratio",
             "render_subtitle_bottom_margin_ratio",
             "render_require_footage", "render_min_footage_coverage",
+            "render_profile",
             # Deliverable QA
             "qa_enabled", "qa_max_silence_db",
             "qa_min_duration_ratio", "qa_max_duration_ratio",

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -101,6 +101,7 @@ def merge_job(
             "render_subtitle_position", "render_subtitle_max_width_ratio",
             "render_subtitle_bottom_margin_ratio",
             "render_require_footage", "render_min_footage_coverage",
+            "render_profile",
             # QA
             "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
             # Prompt shaping (preset-driven, but also YAML-configurable)

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -76,6 +76,7 @@ class JobParams(BaseModel):
     render_subtitle_bottom_margin_ratio: Optional[float] = None
     render_require_footage: Optional[bool] = None
     render_min_footage_coverage: Optional[float] = None
+    render_profile: Optional[str] = None  # "publish" (default) | "draft" (fast iteration)
     # ── QA ──
     qa_enabled: Optional[bool] = None
     qa_max_silence_db: Optional[float] = None


### PR DESCRIPTION
Stage D remaining work: WP5 pause feedback + ST-06 tail trim protection + WP7 draft profile.

## D-2: ST-06 — trim 不砍尾部高潮

**Problem**: `_trim_segments` only locked the first 3 hook segments. The last segment (tail climax/outro) could be dropped during trimming.

**Fix**: Also lock the last segment when there are enough segments to spare (`target > hook_count + 1 and len(segments) > target + 1`). The locked tail is reassembled in chronological order with the locked hooks and median-ranked pool.

**File**: `pipeline/script.py` (+11/-4)

## D-3: AQ-02 — soft-step degraded_steps (already implemented)

Verified that the F3 patch in `runner.py` (line 375-394) already covers soft-step internal failures. `mix_bgm` is in `STATUS_FIELD_FOR_STEP`, and the catch path sets `_degraded_steps` when status is `failed`/`skipped`. No code change needed.

## D-1: WP5 — duration pause feedback

**Problem**: Narration could exceed target `--duration` by >15% with no auto-correction.

**Fix**: After TTS assembly, if `actual/target > 1.15` and `pause_ms > 50`:
1. Calculate `new_pause_ms = max(50, (target - audio_only) * 1000 / (n-1))`
2. Rebuild audio with reduced pause
3. Write `metadata.duration_metrics` with `{target_sec, narration_sec, ratio_vs_target, pause_ms_original, pause_ms_applied, adjusted}`

Extracted `_build_audio()` helper to avoid code duplication between initial build and rebuild.

**File**: `pipeline/tts.py` (+78/-16)

## D-5: WP7 — draft profile

**Problem**: `crf=18 + preset=slow` slows iteration during development.

**Fix**: New `render_profile` param (job.yaml). When `render_profile: draft`:
- `render_crf: 28` (vs default 18)
- `render_preset: ultrafast` (vs default slow)
- `render_faststart: true`

User-supplied params always override draft defaults — draft only fills gaps.

**Files**: `pipeline/runner.py` (+18), `workflow/schema.py` (+1), `workflow/load.py` (+1), `workflow/merge.py` (+1), `examples/job.example.yaml` (+2)

## Files changed (7 files, +119/-20)

Tests: 477 passed, 23 skipped, 0 failures.
