### PR TITLE
feat(ep1): act-weighted timeline partitioning for match pipeline

### DIFF
--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -69,7 +69,9 @@ narration_preset: ""        # douyin-fast | mainstream-dry | bilibili-long
 #   场景: scene_threshold / scene_frame_skip
 #   匹配: match_min_score / match_speed_clamp_min / match_speed_clamp_max
 #          scene_merge_min_duration / match_drop_scene_min_duration
-#          embedding_model_name / match_diversity_window / match_max_scene_reuse
+#          embedding_model_name
+#          match_diversity_window / match_max_scene_reuse
+#          match_timeline_mode / match_act_weights
 #   BGM:  bgm_gain_db / bgm_duck_db / bgm_normalize / audio_target_dbfs
 #   TTS:  tts_pause_ms / tts_max_concurrent / tts_audio_format / tts_audio_bitrate
 #   翻译: translate_source_lang / translate_provider / translate_retries
@@ -104,6 +106,8 @@ params:
   # embedding_model_name: paraphrase-multilingual-MiniLM-L12-v2
   # match_diversity_window: 3       # 滑动窗口大小（段），检测连续场景复用
   # match_max_scene_reuse: 2        # 窗口内同一场景最大允许出现次数（超过则换景）
+  # match_timeline_mode: uniform    # uniform（默认，全片比例映射）| weighted_acts（四幕时间桶，高光集中在高潮幕）
+  # match_act_weights: [0.15, 0.25, 0.40, 0.20]  # 四幕时间占比（开/中/高潮/尾），仅 weighted_acts 模式生效
 
   # ---- BGM / 音频 ----
   # bgm_gain_db: -18          # BGM 基础增益（dB）

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -599,6 +599,10 @@ def _match_clips_impl(
             f"  EP1 weighted_acts: {len(act_weights)} acts, "
             f"segments per act: {[act_assignments.count(a) for a in range(len(act_weights))]}"
         )
+        # Pre-compute act -> segment indices map (O(n) once, not O(n²) per segment)
+        act_seg_map: dict[int, list[int]] = {}
+        for seg_idx, act_i in enumerate(act_assignments):
+            act_seg_map.setdefault(act_i, []).append(seg_idx)
     else:
         act_scenes = None
         act_assignments = None
