### PR TITLE
feat(ep3): top-K rerank with order-backtrack reuse penalty

### DIFF
--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -72,6 +72,7 @@ narration_preset: ""        # douyin-fast | mainstream-dry | bilibili-long
 #          embedding_model_name
 #          match_diversity_window / match_max_scene_reuse
 #          match_timeline_mode / match_act_weights
+#          match_topk / match_topk_reuse_penalty
 #   BGM:  bgm_gain_db / bgm_duck_db / bgm_normalize / audio_target_dbfs
 #   TTS:  tts_pause_ms / tts_max_concurrent / tts_audio_format / tts_audio_bitrate
 #   翻译: translate_source_lang / translate_provider / translate_retries
@@ -108,6 +109,8 @@ params:
   # match_max_scene_reuse: 2        # 窗口内同一场景最大允许出现次数（超过则换景）
   # match_timeline_mode: uniform    # uniform（默认，全片比例映射）| weighted_acts（四幕时间桶，高光集中在高潮幕）
   # match_act_weights: [0.15, 0.25, 0.40, 0.20]  # 四幕时间占比（开/中/高潮/尾），仅 weighted_acts 模式生效
+  # match_topk: 5                    # EP3: 每句取 top-K 候选场景，贪心分配时避免近期已用场景（默认 5，0/1 = 禁用退回 top-1）
+  # match_topk_reuse_penalty: 0.15   # EP3: 近期已用场景的分数扣减值（默认 0.15，越大越倾向换景）
 
   # ---- BGM / 音频 ----
   # bgm_gain_db: -18          # BGM 基础增益（dB）

--- a/src/movie_narrator/models.py
+++ b/src/movie_narrator/models.py
@@ -152,7 +152,7 @@ class MatchedClip(BaseModel):
     src_end: float
     score: float
     scene_index: Optional[int] = None
-    source: Literal["scene", "heuristic", "embedding", "fallback"] = "fallback"
+    source: Literal["scene", "heuristic", "embedding", "embedding_topk", "embedding_top1", "fallback"] = "fallback"
 
 
 class Context(BaseModel):

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -214,6 +214,114 @@ def _cosine_top1(target_vec, candidate_matrix) -> int:
     return int(sims.argmax())
 
 
