### PR TITLE
feat(ep8-ep9): VisionCaptioner abstraction + pause/resume pipeline

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -92,6 +92,11 @@ def create(
         None, "--output-dir", "-o",
         help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
     ),
+    pause_at: Optional[str] = typer.Option(
+        None, "--pause-at",
+        help="在指定步骤后暂停(人在环 EP9) / Pause after this step name "
+             "(e.g. match_clips, generate_script). Resume with: mn resume --state <path>",
+    ),
 ):
     """生成解说短视频 — 从电影名到成片一站式产出.
 
@@ -204,9 +209,22 @@ def create(
         narration_preset=resolved.narration_preset or narration_preset,
     )
     controller = InteractiveCLIController() if retry else None
+
+    # EP9: Store pause-at request in context metadata
+    if pause_at:
+        ctx.metadata["pause_at"] = pause_at
+
     try:
         ctx = run_pipeline(ctx, controller=controller)
     except Exception as e:
+        # EP9: PipelinePaused — state saved, inform user how to resume
+        from .pipeline.errors import PipelinePaused
+        if isinstance(e, PipelinePaused):
+            typer.echo(
+                f"\n⏸ Pipeline paused after '{e.completed_step}'. "
+                f"Resume with: mn resume --state \"{Path(ctx.output_dir) / 'pipeline_state.json'}\""
+            )
+            raise typer.Exit(code=0)
         # PreflightError gets a targeted remediation hint.
         from .pipeline.preflight import PreflightError
         if isinstance(e, PreflightError):
@@ -222,6 +240,69 @@ def create(
             err=True,
         )
     typer.echo(f"{ctx.video_path}")
+
+
+@app.command()
+def resume(
+    state: str = typer.Option(..., "--state", help="pipeline_state.json 路径 / Path to pipeline state file"),
+    retry: bool = typer.Option(False, "--retry", help="硬步骤失败时交互重试 / Enable interactive retry on hard step failure"),
+):
+    """恢复暂停的管线 (EP9) — 从上次暂停点继续执行.
+
+    \b
+    用法 / Usage:
+        mn resume --state output/movie/pipeline_state.json
+    """
+    from .pipeline.runner import _load_pipeline_state, _next_step_after, run_pipeline
+    from .pipeline.errors import PipelinePaused
+    from .pipeline.preflight import PreflightError
+    from .utils.console import build_console
+
+    state_path = Path(state)
+    if not state_path.is_file():
+        typer.echo(f"State file not found: {state}", err=True)
+        raise typer.Exit(code=1)
+
+    ctx, completed_step = _load_pipeline_state(state_path)
+
+    # Re-inject a real console (serialized state has SilentConsole)
+    from .models import Services
+    ctx.services = Services(console=build_console(Path(ctx.output_dir)))
+
+    # Determine the step to start from (the step AFTER the completed one)
+    start_step = _next_step_after(completed_step)
+    if start_step is None:
+        typer.echo(
+            f"Pipeline already completed (last step: {completed_step}). "
+            f"Nothing to resume."
+        )
+        raise typer.Exit(code=0)
+
+    console = ctx.services.console
+    console.debug(f"Resuming from step '{start_step}' (completed: {completed_step})")
+
+    controller = InteractiveCLIController() if retry else None
+    try:
+        ctx = run_pipeline(ctx, controller=controller, start_step=start_step)
+    except Exception as e:
+        if isinstance(e, PipelinePaused):
+            typer.echo(
+                f"\n⏸ Pipeline paused after '{e.completed_step}'. "
+                f"Resume with: mn resume --state \"{Path(ctx.output_dir) / 'pipeline_state.json'}\""
+            )
+            raise typer.Exit(code=0)
+        if isinstance(e, PreflightError):
+            typer.echo(str(e), err=True)
+            raise typer.Exit(code=1)
+        raise typer.Exit(code=1)
+
+    if ctx.metadata.get("script_degraded"):
+        typer.echo(
+            "⚠ 警告：旁白为占位内容——LLM 不可达。请检查 LLM 连接后重试。",
+            err=True,
+        )
+    if ctx.video_path:
+        typer.echo(f"{ctx.video_path}")
 
 
 @app.command()

--- a/src/movie_narrator/pipeline/errors.py
+++ b/src/movie_narrator/pipeline/errors.py
@@ -43,6 +43,26 @@ class PipelineCancelled(RuntimeError):
     """
 
 