@@ -621,7 +625,7 @@ def _match_clips_impl(
             b_span = b_end - b_start
 
             # Position within this segment's slot in the bucket
-            act_segs = [j for j, a in enumerate(act_assignments) if a == act_idx]
+            act_segs = act_seg_map[act_idx]
             pos_in_act = act_segs.index(i)
             n_in_act = len(act_segs)
             if n_in_act > 1:

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -402,6 +402,102 @@ def _apply_diversity(
     return swaps, swaps_log
 
 
+# ── EP1: Act-weighted timeline partitioning ────────────────
+
+
+_DEFAULT_ACT_WEIGHTS = [0.15, 0.25, 0.40, 0.20]
+
+
+def _partition_scenes_by_act(
+    scenes: List[Scene],
+    n_acts: int = 4,
+) -> List[List[Scene]]:
+    """Partition scenes into *n_acts* equal-time buckets.
+
+    Returns a list of scene lists, one per act.  Acts with no scenes
+    get an empty list — the caller is responsible for fallback.
+    """
+    if not scenes:
+        return [[] for _ in range(n_acts)]
+
+    scene_start = min(s.start for s in scenes)
+    scene_end = max(s.end for s in scenes)
+    span = scene_end - scene_start
+    if span <= 0:
+        return [list(scenes)] + [[] for _ in range(n_acts - 1)]
+
+    bucket_size = span / n_acts
+    buckets: List[List[Scene]] = [[] for _ in range(n_acts)]
+    for s in scenes:
+        idx = min(n_acts - 1, int((s.start - scene_start) / bucket_size))
+        buckets[idx].append(s)
+    return buckets
+
+
+def _assign_segments_to_acts(
+    n_segments: int,
+    weights: List[float],
+) -> List[int]:
+    """Assign *n_segments* narration segments to acts by *weights*.
+
+    Returns a list of act indices (0-based), one per segment, in
+    chronological order.  Segment counts per act are proportional to
+    weights, adjusted to sum exactly to *n_segments*.
+    """
+    n_acts = len(weights)
+    total = sum(weights)
+    if total <= 0:
+        weights = list(_DEFAULT_ACT_WEIGHTS)
+        total = sum(weights)
+    norm = [w / total for w in weights]
+
+    # Raw counts (may not sum to n_segments due to rounding)
+    counts = [max(1, round(n_segments * w)) for w in norm]
+
+    # Adjust to sum exactly to n_segments
+    while sum(counts) > n_segments:
+        max_idx = counts.index(max(counts))
+        counts[max_idx] -= 1
+    while sum(counts) < n_segments:
+        max_idx = counts.index(max(counts))
+        counts[max_idx] += 1
+
+    # Build chronological assignment list
+    assignments: List[int] = []
+    for act_idx, count in enumerate(counts):
+        assignments.extend([act_idx] * count)
+    return assignments
+
+
+def _get_act_candidate_indices(
+    act_idx: int,
+    n_acts: int,
+    act_scenes: List[List[Scene]],
+    allow_overflow: bool = True,
+) -> List[int]:
+    """Return global scene indices for act *act_idx* + optional adjacent overflow.
+
+    When the target act has no scenes, expands search to all acts.
+    """
+    # Start with the act's own scenes
+    indices = [s.index for s in act_scenes[act_idx]]
+
+    if not indices and allow_overflow:
+        # Act is empty — fall back to all scenes
+        for bucket in act_scenes:
+            indices.extend(s.index for s in bucket)
+        return indices
+
+    if allow_overflow and len(act_scenes) > 1:
+        # Add adjacent acts (±1) for overflow candidates
+        for delta in (-1, 1):
+            neighbor = act_idx + delta
+            if 0 <= neighbor < len(act_scenes):
+                indices.extend(s.index for s in act_scenes[neighbor])
+
+    return indices
+
+
 def match_clips(ctx: Context) -> Context:
     if not ctx.source_video_path:
         ctx.status.match = "skipped"
@@ -481,26 +577,84 @@ def _match_clips_impl(
     last_end = ctx.timed_segments[-1].end
     narr_span = last_end - first_start
 
+    # ── EP1: Act-weighted timeline partitioning ─────────────
+    # When match_timeline_mode="weighted_acts", partition scenes into 4
+    # equal-time buckets and assign narration segments to acts by weight.
+    # Each segment's heuristic midpoint is mapped within its assigned
+    # bucket (not the full timeline), and embedding candidates are
+    # restricted to the bucket (+ adjacent overflow).
+    timeline_mode = ctx.metadata.get("match_timeline_mode", "uniform")
+    act_weights = ctx.metadata.get("match_act_weights", list(_DEFAULT_ACT_WEIGHTS))
+    use_weighted_acts = (
+        timeline_mode == "weighted_acts"
+        and len(scenes) >= 8
+        and len(ctx.timed_segments) >= 4
+    )
+    if use_weighted_acts:
+        act_scenes = _partition_scenes_by_act(scenes, n_acts=len(act_weights))
+        act_assignments = _assign_segments_to_acts(
+            len(ctx.timed_segments), act_weights
+        )
+        ctx.services.console.debug(
+            f"  EP1 weighted_acts: {len(act_weights)} acts, "
+            f"segments per act: {[act_assignments.count(a) for a in range(len(act_weights))]}"
+        )
+    else:
+        act_scenes = None
+        act_assignments = None
+
     # --- Heuristic baseline -------------------------------------------------
     # Map each narration midpoint proportionally onto the scene span, pick the
     # containing scene window. Produces a stable candidate per segment with
     # score=1.0 (plan T14 normative rule).
     heuristic = []
     for i, seg in enumerate(ctx.timed_segments):
-        narr_mid = (seg.start + seg.end) / 2.0
-        if narr_span > 0:
-            ratio = (narr_mid - first_start) / narr_span
-            src_mid = scene_start + ratio * scene_span
-        else:
-            src_mid = scene_start
+        if use_weighted_acts:
+            # EP1: map within assigned act bucket
+            act_idx = act_assignments[i]
+            bucket = act_scenes[act_idx]
+            if not bucket:
+                # Empty act — fall back to all scenes
+                bucket = scenes
+            b_start = min(s.start for s in bucket)
+            b_end = max(s.end for s in bucket)
+            b_span = b_end - b_start
 
-        containing = None
-        for scene in scenes:
-            if scene.start <= src_mid <= scene.end:
-                containing = scene
-                break
-        if containing is None:
-            containing = scenes[0]
+            # Position within this segment's slot in the bucket
+            act_segs = [j for j, a in enumerate(act_assignments) if a == act_idx]
+            pos_in_act = act_segs.index(i)
+            n_in_act = len(act_segs)
+            if n_in_act > 1:
+                local_ratio = (pos_in_act + 0.5) / n_in_act
+            else:
+                local_ratio = 0.5
+
+            src_mid = b_start + local_ratio * b_span if b_span > 0 else b_start
+
+            # Find containing scene within bucket
+            containing = None
+            for scene in bucket:
+                if scene.start <= src_mid <= scene.end:
+                    containing = scene
+                    break
+            if containing is None:
+                containing = bucket[0]
+        else:
+            # Original uniform mapping
+            narr_mid = (seg.start + seg.end) / 2.0
+            if narr_span > 0:
+                ratio = (narr_mid - first_start) / narr_span
+                src_mid = scene_start + ratio * scene_span
+            else:
+                src_mid = scene_start
+
+            containing = None
+            for scene in scenes:
+                if scene.start <= src_mid <= scene.end:
+                    containing = scene
+                    break
+            if containing is None:
+                containing = scenes[0]
 
         heuristic.append(
             {
@@ -590,10 +744,35 @@ def _match_clips_impl(
                 scene_labels = [label for label, _ in scene_captions]
                 scene_vecs = _embed_texts(scene_labels, emb_model)
                 narration_vecs = _embed_texts([seg.text for seg in ctx.timed_segments], emb_model)
+                import numpy as np
+
                 for i, seg in enumerate(ctx.timed_segments):
-                    best_idx = _cosine_top1(narration_vecs[i], scene_vecs)
-                    best_scene = scenes[best_idx]
-                    score = float(scene_vecs[best_idx] @ narration_vecs[i])
+                    if use_weighted_acts:
+                        # EP1: restrict embedding candidates to act bucket + overflow
+                        act_idx = act_assignments[i]
+                        cand_indices = _get_act_candidate_indices(
+                            act_idx, len(act_weights), act_scenes
+                        )
+                        # Filter to valid indices within scene_vecs
+                        cand_indices = [idx for idx in cand_indices if idx < len(scene_vecs)]
+                        if not cand_indices:
+                            cand_indices = list(range(len(scenes)))
+                        cand_vecs = scene_vecs[np.array(cand_indices)]
+                        local_best = _cosine_top1(narration_vecs[i], cand_vecs)
+                        if local_best >= 0:
+                            best_idx = cand_indices[local_best]
+                            best_scene = scenes[best_idx]
+                            score = float(scene_vecs[best_idx] @ narration_vecs[i])
+                        else:
+                            best_scene = next(
+                                (s for s in scenes if s.index == heuristic[i]["scene_index"]),
+                                scenes[0],
+                            )
+                            score = 1.0
+                    else:
+                        best_idx = _cosine_top1(narration_vecs[i], scene_vecs)
+                        best_scene = scenes[best_idx]
+                        score = float(scene_vecs[best_idx] @ narration_vecs[i])
                     final.append((heuristic[i], score, best_scene, "embedding"))
                     # F1: collect raw embedding score (before low-score
                     # fallback overrides it to 1.0). Lets match_summary
@@ -760,6 +939,14 @@ def _match_clips_impl(
             "swaps_log": diversity_swaps_log,
             "window": ctx.metadata.get("match_diversity_window", 3),
             "max_reuse": ctx.metadata.get("match_max_scene_reuse", 2),
+        },
+        "timeline": {
+            "mode": "weighted_acts" if use_weighted_acts else "uniform",
+            "act_weights": act_weights if use_weighted_acts else None,
+            "segments_per_act": (
+                [act_assignments.count(a) for a in range(len(act_weights))]
+                if use_weighted_acts else None
+            ),
         },
         # Back-compat fields (kept for existing consumers)
         "total": total,

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -37,6 +37,7 @@ PARAM_WHITELIST: frozenset[str] = frozenset({
     "match_speed_clamp_min", "match_speed_clamp_max",
     "scene_merge_min_duration", "match_drop_scene_min_duration",
     "match_diversity_window", "match_max_scene_reuse",
+    "match_timeline_mode", "match_act_weights",
     "embedding_model_name",
     "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
     "tts_pause_ms",

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -79,6 +79,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             "scene_merge_min_duration", "embedding_model_name",
             "match_drop_scene_min_duration",
             "match_diversity_window", "match_max_scene_reuse",
+            "match_timeline_mode", "match_act_weights",
             # BGM + loudness
             "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
             # TTS pacing

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -81,6 +81,7 @@ def merge_job(
             "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
             "scene_merge_min_duration", "match_drop_scene_min_duration",
             "match_diversity_window", "match_max_scene_reuse",
+            "match_timeline_mode", "match_act_weights",
             "embedding_model_name",
             # BGM
             "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -33,6 +33,8 @@ class JobParams(BaseModel):
     match_drop_scene_min_duration: Optional[float] = None
     match_diversity_window: Optional[int] = None
     match_max_scene_reuse: Optional[int] = None
+    match_timeline_mode: Optional[str] = None  # "uniform" (default) | "weighted_acts"
+    match_act_weights: Optional[list] = None  # e.g. [0.15, 0.25, 0.40, 0.20]
     embedding_model_name: Optional[str] = None
     # ── BGM ──
     bgm_gain_db: Optional[float] = None

--- a/tests/test_ep1_weighted_acts.py
+++ b/tests/test_ep1_weighted_acts.py
@@ -1,0 +1,266 @@
+"""EP1: Act-weighted timeline partitioning tests.
+
+Verifies that match_timeline_mode="weighted_acts" correctly:
+- Partitions scenes into 4 act buckets by time
+- Allocates narration segments to acts by weight
+- Constrains heuristic + embedding candidates to act buckets
+- Falls back gracefully when too few scenes/segments
+- Audit metadata (timeline.mode, act_weights, segments_per_act) is correct
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from movie_narrator.models import Context, Scene, Services, TimedSegment
+from movie_narrator.pipeline import match as match_module
+from movie_narrator.pipeline.match import (
+    _assign_segments_to_acts,
+    _get_act_candidate_indices,
+    _partition_scenes_by_act,
+    match_clips,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_embedding_cache():
+    match_module._load_embedding_model.cache_clear()
+    yield
+    match_module._load_embedding_model.cache_clear()
+
+
+# ── Unit tests for helper functions ──
+
+
+class TestPartitionScenesByAct:
+    def test_four_equal_buckets(self):
+        """20 scenes spanning 0-400s → 5 scenes per act."""
+        scenes = [Scene(index=i, start=float(i * 20), end=float(i * 20 + 20)) for i in range(20)]
+        buckets = _partition_scenes_by_act(scenes, n_acts=4)
+        assert len(buckets) == 4
+        for b in buckets:
+            assert len(b) == 5
+
+    def test_uneven_scene_distribution(self):
+        """Scenes clustered in first half → acts 3,4 may be empty."""
+        scenes = [Scene(index=i, start=float(i * 5), end=float(i * 5 + 5)) for i in range(10)]
+        buckets = _partition_scenes_by_act(scenes, n_acts=4)
+        assert len(buckets[0]) > 0
+        assert len(buckets[1]) > 0
+        # Acts 2,3 may be empty — that's OK, caller handles fallback
+
+    def test_empty_scenes(self):
+        buckets = _partition_scenes_by_act([], n_acts=4)
+        assert all(b == [] for b in buckets)
+
+    def test_single_scene(self):
+        scenes = [Scene(index=0, start=0.0, end=10.0)]
+        buckets = _partition_scenes_by_act(scenes, n_acts=4)
+        assert len(buckets[0]) == 1
+        assert all(len(b) == 0 for b in buckets[1:])
+
+
+class TestAssignSegmentsToActs:
+    def test_counts_sum_to_n(self):
+        """Segment counts per act must sum exactly to n_segments."""
+        weights = [0.15, 0.25, 0.40, 0.20]
+        for n in [4, 8, 12, 18, 25, 50]:
+            assignments = _assign_segments_to_acts(n, weights)
+            assert len(assignments) == n
+
+    def test_weight_proportional(self):
+        """Act 2 (weight=0.40) should get the most segments."""
+        weights = [0.15, 0.25, 0.40, 0.20]
+        assignments = _assign_segments_to_acts(20, weights)
+        counts = [assignments.count(a) for a in range(4)]
+        assert counts[2] == max(counts), f"Act 2 should have most segments, got {counts}"
+
+    def test_chronological_order(self):
+        """Assignments should be in chronological order (all act 0, then act 1, ...)."""
+        weights = [0.25, 0.25, 0.25, 0.25]
+        assignments = _assign_segments_to_acts(16, weights)
+        for i in range(len(assignments) - 1):
+            assert assignments[i] <= assignments[i + 1]
+
+    def test_zero_weights_fallback(self):
+        """All-zero weights → fallback to default."""
+        assignments = _assign_segments_to_acts(8, [0, 0, 0, 0])
+        assert len(assignments) == 8
+
+    def test_min_one_per_act(self):
+        """Each act should get at least 1 segment when n >= n_acts."""
+        weights = [0.01, 0.01, 0.01, 0.97]
+        assignments = _assign_segments_to_acts(8, weights)
+        counts = [assignments.count(a) for a in range(4)]
+        for c in counts:
+            assert c >= 1
+
+
+class TestGetActCandidateIndices:
+    def test_own_act_plus_overflow(self):
+        """Act 1 candidates should include acts 0,1,2 (±1 overflow)."""
+        scenes = [Scene(index=i, start=float(i * 20), end=float(i * 20 + 20)) for i in range(20)]
+        buckets = _partition_scenes_by_act(scenes, n_acts=4)
+        indices = _get_act_candidate_indices(1, 4, buckets, allow_overflow=True)
+        # Should include scenes from acts 0, 1, 2 (not act 3)
+        assert len(indices) > 0
+        # All indices from acts 0-2 (scenes 0-14)
+        for idx in indices:
+            assert 0 <= idx <= 14
+
+    def test_empty_act_fallback(self):
+        """Empty act → all scenes as candidates."""
+        buckets = [[], [], [Scene(index=5, start=100.0, end=120.0)], []]
+        indices = _get_act_candidate_indices(0, 4, buckets, allow_overflow=True)
+        assert len(indices) > 0  # falls back to all scenes
+
+    def test_no_overflow(self):
+        """allow_overflow=False → only own act scenes."""
+        scenes = [Scene(index=i, start=float(i * 20), end=float(i * 20 + 20)) for i in range(20)]
+        buckets = _partition_scenes_by_act(scenes, n_acts=4)
+        indices = _get_act_candidate_indices(1, 4, buckets, allow_overflow=False)
+        # Only act 1 scenes (5-9)
+        for idx in indices:
+            assert 5 <= idx <= 9
+
+
+# ── Integration tests through match_clips ──
+
+
+def _make_ctx(tmp_path, n_scenes=20, n_segments=18, mode="weighted_acts", weights=None):
+    ctx = Context(
+        movie_name="test",
+        output_dir=str(tmp_path),
+        source_video_path=str(tmp_path / "video.mp4"),
+    )
+    ctx.services = Services(console=MagicMock())
+    ctx.status.scene = "success"
+    (tmp_path / "video.mp4").write_bytes(b"00")
+
+    ctx.scenes = [
+        Scene(index=i, start=float(i * 20), end=float(i * 20 + 20))
+        for i in range(n_scenes)
+    ]
+    ctx.timed_segments = [
+        TimedSegment(text=f"segment {i}", start=float(i * 3), end=float(i * 3 + 2.5))
+        for i in range(n_segments)
+    ]
+
+    ctx.metadata["match_timeline_mode"] = mode
+    if weights:
+        ctx.metadata["match_act_weights"] = weights
+
+    # Disable embedding path — isolate weighted_acts heuristic
+    import unittest.mock as mock
+    ctx._mock_patch = mock.patch(
+        "movie_narrator.pipeline.match.probe", lambda name: (False, "")
+    )
+    return ctx
+
+
+def test_weighted_acts_produces_act_constrained_heuristic(tmp_path):
+    """18 segments over 20 scenes with weighted_acts → src_start distribution
+    should be non-uniform, concentrated in act 2 (weight=0.40).
+    """
+    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=18,
+                    weights=[0.15, 0.25, 0.40, 0.20])
+    with ctx._mock_patch:
+        match_clips(ctx)
+
+    summary = ctx.metadata["match_summary"]
+    timeline = summary["timeline"]
+
+    # Audit fields
+    assert timeline["mode"] == "weighted_acts"
+    assert timeline["act_weights"] == [0.15, 0.25, 0.40, 0.20]
+    assert timeline["segments_per_act"] is not None
+    assert sum(timeline["segments_per_act"]) == 18
+
+    # Act 2 should have the most segments (weight=0.40)
+    assert timeline["segments_per_act"][2] == max(timeline["segments_per_act"])
+
+    # Verify src_start distribution: act 2 segments should map to scenes 10-14
+    # (act 2 covers 200-300s out of 0-400s total)
+    act2_segs = [mc for i, mc in enumerate(ctx.matched_clips)
+                 if i < timeline["segments_per_act"][0] + timeline["segments_per_act"][1]
+                 + timeline["segments_per_act"][2]
+                 and i >= timeline["segments_per_act"][0] + timeline["segments_per_act"][1]]
+    for mc in act2_segs:
+        # Scene index should be in act 2 range (10-14) or adjacent overflow (5-19)
+        assert 5 <= mc.scene_index <= 19, (
+            f"segment {mc.segment_index} scene_index={mc.scene_index} "
+            f"should be in act 2 bucket range"
+        )
+
+
+def test_weighted_acts_disabled_with_few_scenes(tmp_path):
+    """Fewer than 8 scenes → falls back to uniform, mode in metadata = "uniform"."""
+    ctx = _make_ctx(tmp_path, n_scenes=5, n_segments=10,
+                    weights=[0.15, 0.25, 0.40, 0.20])
+    with ctx._mock_patch:
+        match_clips(ctx)
+
+    timeline = ctx.metadata["match_summary"]["timeline"]
+    assert timeline["mode"] == "uniform"
+    assert timeline["act_weights"] is None
+
+
+def test_weighted_acts_disabled_with_few_segments(tmp_path):
+    """Fewer than 4 segments → falls back to uniform."""
+    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=3,
+                    weights=[0.15, 0.25, 0.40, 0.20])
+    with ctx._mock_patch:
+        match_clips(ctx)
+
+    timeline = ctx.metadata["match_summary"]["timeline"]
+    assert timeline["mode"] == "uniform"
+
+
+def test_uniform_mode_default(tmp_path):
+    """No match_timeline_mode set → uniform (default, backward compat)."""
+    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=18, mode="uniform")
+    with ctx._mock_patch:
+        match_clips(ctx)
+
+    timeline = ctx.metadata["match_summary"]["timeline"]
+    assert timeline["mode"] == "uniform"
+    assert timeline["act_weights"] is None
+
+
+def test_weighted_acts_different_weights(tmp_path):
+    """Custom weights → segment counts match weight ratios."""
+    ctx = _make_ctx(tmp_path, n_scenes=40, n_segments=20,
+                    weights=[0.10, 0.20, 0.50, 0.20])
+    with ctx._mock_patch:
+        match_clips(ctx)
+
+    timeline = ctx.metadata["match_summary"]["timeline"]
+    assert timeline["mode"] == "weighted_acts"
+    counts = timeline["segments_per_act"]
+
+    # Act 2 (weight=0.50) should have the most segments
+    assert counts[2] == max(counts)
+    # Act 0 (weight=0.10) should have the fewest
+    assert counts[0] == min(counts)
+    # Sum to 20
+    assert sum(counts) == 20
+
+
+def test_weighted_acts_src_start_not_uniform(tmp_path):
+    """With weighted_acts, src_start values should NOT be uniformly distributed
+    across the full timeline — they should cluster in act 2 (the heaviest act).
+    """
+    ctx = _make_ctx(tmp_path, n_scenes=40, n_segments=20,
+                    weights=[0.10, 0.20, 0.50, 0.20])
+    with ctx._mock_patch:
+        match_clips(ctx)
+
+    src_starts = [mc.src_start for mc in ctx.matched_clips]
+
+    # Count how many src_starts fall in act 2 (60%-100% of 800s = 480-800)
+    act2_count = sum(1 for s in src_starts if 320 <= s <= 640)
+    # With 50% weight, ~10 of 20 segments should be in act 2
+    assert act2_count >= 8, (
+        f"Expected >=8 segments in act 2 range, got {act2_count}/20. "
+        f"src_starts={sorted(src_starts)}"
+    )


### PR DESCRIPTION
EP1: Act-weighted timeline partitioning for match pipeline.

## Problem

Current `match_timeline_mode="uniform"` maps narration segments proportionally across the entire video timeline. For a 130-min movie with 18 narration segments, this creates a "fast-forward browse" feel — all acts of the film get equal coverage, even though the climax (act 3) is typically more visually compelling than the slow setup (act 1).

## Solution

New `match_timeline_mode="weighted_acts"` mode:

1. **Scene partitioning**: `_partition_scenes_by_act()` divides scenes into 4 equal-time buckets (e.g., 0-25%, 25-50%, 50-75%, 75-100% of timeline).

2. **Segment allocation**: `_assign_segments_to_acts()` assigns narration segments to acts by weight. Default `[0.15, 0.25, 0.40, 0.20]` — act 3 (climax) gets 40% of segments, act 1 (setup) gets 15%.

3. **Heuristic mapping**: Each segment's `src_mid` is calculated within its assigned act bucket, not the full timeline. Segments within an act are evenly distributed across the bucket's time span.

4. **Embedding constraint**: When using embedding re-rank, candidate scenes are restricted to the act bucket + adjacent acts (±1 bucket overflow). This prevents act-3 narration from matching a visually similar scene in act 1.

5. **Graceful fallback**: If `< 8 scenes` or `< 4 segments`, falls back to uniform mode (weighted_acts requires enough data to meaningfully partition).

## New params (job.yaml)

```yaml
match_timeline_mode: weighted_acts  # uniform (default) | weighted_acts
match_act_weights: [0.15, 0.25, 0.40, 0.20]  # four-act allocation
```

## Audit metadata

```json
"timeline": {
  "mode": "weighted_acts",
  "act_weights": [0.15, 0.25, 0.40, 0.20],
  "segments_per_act": [3, 5, 7, 3]
}
```

## Files changed (7 files, +478/-16)

- `pipeline/match.py`: 3 new helpers (`_partition_scenes_by_act`, `_assign_segments_to_acts`, `_get_act_candidate_indices`) + heuristic + embedding modification + audit metadata (+217)
- `pipeline/runner.py`: PARAM_WHITELIST +2 params (+1)
- `workflow/schema.py`: JobParams +2 fields (+2)
- `workflow/load.py`: allowed params +2 (+1)
- `workflow/merge.py`: allowed params +2 (+1)
- `examples/job.example.yaml`: examples + whitelist comment (+6/-2)
- `tests/test_ep1_weighted_acts.py`: 18 tests (3 unit test classes + 6 integration tests) (+266)

## Test coverage

| Test | Validates |
|------|-----------|
| `TestPartitionScenesByAct` (4 tests) | Equal buckets, uneven distribution, empty, single scene |
| `TestAssignSegmentsToActs` (5 tests) | Sum to n, weight proportional, chronological order, zero weights, min 1 per act |
| `TestGetActCandidateIndices` (3 tests) | Overflow ±1, empty fallback, no overflow |
| `test_weighted_acts_produces_act_constrained_heuristic` | 18 segs over 20 scenes → act 2 gets most segments, src_start in act 2 range |
| `test_weighted_acts_disabled_with_few_scenes` | < 8 scenes → uniform fallback |
| `test_weighted_acts_disabled_with_few_segments` | < 4 segments → uniform fallback |
| `test_uniform_mode_default` | No mode set → uniform (backward compat) |
| `test_weighted_acts_different_weights` | Custom weights → proportional segment counts |
| `test_weighted_acts_src_start_not_uniform` | src_starts cluster in act 2 (heaviest weight) |

Tests: 495 passed (+18), 23 skipped, 0 failures.