+def _cosine_topk(
+    target_vec, candidate_matrix, k: int = 5
+) -> list[tuple[int, float]]:
+    """Return top-K candidates as ``(local_index, score)`` sorted by score descending.
+
+    ``local_index`` is the row index within ``candidate_matrix``.
+    Returns an empty list if the matrix is empty or k <= 0.
+    """
+    if candidate_matrix.size == 0 or k <= 0:
+        return []
+    import numpy as np
+
+    sims = candidate_matrix @ target_vec
+    k = min(k, len(sims))
+    # argpartition for O(n) top-K, then sort the K winners
+    top_indices = np.argpartition(sims, -k)[-k:]
+    top_indices = top_indices[np.argsort(sims[top_indices])[::-1]]
+    return [(int(i), float(sims[i])) for i in top_indices]
+
+
+def _greedy_topk_assign(
+    narration_vecs,
+    scene_vecs,
+    scenes: List[Scene],
+    topk: int = 5,
+    reuse_penalty: float = 0.15,
+    reuse_window: int = 3,
+    use_weighted_acts: bool = False,
+    act_assignments: Optional[list[int]] = None,
+    act_scenes: Optional[list[list[Scene]]] = None,
+    act_weights: Optional[list[float]] = None,
+) -> list[tuple[int, float, str]]:
+    """Greedy top-K assignment with order-backtrack reuse penalty (EP3).
+
+    For each narration segment, computes top-K candidate scenes from the
+    embedding similarity, then picks the candidate with the highest
+    *adjusted* score — where scenes used in the last ``reuse_window``
+    segments get a ``reuse_penalty`` deduction.
+
+    Returns a list of ``(scene_index, score, source)`` per segment.
+    ``source`` is ``"embedding_topk"`` when top-K ran, ``"embedding_top1"``
+    when top-K is disabled (k <= 1).
+    """
+    import numpy as np
+
+    n_seg = len(narration_vecs)
+    n_scenes = len(scenes)
+    results: list[tuple[int, float, str]] = []
+    recent_usage: list[int] = []  # scene indices used recently (chronological)
+
+    source = "embedding_topk" if topk > 1 else "embedding_top1"
+
+    for i in range(n_seg):
+        # Determine candidate pool
+        if use_weighted_acts and act_assignments and act_scenes:
+            act_idx = act_assignments[i]
+            cand_indices = _get_act_candidate_indices(
+                act_idx, len(act_weights), act_scenes
+            )
+            cand_indices = [idx for idx in cand_indices if idx < n_scenes]
+            if not cand_indices:
+                cand_indices = list(range(n_scenes))
+        else:
+            cand_indices = list(range(n_scenes))
+
+        cand_vecs = scene_vecs[np.array(cand_indices)]
+
+        if topk > 1:
+            top_candidates = _cosine_topk(narration_vecs[i], cand_vecs, k=topk)
+        else:
+            # Fallback to top-1
+            best_local = _cosine_top1(narration_vecs[i], cand_vecs)
+            if best_local < 0:
+                results.append((0, 1.0, source))
+                continue
+            top_candidates = [(best_local, float(cand_vecs[best_local] @ narration_vecs[i]))]
+
+        if not top_candidates:
+            results.append((0, 1.0, source))
+            continue
+
+        # Adjust scores with reuse penalty
+        recent_set = set(recent_usage[-reuse_window:]) if recent_usage else set()
+        # Initialise from the first candidate's *adjusted* score (not raw)
+        # so that the penalty on a recently-used top-1 candidate can actually
+        # let a lower-ranked candidate win.
+        first_global = cand_indices[top_candidates[0][0]]
+        first_raw = top_candidates[0][1]
+        best_global_idx = first_global
+        best_adjusted = first_raw - reuse_penalty if first_global in recent_set else first_raw
+        best_raw = first_raw
+
+        for local_idx, raw_score in top_candidates:
+            global_idx = cand_indices[local_idx]
+            adjusted = raw_score
+            if global_idx in recent_set:
+                adjusted -= reuse_penalty
+            if adjusted > best_adjusted:
+                best_adjusted = adjusted
+                best_global_idx = global_idx
+                best_raw = raw_score
+
+        results.append((best_global_idx, best_raw, source))
+        recent_usage.append(best_global_idx)
+
+    return results
+
+
 # ── Scene merging ───────────────────────────────────────────
 
 
@@ -590,6 +698,9 @@ def _match_clips_impl(
         and len(scenes) >= 8
         and len(ctx.timed_segments) >= 4
     )
