### PR TITLE
feat(stage-e): E.5 CLI match summary + RS-07/08/09 render fixes

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -1,7 +1,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import typer
 
@@ -10,6 +10,80 @@ from .models import Context
 from .pipeline.resolve import resolve_video
 from .pipeline.research import research_plot
 from .pipeline.runner import build_context, run_pipeline
+
+
+def _format_match_summary(ctx: Context) -> Optional[str]:
+    """Format a one-line match summary from ctx.metadata for CLI output.
+
+    Returns None if no match_summary is available (e.g. match step skipped).
+    """
+    ms: Optional[Dict[str, Any]] = ctx.metadata.get("match_summary")
+    if not ms:
+        return None
+
+    segments = ms.get("segments", 0)
+    sc = ms.get("source_counts", {})
+    emb = sc.get("embedding", 0)
+    heur = sc.get("heuristic", 0)
+    fb = sc.get("fallback", 0)
+    scene = sc.get("scene", 0)
+
+    parts: list[str] = [f"match: {segments} segs"]
+
+    source_parts: list[str] = []
+    if emb:
+        pct = round(emb / segments * 100) if segments else 0
+        source_parts.append(f"emb {emb}({pct}%)")
+    if heur:
+        pct = round(heur / segments * 100) if segments else 0
+        source_parts.append(f"heur {heur}({pct}%)")
+    if fb:
+        source_parts.append(f"fb {fb}")
+    if scene:
+        source_parts.append(f"scene {scene}")
+    if source_parts:
+        parts.append(" | ".join(source_parts))
+
+    score = ms.get("score")
+    if score and isinstance(score, dict):
+        avg = score.get("avg")
+        if avg is not None:
+            parts.append(f"avg {avg:.2f}")
+
+    degraded = ms.get("degraded_reason")
+    if degraded:
+        parts.append(f"degraded: {degraded}")
+
+    return " | ".join(parts)
+
+
+def _format_degradation_hints(ctx: Context) -> list[str]:
+    """Return human-readable degradation hints for the CLI output."""
+    hints: list[str] = []
+    ms: Optional[Dict[str, Any]] = ctx.metadata.get("match_summary")
+    if ms:
+        degraded = ms.get("degraded_reason")
+        if degraded == "fake_captions":
+            hints.append(
+                "match: using fake captions (no WhisperX) — "
+                "scene matching is heuristic-only, install [ml] extras for embedding match"
+            )
+        elif degraded == "all_heuristic":
+            hints.append(
+                "match: all segments fell back to heuristic — "
+                "check embedding model availability"
+            )
+        elif degraded:
+            hints.append(f"match degraded: {degraded}")
+
+    degraded_steps = ctx.metadata.get("_degraded_steps", [])
+    if degraded_steps:
+        hints.append(
+            f"degraded steps: {', '.join(degraded_steps)} — "
+            f"see metadata.json for details"
+        )
+
+    return hints
 
 app = typer.Typer(
     help="Movie Narrator — 从一个提示词生成解说短视频 / Generate narrated movie recap videos from a single prompt.",
@@ -221,6 +295,12 @@ def create(
             "⚠ 警告：旁白为占位内容——LLM 不可达。请检查 LLM 连接后重试。",
             err=True,
         )
+    # E.5: one-line match summary + degradation hints
+    match_line = _format_match_summary(ctx)
+    if match_line:
+        typer.echo(f"  {match_line}", err=True)
+    for hint in _format_degradation_hints(ctx):
+        typer.echo(f"  ⚠ {hint}", err=True)
     typer.echo(f"{ctx.video_path}")
 
 

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -12,6 +12,16 @@ from ..utils.text_image import create_text_image as _create_text_image
 from ..utils.video_layout import compute_fit_box
 from .bgm import ensure_final_audio
 
+# RS-07: Minimum segment duration floor for speed scaling.
+# Prevents division-by-zero when seg_duration is extremely short
+# (e.g. 0-length segment from alignment glitch). 0.1s is intentional:
+# below this, speed scaling produces visually absurd fast-forward.
+_SEG_DURATION_FLOOR = 0.1
+
+# RS-08: Default ffmpeg mux timeout (seconds) when render_ffmpeg_timeout
+# is not specified in job params. 10 min is generous for 4K + slow preset.
+_DEFAULT_MUX_TIMEOUT = 600
+
 
 class _RenderProgressLogger(TqdmProgressBarLogger):
     """MoviePy progress logger with readable bar descriptions.
@@ -109,7 +119,7 @@ def render_video(ctx: Context) -> Context:
                 try:
                     subclip = source.subclipped(mc.src_start, mc.src_end)
                     if src_duration > 0:
-                        subclip = subclip.with_speed_scaled(factor=src_duration / max(seg_duration, 0.1))
+                        subclip = subclip.with_speed_scaled(factor=src_duration / max(seg_duration, _SEG_DURATION_FLOOR))
 
                     # Fit source frame onto the canvas (cover=crop+fill,
                     # contain=letterbox+center). Keeps footage from overflowing
@@ -255,16 +265,17 @@ def render_video(ctx: Context) -> Context:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=600,  # 10 min — generous for slow ffmpeg mux
+            timeout=ctx.metadata.get("render_ffmpeg_timeout", _DEFAULT_MUX_TIMEOUT),
         )
         if proc.returncode != 0:
             raise RuntimeError(
                 f"ffmpeg mux failed (exit={proc.returncode}): {proc.stderr}"
             )
     finally:
-        # Clean up the video-only intermediate to keep the output dir tidy.
+        # RS-09: Clean up the .tmp directory (video_only.mp4 and any
+        # other intermediates) to keep the output dir tidy.
         try:
-            video_only_path.unlink(missing_ok=True)
+            shutil.rmtree(tmp_dir, ignore_errors=True)
         except OSError:
             pass
 


### PR DESCRIPTION
## Stage E 产品化收尾

### E.5 — CLI match 摘要输出
- \mn create\ 末行打印 match 一行摘要（段数、embedding/heuristic 占比、avg score）
- 降级提示：fake captions 提示装 [ml]；all_heuristic 提示检查 embedding；列出 degraded steps

### RS-07 — 极短段 speed scaling 溢出修复
- 提取 \_SEG_DURATION_FLOOR = 0.1\ 命名常量，防止对齐故障产生的极短段导致除零

### RS-08 — mux 超时硬编修复
- \ender_ffmpeg_timeout\ job 参数此前被硬编 600s 忽略，现已生效

### RS-09 — .tmp/ 残留清理
- \unlink(missing_ok=True)\ 改为 \shutil.rmtree(tmp_dir, ignore_errors=True)\

### M2 文档状态确认
- \prompt_target_segment_duration\ YAML 通路已在 v0.4.24 全链路打通（JobParams + load + merge + PARAM_WHITELIST）