+class PipelinePaused(RuntimeError):
+    """Pipeline paused at a step boundary for human-in-the-loop (EP9).
+
+    Raised by ``run_pipeline`` when ``ctx.metadata["pause_at"]`` matches
+    the step that just completed. The pipeline state is serialized to
+    ``pipeline_state.json`` in the output directory before raising.
+
+    Callers **must** catch this before bare ``except Exception``.
+    ``mn resume`` deserializes the state and re-enters ``run_pipeline``
+    starting from the next step.
+
+    Attributes:
+        completed_step: name of the step that just finished.
+    """
+
+    def __init__(self, completed_step: str):
+        self.completed_step = completed_step
+        super().__init__(f"pipeline paused after step: {completed_step}")
+
+
 class RunController(Protocol):
     """Protocol for cooperative pipeline cancellation.
 

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -829,6 +829,37 @@ def _match_clips_impl(
 
             scene_captions = _build_scene_captions(scenes, transcript)
 
+            # ── EP8: Vision captioner integration ───────────────
+            # When vision_captioner is configured, use visual scene
+            # descriptions to supplement or replace audio-transcript
+            # captions. The stub returns the same placeholder format
+            # as _build_scene_label (is_fake=True), so behavior is
+            # unchanged. Real providers (BLIP, LLaVA) will produce
+            # semantic descriptions (is_fake=False) that unlock
+            # embedding re-rank even without WhisperX transcripts.
+            vision_provider = ctx.metadata.get("vision_captioner", "none")
+            if vision_provider != "none":
+                try:
+                    from ..vision import get_vision_captioner
+                    captioner = get_vision_captioner(vision_provider)
+                    vision_labels = captioner.caption_scenes(
+                        scenes, ctx.source_video_path
+                    )
+                    is_stub = vision_provider == "stub"
+                    scene_captions = [
+                        (label, is_stub) for label in vision_labels
+                    ]
+                    ctx.services.console.debug(
+                        f"  EP8 vision captioner ({vision_provider}): "
+                        f"{len(scene_captions)} captions, "
+                        f"{'stub placeholders' if is_stub else 'real descriptions'}"
+                    )
+                except Exception as ve:
+                    ctx.services.console.debug(
+                        f"  EP8 vision captioner failed ({ve}); "
+                        f"using audio-transcript captions"
+                    )
+
             # ── MS-02: Truth in match (Q-M1) ──────────────
             # Detect fake captions (placeholder labels without real transcript).
             # If too many scenes have fake captions, embedding re-rank is

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -10,7 +10,7 @@ from ..utils.environment import collect_environment
 from .align import align_audio
 from .assets import prepare_assets
 from .bgm import mix_bgm
-from .errors import PipelineCancelled, PipelineStrictError, RunController, StepAction, check_cancelled
+from .errors import PipelineCancelled, PipelinePaused, PipelineStrictError, RunController, StepAction, check_cancelled
 from .export_clips import export_clips
 from .match import match_clips
 from .preflight import PreflightError, run_preflight
@@ -40,7 +40,8 @@ PARAM_WHITELIST: frozenset[str] = frozenset({
     "match_timeline_mode", "match_act_weights",
     "match_topk", "match_topk_reuse_penalty",
     "embedding_model_name",
-    "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
+    "vision_captioner",  # EP8: "none" (default) | "stub" | future providers
+    "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs", "bgm_loudnorm",
     "tts_pause_ms",
     "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
     "translate_source_lang", "translate_provider", "translate_retries",
@@ -293,10 +294,55 @@ def build_context(
 # ── Pipeline execution ─────────────────────────────────────
 
 
+def _save_pipeline_state(ctx: Context, completed_step: str) -> Path:
+    """Serialize pipeline state for resume (EP9).
+
+    Writes ``pipeline_state.json`` to ``ctx.output_dir``. Excludes the
+    non-serializable ``services`` field — the ``Context`` model_validator
+    auto-injects ``SilentConsole`` on load.
+
+    Returns the path to the saved state file.
+    """
+    import json
+    state = {
+        "completed_step": completed_step,
+        "context": ctx.model_dump(mode="json", exclude={"services"}),
+    }
+    state_path = Path(ctx.output_dir) / "pipeline_state.json"
+    state_path.write_text(
+        json.dumps(state, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return state_path
+
+
+def _load_pipeline_state(state_path: Path) -> tuple[Context, str]:
+    """Load pipeline state from a file (EP9).
+
+    Returns ``(context, completed_step)``. The context's ``services``
+    field is auto-filled with ``SilentConsole`` by the model_validator —
+    callers should assign a real console if interactive output is needed.
+    """
+    import json
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    completed_step = data["completed_step"]
+    ctx = Context(**data["context"])
+    return ctx, completed_step
+
+
+def _next_step_after(completed_step: str) -> Optional[str]:
+    """Return the name of the step after *completed_step*, or None if last."""
+    for i, step in enumerate(STEPS):
+        if step.__name__ == completed_step and i + 1 < len(STEPS):
+            return STEPS[i + 1].__name__
+    return None
+
+
 def run_pipeline(
     ctx: Context,
     *,
     controller: Optional[RunController] = None,
+    start_step: Optional[str] = None,
 ) -> Context:
     """Execute the 15-step pipeline against *ctx*.
 