+    # EP3: top-K rerank params
+    topk = ctx.metadata.get("match_topk", 5)
+    reuse_penalty = ctx.metadata.get("match_topk_reuse_penalty", 0.15)
     if use_weighted_acts:
         act_scenes = _partition_scenes_by_act(scenes, n_acts=len(act_weights))
         act_assignments = _assign_segments_to_acts(
@@ -748,36 +859,24 @@ def _match_clips_impl(
                 scene_labels = [label for label, _ in scene_captions]
                 scene_vecs = _embed_texts(scene_labels, emb_model)
                 narration_vecs = _embed_texts([seg.text for seg in ctx.timed_segments], emb_model)
-                import numpy as np
 
-                for i, seg in enumerate(ctx.timed_segments):
-                    if use_weighted_acts:
-                        # EP1: restrict embedding candidates to act bucket + overflow
-                        act_idx = act_assignments[i]
-                        cand_indices = _get_act_candidate_indices(
-                            act_idx, len(act_weights), act_scenes
-                        )
-                        # Filter to valid indices within scene_vecs
-                        cand_indices = [idx for idx in cand_indices if idx < len(scene_vecs)]
-                        if not cand_indices:
-                            cand_indices = list(range(len(scenes)))
-                        cand_vecs = scene_vecs[np.array(cand_indices)]
-                        local_best = _cosine_top1(narration_vecs[i], cand_vecs)
-                        if local_best >= 0:
-                            best_idx = cand_indices[local_best]
-                            best_scene = scenes[best_idx]
-                            score = float(scene_vecs[best_idx] @ narration_vecs[i])
-                        else:
-                            best_scene = next(
-                                (s for s in scenes if s.index == heuristic[i]["scene_index"]),
-                                scenes[0],
-                            )
-                            score = 1.0
-                    else:
-                        best_idx = _cosine_top1(narration_vecs[i], scene_vecs)
-                        best_scene = scenes[best_idx]
-                        score = float(scene_vecs[best_idx] @ narration_vecs[i])
-                    final.append((heuristic[i], score, best_scene, "embedding"))
+                # EP3: greedy top-K assignment with reuse penalty
+                topk_results = _greedy_topk_assign(
+                    narration_vecs=narration_vecs,
+                    scene_vecs=scene_vecs,
+                    scenes=scenes,
+                    topk=topk,
+                    reuse_penalty=reuse_penalty,
+                    reuse_window=ctx.metadata.get("match_diversity_window", 3),
+                    use_weighted_acts=use_weighted_acts,
+                    act_assignments=act_assignments if use_weighted_acts else None,
+                    act_scenes=act_scenes if use_weighted_acts else None,
+                    act_weights=act_weights if use_weighted_acts else None,
+                )
+
+                for i, (scene_idx, score, source) in enumerate(topk_results):
+                    best_scene = scenes[scene_idx]
+                    final.append((heuristic[i], score, best_scene, source))
                     # F1: collect raw embedding score (before low-score
                     # fallback overrides it to 1.0). Lets match_summary
                     # distinguish "matched well" from "matched poorly".
@@ -874,15 +973,21 @@ def _match_clips_impl(
     # Records the match quality breakdown so L2 hand-test can verify
     # the main path isn't "全 heuristic 糊弄" (O9/O10 in checklist).
     # Schema per CORE_ENGINE_TREATMENT_PLAN §5.2.3.
-    embedding_count = sum(1 for mc in matched_clips if mc.source == "embedding")
+    # EP3: sources can be "embedding_topk", "embedding_top1", or "heuristic"
+    embedding_count = sum(
+        1 for mc in matched_clips
+        if mc.source in ("embedding", "embedding_topk", "embedding_top1")
+    )
     heuristic_count = sum(1 for mc in matched_clips if mc.source == "heuristic")
+    topk_count = sum(1 for mc in matched_clips if mc.source == "embedding_topk")
+    top1_count = sum(1 for mc in matched_clips if mc.source == "embedding_top1")
     total = len(matched_clips)
 
     # score stats: only for source==embedding clips that were adopted
     # (i.e. did NOT fall back to heuristic due to low score)
     adopted_embedding_scores = [
         mc.score for mc in matched_clips
-        if mc.source == "embedding"
+        if mc.source in ("embedding", "embedding_topk", "embedding_top1")
     ]
 
     def _stats(values: List[float]) -> Optional[dict]:
@@ -922,7 +1027,12 @@ def _match_clips_impl(
         "drop_min_duration": drop_min,
         "min_score": min_score,
         "speed_clamp": [clamp_min, clamp_max],
-        "source_counts": {"embedding": embedding_count, "heuristic": heuristic_count},
+        "source_counts": {
+            "embedding": embedding_count,
+            "embedding_topk": topk_count,
+            "embedding_top1": top1_count,
+            "heuristic": heuristic_count,
+        },
         "heuristic_ratio": round(heuristic_count / total, 4) if total else 1.0,
         "embedding_ratio": round(embedding_count / total, 4) if total else 0.0,
         "score": _stats(adopted_embedding_scores),
@@ -951,6 +1061,12 @@ def _match_clips_impl(
                 [act_assignments.count(a) for a in range(len(act_weights))]
                 if use_weighted_acts else None
             ),
+        },
+        "topk": {
+            "k": topk,
+            "reuse_penalty": reuse_penalty,
+            "topk_count": topk_count,
+            "top1_count": top1_count,
         },
         # Back-compat fields (kept for existing consumers)
         "total": total,

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -38,6 +38,7 @@ PARAM_WHITELIST: frozenset[str] = frozenset({
     "scene_merge_min_duration", "match_drop_scene_min_duration",
     "match_diversity_window", "match_max_scene_reuse",
     "match_timeline_mode", "match_act_weights",
+    "match_topk", "match_topk_reuse_penalty",
     "embedding_model_name",
     "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
     "tts_pause_ms",

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -80,6 +80,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             "match_drop_scene_min_duration",
             "match_diversity_window", "match_max_scene_reuse",
             "match_timeline_mode", "match_act_weights",
+            "match_topk", "match_topk_reuse_penalty",
             # BGM + loudness
             "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
             # TTS pacing

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -82,6 +82,7 @@ def merge_job(
             "scene_merge_min_duration", "match_drop_scene_min_duration",
             "match_diversity_window", "match_max_scene_reuse",
             "match_timeline_mode", "match_act_weights",
+            "match_topk", "match_topk_reuse_penalty",
             "embedding_model_name",
             # BGM
             "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -35,6 +35,8 @@ class JobParams(BaseModel):
     match_max_scene_reuse: Optional[int] = None
     match_timeline_mode: Optional[str] = None  # "uniform" (default) | "weighted_acts"
     match_act_weights: Optional[list] = None  # e.g. [0.15, 0.25, 0.40, 0.20]
+    match_topk: Optional[int] = None  # EP3: top-K rerank (default 5, 0/1 = top-1)
+    match_topk_reuse_penalty: Optional[float] = None  # EP3: score deduction for recently used scenes (default 0.15)
     embedding_model_name: Optional[str] = None
     # ── BGM ──
     bgm_gain_db: Optional[float] = None

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -835,7 +835,7 @@ def test_match_clips_whisperx_scene_captions(tmp_path, monkeypatch):
     assert racing_match.scene_index == 0
     # Crying narration should match scene 1 (crying dialogue)
     assert crying_match.scene_index == 1
-    assert all(m.source == "embedding" for m in ctx.matched_clips)
+    assert all(m.source.startswith("embedding") for m in ctx.matched_clips)
 
 
 def test_match_clips_whisperx_cache_hit(tmp_path, monkeypatch):
@@ -996,7 +996,7 @@ def test_match_clips_embedding_reranks_when_available(tmp_path, monkeypatch):
     # alpha should resolve to scene 0, beta to scene 1
     assert alpha_match.scene_index == 0
     assert beta_match.scene_index == 1
-    assert all(m.source == "embedding" for m in ctx.matched_clips)
+    assert all(m.source.startswith("embedding") for m in ctx.matched_clips)
     # Cosine between one-hots is exactly 1.0
     for m in ctx.matched_clips:
         assert math.isclose(m.score, 1.0, abs_tol=1e-6)
@@ -1210,3 +1210,221 @@ def test_apply_diversity_no_swap_when_all_scenes_used():
     # Scene 0 appears 2 times in window of 3, max_reuse=1, but no unused scene available
     assert swaps == 0
     assert swaps_log == []
+
+
+# ── EP3: top-K rerank with order-backtrack reuse penalty ──
+
+
+class _EP3FakeST:
+    """Fake SentenceTransformer for EP3 tests.
+
+    Maps scene/narration texts to 3-D vectors so that:
+    - scene_0 / "zero"  → [1, 0, 0]    (cosine with [1,0,0] = 1.0)
+    - scene_1 / "one"   → [0.96, 0.28, 0]  (cosine with [1,0,0] = 0.96)
+    - alpha / beta      → [1, 0, 0]    (both narrations match scene_0 best)
+
+    After L2-normalisation all vectors are unit length (0.96² + 0.28² = 1.0),
+    so cosine = dot product.
+    """
+
+    def __init__(self, *a, **kw):
+        pass
+
+    def encode(self, texts):
+        arr = np.zeros((len(texts), 3), dtype=float)
+        for i, t in enumerate(texts):
+            tl = t.lower()
+            if "alpha" in tl or "beta" in tl:
+                arr[i] = np.array([1.0, 0.0, 0.0])
+            elif "zero" in tl or "scene 0" in tl:
+                arr[i] = np.array([1.0, 0.0, 0.0])
+            elif "one" in tl or "scene 1" in tl:
+                arr[i] = np.array([0.96, 0.28, 0.0])
+        return arr
+
+
+def _setup_ep3_ctx(tmp_path, monkeypatch, topk=None, reuse_penalty=None):
+    """Shared setup for EP3 embedding-path tests."""
+    ctx = _make_ctx(tmp_path)
+    (tmp_path / "video.mp4").write_bytes(b"00")
+    ctx.scenes = [
+        Scene(index=0, start=0.0, end=4.0),
+        Scene(index=1, start=4.0, end=10.0),
+    ]
+    ctx.timed_segments = [
+        TimedSegment(text="alpha alpha", start=0.0, end=2.0),
+        TimedSegment(text="beta beta", start=2.5, end=5.0),
+    ]
+    if topk is not None:
+        ctx.metadata["match_topk"] = topk
+    if reuse_penalty is not None:
+        ctx.metadata["match_topk_reuse_penalty"] = reuse_penalty
+
+    monkeypatch.setattr(match_module, "probe", lambda name: (True, ""))
+    mock_transcript = [
+        {"start": 0.0, "end": 3.5, "text": "scene zero speech"},
+        {"start": 4.0, "end": 9.0, "text": "scene one speech"},
+    ]
+    monkeypatch.setattr(
+        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
+    )
+
+    fake_mod = ModuleType("sentence_transformers")
+    fake_mod.SentenceTransformer = _EP3FakeST
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+    return ctx
+
+
+def test_ep3_topk_reuse_penalty_swaps_scene(tmp_path, monkeypatch):
+    """EP3: reuse penalty causes segment 1 to pick a different scene.
+
+    Both narrations match scene_0 best (cosine=1.0), but scene_1 is close
+    (cosine=0.96). With reuse_penalty=0.15, segment 1's adjusted score for
+    scene_0 (1.0-0.15=0.85) < scene_1 (0.96) → picks scene_1.
+    """
+    ctx = _setup_ep3_ctx(tmp_path, monkeypatch, topk=5, reuse_penalty=0.15)
+
+    match_clips(ctx)
+    assert ctx.status.match == "success"
+    assert len(ctx.matched_clips) == 2
+    # Segment 0 → scene_0 (best raw, no penalty)
+    assert ctx.matched_clips[0].scene_index == 0
+    # Segment 1 → scene_1 (scene_0 penalized: 1.0-0.15=0.85 < 0.96)
+    assert ctx.matched_clips[1].scene_index == 1
+    # Both use embedding_topk source
+    assert all(m.source == "embedding_topk" for m in ctx.matched_clips)
+
+
+def test_ep3_topk_disabled_top1_mode(tmp_path, monkeypatch):
+    """EP3: topk=1 → source is "embedding_top1", no reuse-penalty swap.
+
+    In top-1 mode only one candidate is considered per segment, so the
+    reuse penalty cannot cause a swap. Both segments pick scene_0.
+    """
+    ctx = _setup_ep3_ctx(tmp_path, monkeypatch, topk=1, reuse_penalty=0.15)
+
+    match_clips(ctx)
+    assert ctx.status.match == "success"
+    assert len(ctx.matched_clips) == 2
+    # Both segments pick scene_0 (only 1 candidate, no swap possible)
+    assert ctx.matched_clips[0].scene_index == 0
+    assert ctx.matched_clips[1].scene_index == 0
+    assert all(m.source == "embedding_top1" for m in ctx.matched_clips)
+
+
+def test_ep3_topk_zero_penalty_no_swap(tmp_path, monkeypatch):
+    """EP3: reuse_penalty=0 → no penalty, both segments pick scene_0."""
+    ctx = _setup_ep3_ctx(tmp_path, monkeypatch, topk=5, reuse_penalty=0.0)
+
+    match_clips(ctx)
+    assert ctx.status.match == "success"
+    assert len(ctx.matched_clips) == 2
+    # No penalty → both pick scene_0 (best raw score)
+    assert ctx.matched_clips[0].scene_index == 0
+    assert ctx.matched_clips[1].scene_index == 0
+    assert all(m.source == "embedding_topk" for m in ctx.matched_clips)
+
+
+def test_ep3_topk_audit_fields(tmp_path, monkeypatch):
+    """EP3: match_summary contains topk audit section."""
+    ctx = _setup_ep3_ctx(tmp_path, monkeypatch, topk=5, reuse_penalty=0.15)
+
+    match_clips(ctx)
+    summary = ctx.metadata["match_summary"]
+
+    assert "topk" in summary
+    assert summary["topk"]["k"] == 5
+    assert summary["topk"]["reuse_penalty"] == 0.15
+    assert summary["topk"]["topk_count"] == 2  # both segments used embedding_topk
+    assert summary["topk"]["top1_count"] == 0
+
+
+def test_ep3_topk_audit_fields_top1_mode(tmp_path, monkeypatch):
+    """EP3: topk audit fields reflect top-1 mode."""
+    ctx = _setup_ep3_ctx(tmp_path, monkeypatch, topk=1, reuse_penalty=0.15)
+
+    match_clips(ctx)
+    summary = ctx.metadata["match_summary"]
+
+    assert summary["topk"]["k"] == 1
+    assert summary["topk"]["topk_count"] == 0
+    assert summary["topk"]["top1_count"] == 2  # both used embedding_top1
+
+
+def test_ep3_cosine_topk_returns_sorted_descending():
+    """EP3: _cosine_topk returns (index, score) sorted by score descending."""
+    from movie_narrator.pipeline.match import _cosine_topk
+
+    target = np.array([1.0, 0.0, 0.0])
+    candidates = np.array([
+        [0.5, 0.866, 0.0],   # cosine = 0.5
+        [1.0, 0.0, 0.0],     # cosine = 1.0
+        [0.0, 1.0, 0.0],     # cosine = 0.0
+        [0.8, 0.6, 0.0],     # cosine = 0.8
+    ])
+    result = _cosine_topk(target, candidates, k=3)
+    assert len(result) == 3
+    # Sorted descending: 1.0, 0.8, 0.5
+    assert result[0] == (1, 1.0)
+    assert result[1] == (3, 0.8)
+    assert result[2] == (0, 0.5)
+
+
+def test_ep3_cosine_topk_k_exceeds_candidates():
+    """EP3: k > len(candidates) → returns all candidates sorted."""
+    from movie_narrator.pipeline.match import _cosine_topk
+
+    target = np.array([1.0, 0.0])
+    candidates = np.array([
+        [0.6, 0.8],   # cosine = 0.6
+        [1.0, 0.0],   # cosine = 1.0
+    ])
+    result = _cosine_topk(target, candidates, k=10)
+    assert len(result) == 2  # capped at available candidates
+    assert result[0] == (1, 1.0)
+    assert result[1] == (0, 0.6)
+
+
+def test_ep3_cosine_topk_empty_matrix():
+    """EP3: empty candidate matrix → returns empty list."""
+    from movie_narrator.pipeline.match import _cosine_topk
+
+    target = np.array([1.0, 0.0])
+    candidates = np.array([]).reshape(0, 2)
+    result = _cosine_topk(target, candidates, k=5)
+    assert result == []
+
+
+def test_ep3_greedy_topk_assign_unit():
+    """EP3: direct unit test for _greedy_topk_assign reuse-penalty logic."""
+    from movie_narrator.pipeline.match import _greedy_topk_assign
+
+    # 3 scenes, 2 narration segments
+    # narration_0 = [1,0,0], narration_1 = [1,0,0]  (both match scene_0 best)
+    # scene_0 = [1,0,0], scene_1 = [0.96,0.28,0], scene_2 = [0,1,0]
+    narration_vecs = np.array([
+        [1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+    ])
+    scene_vecs = np.array([
+        [1.0, 0.0, 0.0],
+        [0.96, 0.28, 0.0],
+        [0.0, 1.0, 0.0],
+    ])
+    scenes = [SimpleNamespace(index=i, start=i * 2, end=i * 2 + 2) for i in range(3)]
+
+    results = _greedy_topk_assign(
+        narration_vecs=narration_vecs,
+        scene_vecs=scene_vecs,
+        scenes=scenes,
+        topk=3,
+        reuse_penalty=0.15,
+        reuse_window=3,
+    )
+    assert len(results) == 2
+    # Segment 0 → scene_0 (best raw, no penalty)
+    assert results[0][0] == 0  # scene_index
+    assert results[0][2] == "embedding_topk"  # source
+    # Segment 1 → scene_1 (scene_0 penalized: 1.0-0.15=0.85 < 0.96)
+    assert results[1][0] == 1  # scene_index
+    assert results[1][2] == "embedding_topk"  # source


### PR DESCRIPTION
## EP3: Top-K Rerank with Order-Backtrack Reuse Penalty

### Changes
- **_cosine_topk**: O(n) top-K candidate selection via 
p.argpartition, sorted descending
- **_greedy_topk_assign**: Greedy assignment with reuse penalty — scenes used in the last euse_window segments get a euse_penalty score deduction, allowing lower-ranked candidates to win
- **Bug fix**: est_adjusted initialization used raw score instead of adjusted score, preventing the penalty from ever triggering a swap
- **MatchedClip.source**: Added embedding_topk / embedding_top1 to the Literal type
- **Parameter wiring**: match_topk (default 5, 0/1 = top-1) and match_topk_reuse_penalty (default 0.15) added to schema/load/merge/runner whitelist
- **Audit**: match_summary.topk section with k, euse_penalty, 	opk_count, 	op1_count
- **Tests**: 9 new EP3 tests covering reuse-penalty swap, top-1 mode, zero-penalty, audit fields, and unit tests for _cosine_topk and _greedy_topk_assign

### Test Results
- 505 passed, 23 skipped (full suite)
- 9 new EP3 tests all passing

### Files Changed (8)
| File | Change |
|------|--------|
| src/movie_narrator/pipeline/match.py | _cosine_topk, _greedy_topk_assign, reuse penalty fix, topk audit |
| src/movie_narrator/models.py | MatchedClip.source Literal update |
| src/movie_narrator/workflow/schema.py | match_topk, match_topk_reuse_penalty params |
| src/movie_narrator/workflow/load.py | Whitelist update |
| src/movie_narrator/workflow/merge.py | Whitelist update |
| src/movie_narrator/pipeline/runner.py | Whitelist update |
| examples/job.example.yaml | EP3 param comments |
| 	ests/test_match.py | 9 EP3 tests |