@@ -304,10 +350,17 @@ def run_pipeline(
     passes a ``GradioController`` so the user can request a cooperative
     cancel at step boundaries.
 
+    ``start_step`` (EP9): when set, skip all steps before this step name.
+    Used by ``mn resume`` to avoid re-running already-completed steps.
+
     ``PipelineCancelled`` raises before ``_check_strict``, so ``--strict``
     never trips on cancellation. Cancel is a distinct terminal path —
     it is NOT a soft-step warning and does NOT set status fields to
     ``failed``.
+
+    ``PipelinePaused`` (EP9) raises after a step completes when
+    ``ctx.metadata["pause_at"]`` matches the step name. The pipeline
+    state is serialized before raising so ``mn resume`` can continue.
     """
     console = ctx.services.console
     workflow_steps: Optional[Dict[str, bool]] = ctx.metadata.get("workflow_steps")
@@ -321,8 +374,18 @@ def run_pipeline(
 
     total_start = time.time()
 
+    # EP9: When resuming, skip steps before start_step
+    _resume_started = start_step is None
+
     for step in STEPS:
         name = step.__name__
+
+        # EP9: Skip already-completed steps when resuming
+        if not _resume_started:
+            if name == start_step:
+                _resume_started = True
+            else:
+                continue
 
         check_cancelled(controller)
 
@@ -419,6 +482,19 @@ def run_pipeline(
         # ── Render step result ───────────────────────────────
         _render_step_result(ctx, name, elapsed, console)
         _check_strict(ctx, name)
+
+        # ── EP9: Pause-at check ─────────────────────────────
+        # If the user requested a pause after this step, serialize state
+        # and raise PipelinePaused so the CLI can inform the user.
+        pause_at = ctx.metadata.get("pause_at")
+        if pause_at and pause_at == name:
+            state_path = _save_pipeline_state(ctx, name)
+            console.inline_warn(
+                f"Pipeline paused after '{name}'. "
+                f"State saved to {state_path.name}. "
+                f"Resume with: mn resume --state \"{state_path}\""
+            )
+            raise PipelinePaused(name)
 
         # ── Reset step_state for next iteration ──────────────
         ctx.step_state = StepState()

--- a/src/movie_narrator/vision/__init__.py
+++ b/src/movie_narrator/vision/__init__.py
@@ -1,0 +1,17 @@
+"""Vision captioning abstraction layer (EP8).
+
+Public API:
+    from movie_narrator.vision import (
+        VisionCaptioner, StubVisionCaptioner, get_vision_captioner,
+    )
+"""
+
+from .factory import get_vision_captioner
+from .protocol import VisionCaptioner
+from .stub import StubVisionCaptioner
+
+__all__ = [
+    "StubVisionCaptioner",
+    "VisionCaptioner",
+    "get_vision_captioner",
+]

--- a/src/movie_narrator/vision/factory.py
+++ b/src/movie_narrator/vision/factory.py
@@ -1,0 +1,40 @@
+"""Factory: settings → VisionCaptioner instance (EP8).
+
+Currently only returns the StubVisionCaptioner. When real vision
+providers (BLIP, LLaVA, etc.) are implemented, they will be
+dispatched here based on settings/configuration.
+"""
+
+from .protocol import VisionCaptioner
+from .stub import StubVisionCaptioner
+
+
+def get_vision_captioner(
+    provider: str = "stub",
+    **kwargs,
+) -> VisionCaptioner:
+    """Return a VisionCaptioner instance.
+
+    Args:
+        provider: "stub" (default) — returns StubVisionCaptioner.
+            Future: "blip", "llava", etc.
+        **kwargs: provider-specific configuration.
+
+    Returns:
+        A VisionCaptioner instance.
+
+    Raises:
+        ValueError: when the provider is unknown.
+    """
+    if provider == "stub":
+        return StubVisionCaptioner()
+
+    # Future providers will be dispatched here:
+    # elif provider == "blip":
+    #     from .blip import BlipVisionCaptioner
+    #     return BlipVisionCaptioner(**kwargs)
+
+    raise ValueError(
+        f"Unsupported vision captioner provider: {provider!r}. "
+        f"Supported: ['stub']"
+    )

--- a/src/movie_narrator/vision/protocol.py
+++ b/src/movie_narrator/vision/protocol.py
@@ -1,0 +1,54 @@
+"""VisionCaptioner abstract interface (EP8).
+
+Defines the contract for visual scene captioning — producing a
+short text description of each scene from video frames, which
+feeds the embedding re-rank in match.py for improved D2 (scene-
+dialogue relevance).
+
+The current implementation (StubVisionCaptioner) returns placeholder
+labels. Future providers (e.g. BLIP, LLaVA) will subclass this
+interface and produce real visual descriptions.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from ..models import Scene
+
+
+class VisionCaptioner(ABC):
+    """Abstract visual scene captioner.
+
+    Concrete providers implement :meth:`caption_scenes` to produce
+    a text label per scene from the video's visual frames.
+
+    The labels feed the embedding re-rank in match.py, replacing
+    or supplementing audio-transcript-based captions. When vision
+    captions are available and high-quality, the fake-caption guard
+    (>70% placeholders) is bypassed, unlocking embedding re-rank.
+    """
+
+    @abstractmethod
+    def caption_scenes(
+        self,
+        scenes: List[Scene],
+        video_path: Optional[str] = None,
+    ) -> List[str]:
+        """Generate a text caption for each scene.
+
+        Args:
+            scenes: list of Scene objects (with .start, .end, .index).
+            video_path: path to the source video file. May be None
+                when no source video is available (stub returns
+                placeholders; real providers should raise).
+
+        Returns:
+            List of caption strings, one per scene, aligned 1:1 with
+            the input ``scenes`` list. Each caption should be a concise
+            visual description suitable for sentence-transformer
+            embedding (e.g. "a man in a red jacket runs through rain").
+
+        Raises:
+            Any IO or model exception. Callers handle via fallback
+            to audio-transcript-based captions.
+        """

--- a/src/movie_narrator/vision/stub.py
+++ b/src/movie_narrator/vision/stub.py
@@ -1,0 +1,32 @@
+"""StubVisionCaptioner — placeholder captions for CI and dev (EP8).
+
+Returns deterministic placeholder labels so the embedding re-rank
+path stays exercisable without a real vision model. Directly
+analogous to BaseTTSProvider._silent_synthesize for CI.
+"""
+
+from typing import List, Optional
+
+from ..models import Scene
+from .protocol import VisionCaptioner
+
+
+class StubVisionCaptioner(VisionCaptioner):
+    """Returns placeholder scene labels without any ML model.
+
+    Labels follow the same format as match._build_scene_label:
+    ``"scene {index} from {start}s to {end}s"``. This ensures
+    backward compatibility — the fake-caption guard in match.py
+    will detect these as placeholders and fall back to heuristic
+    matching, exactly as before EP8 integration.
+    """
+
+    def caption_scenes(
+        self,
+        scenes: List[Scene],
+        video_path: Optional[str] = None,
+    ) -> List[str]:
+        return [
+            f"scene {s.index} from {s.start:.1f}s to {s.end:.1f}s"
+            for s in scenes
+        ]

--- a/tests/test_pipeline_pause.py
+++ b/tests/test_pipeline_pause.py
@@ -1,0 +1,381 @@
+"""Tests for EP9 pipeline pause/resume functionality.
+
+Verifies:
+- PipelinePaused exception carries completed_step attribute
+- _save_pipeline_state writes a valid JSON state file
+- _load_pipeline_state reconstructs Context from the saved state
+- _next_step_after returns the correct next step name
+- run_pipeline with start_step skips already-completed steps
+- run_pipeline raises PipelinePaused when pause_at matches a step
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from movie_narrator.models import Context, Services
+from movie_narrator.pipeline.errors import PipelinePaused
+from movie_narrator.pipeline.runner import (
+    STEPS,
+    _load_pipeline_state,
+    _next_step_after,
+    _save_pipeline_state,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────
+
+
+def _make_ctx(tmp_path: Path) -> Context:
+    """Build a minimal Context for testing."""
+    return Context(
+        movie_name="test-movie",
+        style="热血搞笑",
+        duration=60,
+        output_dir=str(tmp_path),
+        services=Services(console=MagicMock()),
+    )
+
+
+# ── PipelinePaused exception ───────────────────────────────
+
+
+class TestPipelinePaused:
+    def test_is_runtime_error(self):
+        """PipelinePaused is a RuntimeError subclass."""
+        err = PipelinePaused("match_clips")
+        assert isinstance(err, RuntimeError)
+
+    def test_completed_step_attribute(self):
+        """completed_step is accessible on the exception."""
+        err = PipelinePaused("generate_script")
+        assert err.completed_step == "generate_script"
+
+    def test_message_contains_step_name(self):
+        """Exception message includes the step name."""
+        err = PipelinePaused("match_clips")
+        assert "match_clips" in str(err)
+
+
+# ── _next_step_after ───────────────────────────────────────
+
+
+class TestNextStepAfter:
+    def test_returns_next_step_for_first_step(self):
+        """First step (resolve_video) → next is prepare_assets."""
+        result = _next_step_after("resolve_video")
+        assert result == "prepare_assets"
+
+    def test_returns_next_step_for_middle_step(self):
+        """Middle step → correct next step."""
+        result = _next_step_after("generate_script")
+        assert result == "export_script_md"
+
+    def test_returns_none_for_last_step(self):
+        """Last step → None (no step after)."""
+        last_step_name = STEPS[-1].__name__
+        result = _next_step_after(last_step_name)
+        assert result is None
+
+    def test_returns_none_for_unknown_step(self):
+        """Unknown step name → None."""
+        result = _next_step_after("nonexistent_step")
+        assert result is None
+
+    def test_all_steps_have_valid_next_except_last(self):
+        """Every step except the last has a valid next step."""
+        for i, step in enumerate(STEPS[:-1]):
+            next_name = _next_step_after(step.__name__)
+            assert next_name == STEPS[i + 1].__name__
+
+
+# ── _save_pipeline_state ───────────────────────────────────
+
+
+class TestSavePipelineState:
+    def test_creates_state_file(self, tmp_path: Path):
+        """State file is created at output_dir/pipeline_state.json."""
+        ctx = _make_ctx(tmp_path)
+        state_path = _save_pipeline_state(ctx, "match_clips")
+        assert state_path.exists()
+        assert state_path.name == "pipeline_state.json"
+        assert state_path.parent == tmp_path
+
+    def test_state_file_contains_completed_step(self, tmp_path: Path):
+        """State JSON contains the completed_step field."""
+        ctx = _make_ctx(tmp_path)
+        _save_pipeline_state(ctx, "generate_script")
+        data = json.loads(
+            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
+        )
+        assert data["completed_step"] == "generate_script"
+
+    def test_state_file_contains_context(self, tmp_path: Path):
+        """State JSON contains a context field with movie_name."""
+        ctx = _make_ctx(tmp_path)
+        _save_pipeline_state(ctx, "match_clips")
+        data = json.loads(
+            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
+        )
+        assert "context" in data
+        assert data["context"]["movie_name"] == "test-movie"
+
+    def test_state_excludes_services(self, tmp_path: Path):
+        """Services field is excluded from serialization (non-serializable)."""
+        ctx = _make_ctx(tmp_path)
+        _save_pipeline_state(ctx, "match_clips")
+        data = json.loads(
+            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
+        )
+        # services should not be in the serialized context
+        assert "services" not in data["context"]
+
+    def test_preserves_metadata(self, tmp_path: Path):
+        """Context metadata survives serialization round-trip."""
+        ctx = _make_ctx(tmp_path)
+        ctx.metadata["pause_at"] = "render_video"
+        ctx.metadata["custom_key"] = "custom_value"
+        _save_pipeline_state(ctx, "match_clips")
+        data = json.loads(
+            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
+        )
+        assert data["context"]["metadata"]["pause_at"] == "render_video"
+        assert data["context"]["metadata"]["custom_key"] == "custom_value"
+
+
+# ── _load_pipeline_state ───────────────────────────────────
+
+
+class TestLoadPipelineState:
+    def test_loads_completed_step(self, tmp_path: Path):
+        """Loading returns the correct completed_step."""
+        ctx = _make_ctx(tmp_path)
+        _save_pipeline_state(ctx, "generate_voice")
+        state_path = tmp_path / "pipeline_state.json"
+        loaded_ctx, step = _load_pipeline_state(state_path)
+        assert step == "generate_voice"
+
+    def test_loads_context_movie_name(self, tmp_path: Path):
+        """Loaded context preserves movie_name."""
+        ctx = _make_ctx(tmp_path)
+        _save_pipeline_state(ctx, "match_clips")
+        state_path = tmp_path / "pipeline_state.json"
+        loaded_ctx, _ = _load_pipeline_state(state_path)
+        assert loaded_ctx.movie_name == "test-movie"
+
+    def test_loaded_context_has_services(self, tmp_path: Path):
+        """Loaded context auto-injects SilentConsole via model_validator."""
+        ctx = _make_ctx(tmp_path)
+        _save_pipeline_state(ctx, "match_clips")
+        state_path = tmp_path / "pipeline_state.json"
+        loaded_ctx, _ = _load_pipeline_state(state_path)
+        # services should exist (auto-filled by model_validator)
+        assert loaded_ctx.services is not None
+
+    def test_round_trip_preserves_metadata(self, tmp_path: Path):
+        """Metadata survives save → load round-trip."""
+        ctx = _make_ctx(tmp_path)
+        ctx.metadata["test_key"] = "test_value"
+        _save_pipeline_state(ctx, "match_clips")
+        state_path = tmp_path / "pipeline_state.json"
+        loaded_ctx, _ = _load_pipeline_state(state_path)
+        assert loaded_ctx.metadata.get("test_key") == "test_value"
+
+    def test_nonexistent_file_raises(self, tmp_path: Path):
+        """Loading a non-existent file raises an error."""
+        with pytest.raises((FileNotFoundError, json.JSONDecodeError)):
+            _load_pipeline_state(tmp_path / "nonexistent.json")
+
+
+# ── run_pipeline with start_step (EP9 resume) ──────────────
+
+
+class TestRunPipelineStartStep:
+    def test_start_step_skips_preceding_steps(self, tmp_path: Path, monkeypatch):
+        """When start_step is set, steps before it are skipped."""
+        ctx = _make_ctx(tmp_path)
+        ctx.metadata["research_enabled"] = False
+
+        # Track which steps actually run
+        executed: list[str] = []
+        original_steps = list(STEPS)
+
+        # Patch each step to record execution and return ctx
+        for step in original_steps:
+            def make_wrapper(s):
+                def wrapper(c):
+                    executed.append(s.__name__)
+                    return c
+                wrapper.__name__ = s.__name__
+                return wrapper
+
+        # We need to patch STEPS in the runner module
+        import movie_narrator.pipeline.runner as runner_mod
+
+        patched_steps = []
+        for step in original_steps:
+            name = step.__name__
+            def make_mock(n):
+                def mock_step(c):
+                    executed.append(n)
+                    return c
+                mock_step.__name__ = n
+                return mock_step
+            patched_steps.append(make_mock(name))
+
+        monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
+
+        # Mock preflight to pass
+        monkeypatch.setattr(runner_mod, "run_preflight", lambda ctx: None)
+
+        # Start from generate_voice (skip resolve, prepare, research, script, export_script_md)
+        runner_mod.run_pipeline(ctx, start_step="generate_voice")
+
+        # Steps before generate_voice should NOT be in executed
+        assert "resolve_video" not in executed
+        assert "prepare_assets" not in executed
+        assert "research_plot" not in executed
+        assert "generate_script" not in executed
+        assert "export_script_md" not in executed
+        # generate_voice and later should be in executed
+        assert "generate_voice" in executed
+
+    def test_start_step_none_runs_all_steps(self, tmp_path: Path, monkeypatch):
+        """When start_step is None (normal run), all steps run."""
+        ctx = _make_ctx(tmp_path)
+
+        executed: list[str] = []
+        import movie_narrator.pipeline.runner as runner_mod
+
+        original_steps = list(runner_mod.STEPS)
+        patched_steps = []
+        for step in original_steps:
+            name = step.__name__
+            def make_mock(n):
+                def mock_step(c):
+                    executed.append(n)
+                    return c
+                mock_step.__name__ = n
+                return mock_step
+            patched_steps.append(make_mock(name))
+
+        monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
+        monkeypatch.setattr(runner_mod, "run_preflight", lambda ctx: None)
+
+        runner_mod.run_pipeline(ctx, start_step=None)
+        assert "resolve_video" in executed
+        assert executed[0] == "resolve_video"
+
+
+# ── run_pipeline with pause_at ─────────────────────────────
+
+
+class TestRunPipelinePauseAt:
+    def test_pause_at_raises_pipeline_paused(self, tmp_path: Path, monkeypatch):
+        """When pause_at matches a step, PipelinePaused is raised."""
+        ctx = _make_ctx(tmp_path)
+        ctx.metadata["pause_at"] = "resolve_video"
+
+        import movie_narrator.pipeline.runner as runner_mod
+
+        # Mock all steps to be no-ops
+        original_steps = list(runner_mod.STEPS)
+        patched_steps = []
+        for step in original_steps:
+            name = step.__name__
+            def make_mock(n):
+                def mock_step(c):
+                    return c
+                mock_step.__name__ = n
+                return mock_step
+            patched_steps.append(make_mock(name))
+
+        monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
+        monkeypatch.setattr(runner_mod, "run_preflight", lambda ctx: None)
+
+        with pytest.raises(PipelinePaused) as exc_info:
+            runner_mod.run_pipeline(ctx)
+
+        assert exc_info.value.completed_step == "resolve_video"
+
+    def test_pause_at_creates_state_file(self, tmp_path: Path, monkeypatch):
+        """PipelinePaused saves pipeline_state.json before raising."""
+        ctx = _make_ctx(tmp_path)
+        ctx.metadata["pause_at"] = "resolve_video"
+
+        import movie_narrator.pipeline.runner as runner_mod
+
+        original_steps = list(runner_mod.STEPS)
+        patched_steps = []
+        for step in original_steps:
+            name = step.__name__
+            def make_mock(n):
+                def mock_step(c):
+                    return c
+                mock_step.__name__ = n
+                return mock_step
+            patched_steps.append(make_mock(name))
+
+        monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
+        monkeypatch.setattr(runner_mod, "run_preflight", lambda ctx: None)
+
+        with pytest.raises(PipelinePaused):
+            runner_mod.run_pipeline(ctx)
+
+        state_file = tmp_path / "pipeline_state.json"
+        assert state_file.exists()
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+        assert data["completed_step"] == "resolve_video"
+
+    def test_pause_at_none_completes_pipeline(self, tmp_path: Path, monkeypatch):
+        """Without pause_at, the pipeline runs to completion normally."""
+        ctx = _make_ctx(tmp_path)
+
+        import movie_narrator.pipeline.runner as runner_mod
+
+        original_steps = list(runner_mod.STEPS)
+        patched_steps = []
+        for step in original_steps:
+            name = step.__name__
+            def make_mock(n):
+                def mock_step(c):
+                    return c
+                mock_step.__name__ = n
+                return mock_step
+            patched_steps.append(make_mock(name))
+
+        monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
+        monkeypatch.setattr(runner_mod, "run_preflight", lambda ctx: None)
+
+        # Should NOT raise
+        result = runner_mod.run_pipeline(ctx)
+        assert result is not None
+
+    def test_pause_at_not_matching_completes_pipeline(self, tmp_path: Path, monkeypatch):
+        """When pause_at doesn't match any step name, pipeline completes."""
+        ctx = _make_ctx(tmp_path)
+        ctx.metadata["pause_at"] = "nonexistent_step"
+
+        import movie_narrator.pipeline.runner as runner_mod
+
+        original_steps = list(runner_mod.STEPS)
+        patched_steps = []
+        for step in original_steps:
+            name = step.__name__
+            def make_mock(n):
+                def mock_step(c):
+                    return c
+                mock_step.__name__ = n
+                return mock_step
+            patched_steps.append(make_mock(name))
+
+        monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
+        monkeypatch.setattr(runner_mod, "run_preflight", lambda ctx: None)
+
+        # Should NOT raise — pause_at never matches
+        result = runner_mod.run_pipeline(ctx)
+        assert result is not None

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,150 @@
+"""Tests for EP8 VisionCaptioner abstraction.
+
+Verifies the protocol contract, stub implementation, factory dispatch,
+and integration behavior (stub labels are flagged as fake for the
+match pipeline's fake-caption guard).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from movie_narrator.models import Scene
+from movie_narrator.vision import (
+    StubVisionCaptioner,
+    VisionCaptioner,
+    get_vision_captioner,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────
+
+
+def _scenes() -> list[Scene]:
+    return [
+        Scene(index=0, start=0.0, end=5.0),
+        Scene(index=1, start=5.0, end=10.0),
+        Scene(index=2, start=10.0, end=15.0),
+    ]
+
+
+# ── Protocol / ABC contract ────────────────────────────────
+
+
+def test_vision_captioner_is_abstract():
+    """VisionCaptioner is an ABC — cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        VisionCaptioner()
+
+
+def test_subclass_must_implement_caption_scenes():
+    """Subclass without caption_scenes raises TypeError on instantiation."""
+
+    class Incomplete(VisionCaptioner):
+        pass
+
+    with pytest.raises(TypeError):
+        Incomplete()
+
+
+# ── StubVisionCaptioner ────────────────────────────────────
+
+
+class TestStubVisionCaptioner:
+    def test_returns_one_caption_per_scene(self):
+        """Output list length matches input scenes length."""
+        captioner = StubVisionCaptioner()
+        scenes = _scenes()
+        captions = captioner.caption_scenes(scenes)
+        assert len(captions) == len(scenes)
+
+    def test_caption_format_matches_scene_label(self):
+        """Stub labels follow the 'scene {i} from {s}s to {e}s' format."""
+        captioner = StubVisionCaptioner()
+        scenes = _scenes()
+        captions = captioner.caption_scenes(scenes)
+        assert captions[0] == "scene 0 from 0.0s to 5.0s"
+        assert captions[1] == "scene 1 from 5.0s to 10.0s"
+        assert captions[2] == "scene 2 from 10.0s to 15.0s"
+
+    def test_works_without_video_path(self):
+        """Stub does not require a video_path — video_path=None is fine."""
+        captioner = StubVisionCaptioner()
+        captions = captioner.caption_scenes(_scenes(), video_path=None)
+        assert len(captions) == 3
+
+    def test_empty_scenes_returns_empty_list(self):
+        """No scenes → no captions."""
+        captioner = StubVisionCaptioner()
+        assert captioner.caption_scenes([]) == []
+
+    def test_is_subclass_of_vision_captioner(self):
+        """StubVisionCaptioner is a proper subclass of VisionCaptioner."""
+        assert issubclass(StubVisionCaptioner, VisionCaptioner)
+        captioner = StubVisionCaptioner()
+        assert isinstance(captioner, VisionCaptioner)
+
+
+# ── Factory ────────────────────────────────────────────────
+
+
+class TestGetVisionCaptioner:
+    def test_stub_provider_returns_stub(self):
+        """get_vision_captioner('stub') returns StubVisionCaptioner."""
+        captioner = get_vision_captioner("stub")
+        assert isinstance(captioner, StubVisionCaptioner)
+
+    def test_default_provider_is_stub(self):
+        """Default provider is 'stub'."""
+        captioner = get_vision_captioner()
+        assert isinstance(captioner, StubVisionCaptioner)
+
+    def test_none_provider_raises_value_error(self):
+        """'none' is not a valid provider — raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported vision captioner"):
+            get_vision_captioner("none")
+
+    def test_unknown_provider_raises_value_error(self):
+        """Unknown provider raises ValueError with helpful message."""
+        with pytest.raises(ValueError, match="Unsupported vision captioner"):
+            get_vision_captioner("blip")
+
+    def test_unknown_provider_message_lists_supported(self):
+        """Error message mentions 'stub' as supported."""
+        with pytest.raises(ValueError, match="stub"):
+            get_vision_captioner("invalid_provider")
+
+    def test_accepts_kwargs(self):
+        """Factory passes kwargs through without error (future providers)."""
+        captioner = get_vision_captioner("stub", model_name="test", device="cpu")
+        assert isinstance(captioner, StubVisionCaptioner)
+
+
+# ── Integration: stub labels are detectable as placeholders ─
+
+
+def test_stub_labels_match_placeholder_pattern():
+    """Stub labels follow the same format as match._build_scene_label.
+
+    This ensures the fake-caption guard in match.py correctly detects
+    stub labels as placeholders (>70% fake → force heuristic match),
+    so EP8 stub integration does not change existing behavior.
+    """
+    captioner = StubVisionCaptioner()
+    scenes = _scenes()
+    captions = captioner.caption_scenes(scenes)
+
+    # Every stub label starts with "scene " — same as _build_scene_label
+    for cap in captions:
+        assert cap.startswith("scene ")
+        assert "from" in cap
+        assert "to" in cap
+
+
+def test_stub_captions_are_deterministic():
+    """Same scenes always produce same captions (no randomness)."""
+    captioner = StubVisionCaptioner()
+    scenes = _scenes()
+    first = captioner.caption_scenes(scenes)
+    second = captioner.caption_scenes(scenes)
+    assert first == second


### PR DESCRIPTION
## Optional EP8 + EP9

### EP8 — Vision Captioner (optional, route C trigger)
- New `vision/` module: `protocol.py` (abstract interface), `stub.py` (no-op), `factory.py` (provider selector)
- `match.py` integrates vision captions when `vision_captioner` param is set (default: "none")
- Label priority: vision_caption > whisper dialogue > heuristic
- No external dependencies required (stub is default)

### EP9 — Pause/Resume Pipeline (optional, human-in-loop)
- `PipelinePaused` exception in `errors.py`
- `--pause-at` CLI option to pause after a specified step
- `mn resume --state` command to resume from saved state
- State serialized to `pipeline_state.json` in output dir
- Runner supports `start_from_step` for resumption

### Files changed (10 files, +884/-2)
**New files (6):**
- `vision/__init__.py`, `vision/protocol.py`, `vision/stub.py`, `vision/factory.py`
- `tests/test_vision.py` (15 tests)
- `tests/test_pipeline_pause.py` (24 tests)

**Modified files (4):**
- `pipeline/errors.py` — PipelinePaused exception
- `pipeline/runner.py` — pause/resume logic + PARAM_WHITELIST sync
- `pipeline/match.py` — EP8 vision caption integration
- `cli.py` — pause-at option + mn resume command

### Merge conflict resolved
- `runner.py` PARAM_WHITELIST: kept both `vision_captioner` (EP8) and `bgm_loudnorm` (EP6 from PR #84)
- `cli.py` and `match.py` auto-merged cleanly (E.5 summary + EP9 pause + EP2 beats + EP8 vision all present)

### Tests
- 566 passed, 23 skipped (local) — 39 new tests included
- All existing tests still pass
