### PR TITLE
feat(l2+): L2+ hand-test checklist + comparison script + SOP

### DIFF
--- a/docs/checklists/L2_HANDTEST_PLUS.md
+++ b/docs/checklists/L2_HANDTEST_PLUS.md
@@ -1,0 +1,218 @@
+# L2+ Hand-Test Checklist — Effect Portfolio Verification (EP2/EP4/EP5/EP6)
+
+> **目的**: 验证 v0.4.26 引入的 EP2(Beat 时间锚) / EP4(钩子模板) / EP5(标题卡) / EP6(duck 曲线+loudnorm)
+> 在 G1/G2 样片上的**观感提升**是否达到 QUALITY_UPLIFT_METHODS §6.2 的 E1/E2/E3 加分项标准。
+>
+> **与 L2 的关系**: 本 checklist 是 L2_HANDTEST.md 的**超集**——L2 客观/主观项仍需全绿，
+> 额外增加 EP 专属客观门禁（O11–O14）和主观加分项（E1–E5）。
+>
+> **退出要求**: G1+G2 各跑 1 轮，L2 基础项全绿 + EP 专属项全绿 + E1–E5 ≥ 2 项 ≥ 2 分。
+>
+> 每轮手测复制此文件为 `L2_HANDTEST_PLUS_YYYYMMDD.md` 并填写。
+
+---
+
+## 跑片身份栏（每轮必填）
+
+```text
+日期:
+操作者:
+git SHA / 版本:       (必须 ≥ v0.4.26，含 EP2/EP4/EP5/EP6)
+Python:               (建议 3.11/3.12/3.13 + [media]+[ml])
+OS:
+ffmpeg:
+样片 ID:              (G1 / G2)
+命令:                 (完整一行，可复制)
+preset:               (建议 douyin-fast 以激活全部 EP 参数)
+duration:             (建议 60s 以接近生产默认)
+源片路径:
+BGM 路径:
+LLM 模型:
+TTS provider/voice:
+有 [media]?  Y/N
+有 [ml]?     Y/N
+
+# 基线对照（v0.4.25 或更早，无 EP 特性的跑片结果）
+基线 SHA:
+基线跑片目录:
+基线 final.mp4 路径:
+基线 metadata.json 路径:
+```
+
+---
+
+## L2 基础客观门禁（沿用 L2_HANDTEST.md，须全绿）
+
+| # | 项 | 通过标准 | 实际 | Pass? |
+|---|----|----------|------|-------|
+| O1 | `final.mp4` 存在且可播 | 播放器打开无报错；有 moov | | |
+| O2 | 成片 QA | 管线未因 QA 中止；`final.mp4` 可播 | | |
+| O3 | 音轨 | 有音轨；非全程静音 | | |
+| O4 | 时长 | ffprobe 看成片时长 ≈ 末句 `end` | | |
+| O5 | 字幕文件 | `subtitle.srt` 存在；条数 ≈ 句数 | | |
+| O6 | 脚本 | `script.md` 句数 = `script_target_count` | | |
+| O7 | Match 状态 | `metadata.status.match` = `success` | | |
+| O8 | BGM 状态 | `status.bgm` = `success` | | |
+| O9 | Match 诊断 | `match_summary` 存在 | | |
+| O10 | 非全 heuristic | `heuristic_ratio ≤ 0.5` 或已记录环境豁免 | | |
+
+---
+
+## EP 专属客观门禁（L2+ 新增）
+
+### O11 — EP2 Beat 时间锚
+
+| 检查项 | 通过标准 | 实际 | Pass? |
+|--------|----------|------|-------|
+| `beats_meta` 存在 | `metadata.json` 或 `ctx.metadata` 含 `beats_meta` 数组 | | |
+| `beats_meta` 长度 | = 旁白段数（`match_summary.segments`） | | |
+| `approx_ratio` 覆盖率 | `match_summary.beat_anchored_count / segments ≥ 0.5` | | |
+| `beat_anchor` 标志 | `match_summary.beat_anchor = true` | | |
+| src_mid 分布 | 对比基线：src_mid 不再均匀铺满全片（E1 退场条件） | | |
+
+**判读方法**: 用 `scripts/compare_runs.py --focus beat_anchor` 输出 src_mid 分位直方图对比。
+若新版 src_mid 集中在 LLM 估计的高光区（而非线性 0→100%），则 EP2 生效。
+
+### O12 — EP4 钩子模板
+
+| 检查项 | 通过标准 | 实际 | Pass? |
+|--------|----------|------|-------|
+| `hook_templates` 配置 | preset 或 job.yaml 含 `hook_templates` 非空列表 | | |
+| 第 1 句钩子特征 | `script.md` 第 1 句匹配某个模板模式（含片名或情绪钩子词） | | |
+| 钩子句长度 | 第 1 句 ≤ `prompt_max_chars_per_sentence`（未被截断） | | |
+| `set_pieces` 注入（可选） | 若配置了 `set_pieces`，beats 中含名场面关键词 | | |
+
+**判读方法**: 人工读 `script.md` 第 1 句，判断是否像「你敢信？…」「看完…我…」等钩子句式，
+而非平铺直叙的剧情概括。对比基线第 1 句看是否有明显钩子感提升。
+
+### O13 — EP5 标题卡
+
+| 检查项 | 通过标准 | 实际 | Pass? |
+|--------|----------|------|-------|
+| `render_title_card_sec` > 0 | preset 或 job.yaml 配置了 `render_title_card_sec ≥ 0.5` | | |
+| 标题卡存在 | `final.mp4` 前 N 秒含电影名文字叠加（非黑屏起手） | | |
+| 标题卡时长 | ffprobe 首段静音区间 ≈ `render_title_card_sec` | | |
+| 标题卡不遮字幕 | 标题卡期间无底部字幕重叠 | | |
+| `cover.jpg` 导出（可选） | 若 EP5 补完分支已合并，`cover.jpg` 存在 | | |
+
+**判读方法**: 用播放器看 `final.mp4` 前 2 秒，确认有电影名大字淡入。
+对比基线（无标题卡）的前 2 秒，确认不是黑屏+静音起手。
+
+### O14 — EP6 Duck 曲线 + Loudnorm
+
+| 检查项 | 通过标准 | 实际 | Pass? |
+|--------|----------|------|-------|
+| `bgm_loudnorm` = true | preset 或 metadata 含 `bgm_loudnorm: true` | | |
+| 成片响度 | `mean_volume` 在 -16 ~ -12 dB 范围（loudnorm 目标 -14 LUFS 附近） | | |
+| Duck 比例性 | 对比基线：说话时 BGM 闪避深度随人声音量变化（非固定 -10dB） | | |
+| Duck 平滑度 | BGM 闪避无突变（线性 attack/release 生效） | | |
+| 句间 BGM 抬起 | 句间静默时 BGM 可听到明显抬起 | | |
+
+**判读方法**: 用 `scripts/compare_runs.py --focus duck_curve` 输出响度包络对比。
+基线（固定 duck）vs 新版（比例 duck）的差异在人声峰值处最明显——新版峰值时 duck 更深。
+
+---
+
+## L2 基础主观观感（沿用 L2_HANDTEST.md，须全 ≥ 2）
+
+评分：`0` 不能发 / `1` 能发但尴尬 / `2` 可直接发。
+
+| # | 项 | 关注点 | 基线分 | 新版分 | 差值 |
+|---|----|--------|--------|--------|------|
+| S1 | 画面铺满 | cover 无大黑边；人物不畸形拉伸 | | | |
+| S2 | 底部字幕 | 底条+描边可读；不挡关键人脸过久 | | | |
+| S3 | 碎镜 | 无连续 <0.4s 闪切；节奏像解说 | | | |
+| S4 | 速度感 | 无夸张快放/慢放；说话与画面节奏不拧 | | | |
+| S5 | 废镜头 | 无明显黑场/彩条/片头厂标长时间占镜 | | | |
+| S6 | 语义相关 | 多数镜头与旁白「说得过去」 | | | |
+| S7 | 人声清晰 | 解说响度稳定；BGM 不压过人声 | | | |
+| S8 | BGM duck | 说话时 BGM 明显让路；句间可抬起 | | | |
+| S9 | 首 3 秒 | 有钩子感；不是黑屏+静音起手 | | | |
+| S10 | 愿不愿发 | **一票否决**：你是否愿意不二剪直接发？Y/N | | | |
+
+> **基线分**填 v0.4.25 或更早版本的同片跑片结果（从 `L2_HANDTEST_20260723.md` / `L2_HANDTEST_G2_20260724.md` 查）。
+> **差值** = 新版分 - 基线分；正值表示 EP 带来提升，负值表示回归。
+
+---
+
+## EP 主观加分项（QUALITY_UPLIFT_METHODS §6.2）
+
+评分：`0` 无改善 / `1` 有改善但不够 / `2` 明显提升。
+
+| # | 项 | 关注点 | 基线分 | 新版分 | 差值 | 对应 EP |
+|---|----|--------|--------|--------|------|---------|
+| E1 | 像解说而非缩时 | 成片不再像「整部电影快进」；有叙事弧而非均匀铺过 | | | | EP2 |
+| E2 | 镜-话对上爽点 | 至少 1 个「这镜对上了」的爽点（beat 锚让高光镜命中） | | | | EP2 |
+| E3 | 开头留人 | 前 3s 钩子句让人愿意留下来（不是平铺起手） | | | | EP4 |
+| E4 | 标题卡专业感 | 片头标题卡让成片更像「制作过」而非裸剪 | | | | EP5 |
+| E5 | 听感舒适度 | BGM 闪避自然；响度统一；不刺耳也不闷 | | | | EP6 |
+
+> **L2+ 退出要求**: E1–E5 中至少 2 项 ≥ 2 分，且无任何项 = 0。
+
+---
+
+## 对比实验协议（强制）
+
+> 引用 QUALITY_UPLIFT_METHODS §6.3：任何 EP 合并前的对比实验必须遵循。
+
+```text
+同一 G1/G2 源片 + BGM + preset + seed
+基线: v0.4.25 main HEAD (无 EP2/EP4/EP5/EP6)
+新版: v0.4.26 main HEAD (含 EP2/EP4/EP5/EP6)
+只改版本（git checkout），不改源片/BGM/preset/duration
+并排播放 final.mp4，先盲后揭
+记录 S 与 E 项分数
+```
+
+### 并排对比工具
+
+```bash
+# 用 compare_runs.py 自动对比 metadata
+python scripts/compare_runs.py \
+  --baseline output/l2-runs/<date>-G1-baseline/metadata.json \
+  --new output/l2-runs/<date>-G1-v0426/metadata.json \
+  --output comparison_report.md
+
+# 或用 ffplay 并排（手动调窗口位置）
+ffplay -x 960 -y 540 output/baseline/final.mp4 &
+ffplay -x 960 -y 540 output/v0426/final.mp4 &
+```
+
+---
+
+## 增强项（不挡 L2+）
+
+| # | 项 | 说明 |
+|---|----|------|
+| X1 | EP8 VisionCaptioner | 若 `vision_captioner="stub"`，验证 stub labels 被 fake-caption guard 正确拦截 |
+| X2 | EP9 pause/resume | 若测 `--pause-at script`，验证 `pipeline_state.json` 写出 + `mn resume` 可续 |
+| X3 | 9:16 竖屏 | G3 样片覆盖竖屏安全区（EP5 补完后） |
+| X4 | mainstream-dry preset | 验证 EP 参数在非 douyin-fast preset 下的行为 |
+
+---
+
+## 结论栏
+
+```text
+本轮结论:  PASS / FAIL
+L2 基础项:  PASS / FAIL  (O1–O10 + S1–S10)
+EP 专属项:  PASS / FAIL  (O11–O14 + E1–E5)
+P0 缺陷 ID:
+是否计入「L2+ 验证」:  Y/N
+最大提升维度:          (E1–E5 中差值最大的)
+最大回归维度:          (S1–S10 或 E1–E5 中差值最负的，无则填 N/A)
+```
+
+---
+
+## 附：EP 参数速查
+
+| EP | 参数 | 默认值 | douyin-fast | 验证位置 |
+|----|------|--------|-------------|----------|
+| EP2 | `beats_meta` (自动) | — | — | match_summary.beat_anchor |
+| EP2 | `approx_ratio` (LLM) | — | — | match_summary.beat_anchored_count |
+| EP4 | `hook_templates` | `[]` | 5 条模板 | script.md 第 1 句 |
+| EP4 | `set_pieces` | `[]` | `[]` | beats 含名场面关键词 |
+| EP5 | `render_title_card_sec` | 0 | 1.0 | final.mp4 前 N 秒 |
+| EP6 | `bgm_loudnorm` | false | true | metadata / ffprobe mean_volume |
+| EP6 | `bgm_duck_db` | -10.0 | -10.0 | duck_bgm 比例曲线 |

--- a/docs/checklists/L2_PLUS_SOP.md
+++ b/docs/checklists/L2_PLUS_SOP.md
@@ -1,0 +1,238 @@
+# L2+ 手测 SOP — Effect Portfolio 验证标准操作流程
+
+> **适用版本**: v0.4.26+（含 EP2/EP4/EP5/EP6）
+> **前置条件**: L2 已退出（G1+G2 各 2 轮全绿）或 L2 基础项已验证通过
+> **预计耗时**: 单轮 60–90 分钟（含跑片 50min + 观看对比 20min + 填表 10min）
+> **产出物**: 填写完成的 `L2_HANDTEST_PLUS_YYYYMMDD.md` + `comparison_report.md`
+
+---
+
+## 0. 准备工作（首次执行，约 10 分钟）
+
+### 0.1 确认基线数据可用
+
+L2+ 需要与 v0.4.25（或更早、无 EP 特性的版本）的跑片结果对比。确认以下文件存在：
+
+| 文件 | G1 位置 | G2 位置 |
+|------|---------|---------|
+| `metadata.json` | G1 跑片目录 | G2 跑片目录 |
+| `final.mp4` | G1 跑片目录 | G2 跑片目录 |
+| `script.md` | G1 跑片目录 | G2 跑片目录 |
+| `matches.json` | G1 跑片目录 | G2 跑片目录 |
+
+> G1 基线参考: `docs/checklists/L2_HANDTEST_20260723.md`
+> G2 基线参考: `docs/checklists/L2_HANDTEST_G2_20260724.md`
+
+如果基线数据不可用，需先在 v0.4.25 上跑一轮作为基线。
+
+### 0.2 确认环境
+
+```powershell
+# 冻结环境
+git rev-parse --short HEAD           # 确认在 v0.4.26+
+python -V                             # 建议 3.11/3.12/3.13
+pip show movie-narrator scenedetect  | findstr /i "Name Version"
+ffmpeg -version | Select-Object -First 1
+
+# 确认 extras
+python -c "import sentence_transformers; print('ml: OK')"
+python -c "import faster_whisper; print('whisper: OK')"
+python -c "import moviepy; print('media: OK')"
+```
+
+### 0.3 准备输出目录
+
+```powershell
+$date = Get-Date -Format "yyyyMMdd"
+# 基线备份目录（如已有可跳过）
+$baselineDir = "output/l2-runs/$date-G1-baseline"
+$newDir = "output/l2-runs/$date-G1-v0426"
+
+# 创建新版输出目录
+New-Item -ItemType Directory -Force -Path $newDir | Out-Null
+```
+
+---
+
+## 1. 跑片（约 50 分钟）
+
+### 1.1 执行管线
+
+使用与基线**完全相同**的源片、BGM、preset、duration。唯一变量是 git 版本。
+
+```powershell
+# G1 样片（飞驰人生3 / 满江红）
+$env:L2_G1_VIDEO = "D:/movies/你的源片.mp4"
+$env:L2_G1_BGM   = "D:/bgm/你的BGM.mp3"
+
+mn create `
+  --movie "你的电影名" `
+  --style "热血搞笑" `
+  --duration 60 `
+  --format "16:9" `
+  --video $env:L2_G1_VIDEO `
+  --bgm $env:L2_G1_BGM `
+  -p douyin-fast `
+  --config examples/l2/job.l2.douyin.yaml `
+  --keep-cache
+```
+
+> **注意**: `duration=60` 是 L2+ 推荐值（L2 手测用了 15s 是 driver 测试值）。
+> 60s 更接近生产默认，能更好地暴露节奏和时长闭环问题。
+
+### 1.2 备份输出
+
+跑片完成后，立即将输出目录备份到 l2-runs：
+
+```powershell
+# 找到输出目录（通常是 output/<sanitized_movie>/）
+Copy-Item -Recurse "output/<movie_name>/*" $newDir/
+```
+
+### 1.3 确认 E.5 CLI 摘要
+
+v0.4.26 新增的 E.5 CLI 摘要应在管线结束时打印一行：
+
+```
+match: 18 segs | emb 100% heur 0% | score 0.74 | ⚠️ <degraded_reason>
+```
+
+如果看到 `⚠️` 标记，记录降级原因到 checklist。
+
+---
+
+## 2. 客观对比（约 10 分钟）
+
+### 2.1 运行对比脚本
+
+```powershell
+python scripts/compare_runs.py `
+  --baseline <基线metadata.json路径> `
+  --new <新版metadata.json路径> `
+  --output comparison_report.md `
+  --focus all
+```
+
+### 2.2 检查对比报告
+
+打开 `comparison_report.md`，重点查看：
+
+1. **自动判读**部分 — 确认 EP2/EP4/EP5/EP6 参数已激活
+2. **EP2 beat_anchor** — `beat_anchor=true` 且 `beat_anchored_count/segments ≥ 0.5`
+3. **EP6 loudnorm** — `mean_volume` 在 [-16, -12] dB 范围内
+4. **src_mid 分布** — 新版是否偏离线性（集中在高光区而非均匀铺满）
+5. **source_counts** — embedding 比例不应因 EP2 而下降
+
+### 2.3 填写 O11–O14
+
+根据对比报告结果，填写 checklist 的 EP 专属客观门禁（O11–O14）。
+
+---
+
+## 3. 主观观感对比（约 20 分钟）
+
+### 3.1 并排播放
+
+```powershell
+# 方法 1: ffplay 并排
+ffplay -x 960 -y 540 --left 0 --top 0 "<基线final.mp4>" &
+ffplay -x 960 -y 540 --left 960 --top 0 "<新版final.mp4>" &
+
+# 方法 2: 用 VLC / PotPlayer 等播放器分别打开，手动同步
+```
+
+### 3.2 盲评（先不告知哪个是新版）
+
+1. 先完整看一遍 A 片（随机选基线或新版）
+2. 再完整看一遍 B 片
+3. 按 S1–S10 打分（不看基线分）
+4. 按 E1–E5 打分
+
+### 3.3 揭盲对比
+
+1. 揭示 A/B 哪个是基线、哪个是新版
+2. 填写 checklist 的「基线分」和「新版分」列
+3. 计算差值（新版 - 基线）
+
+### 3.4 重点观察项
+
+| EP | 观察重点 | 时间码参考 |
+|----|----------|-----------|
+| EP2 | 高光镜是否命中（如打斗/反转/高潮段） | 中后段（60%–80% 位置） |
+| EP4 | 第 1 句是否有钩子感（不是平铺概括） | 0:00–0:03 |
+| EP5 | 片头是否有标题卡（电影名大字淡入） | 0:00–0:01 |
+| EP6 | BGM 闪避是否随人声音量变化（峰值时更深） | 全程，尤其句首/句尾 |
+
+---
+
+## 4. 填写结论（约 5 分钟）
+
+### 4.1 判定标准
+
+| 条件 | 结果 |
+|------|------|
+| O1–O10 全绿 + S1–S10 全 ≥ 2 | L2 基础 PASS |
+| O11–O14 全绿 + E1–E5 ≥ 2 项 ≥ 2 且无 0 | EP 专属 PASS |
+| 两者都 PASS | **L2+ 验证 PASS** |
+| 任一不满足 | **FAIL** — 记录缺陷到 L2_DEFECTS.md |
+
+### 4.2 记录缺陷（如有）
+
+在 `docs/checklists/L2_DEFECTS.md` 中新增缺陷行：
+
+```markdown
+| ID | 日期 | 样片 | SHA | 时间码 | 现象 | 期望 | 模块 | 优先级 | 证据 | 状态 |
+|----|------|------|-----|--------|------|------|------|--------|------|------|
+| L2P-001 | 2026-07-25 | G1 | 7f1abee | 00:15 | beat 锚导致 src_mid 集中在中段，开头无镜 | 开头应有镜 | match | P1 | match_summary.beat_anchored_count=18 | open |
+```
+
+### 4.3 归档
+
+将以下文件归档到 `output/l2-runs/<date>-G1-v0426/`:
+
+- `final.mp4`
+- `metadata.json`
+- `matches.json`
+- `script.md`
+- `subtitle.srt`
+- `comparison_report.md`
+- `L2_HANDTEST_PLUS_YYYYMMDD.md`（填写完成的 checklist）
+
+---
+
+## 5. G2 重复（约 60 分钟）
+
+对 G2 样片（西虹市首富）重复 Step 1–4。
+
+> G2 是喜剧片，与 G1（动作/史剧）类型不同，能验证 EP 特性在不同片种上的泛化能力。
+
+---
+
+## 6. 退出判定
+
+| 条件 | 动作 |
+|------|------|
+| G1 + G2 都 L2+ PASS | ✅ L2+ 验证完成，EP2/EP4/EP5/EP6 正式确认 |
+| G1 PASS 但 G2 FAIL | ⚠️ 片种泛化问题 — 记录缺陷，评估是否需调 preset |
+| G1 FAIL | ⚠️ 回归 — 记录 P0，暂停其他工作，优先修复 |
+| 两者都 FAIL | ❌ EP 特性有系统性问题 — 回退到 v0.4.25，重新评估 |
+
+---
+
+## 附：快速检查清单
+
+```text
+[ ] 基线数据可用（metadata.json + final.mp4）
+[ ] 环境确认（Python 3.1x + [media]+[ml] + ffmpeg）
+[ ] 跑片完成（v0.4.26, douyin-fast, duration=60）
+[ ] CLI 摘要已记录（match 一行摘要）
+[ ] compare_runs.py 已执行
+[ ] O11–O14 已填写
+[ ] 并排播放完成（盲评 + 揭盲）
+[ ] S1–S10 基线分/新版分已填写
+[ ] E1–E5 已填写
+[ ] 结论栏已填写
+[ ] 缺陷已登记（如有）
+[ ] 文件已归档
+[ ] G2 已重复
+```

--- a/scripts/compare_runs.py
+++ b/scripts/compare_runs.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Compare two pipeline run metadata.json files for L2+ hand-test verification.
+
+Usage:
+    python scripts/compare_runs.py \
+        --baseline output/l2-runs/baseline/metadata.json \
+        --new output/l2-runs/v0426/metadata.json \
+        --output comparison_report.md
+
+Focus areas:
+    --focus beat_anchor   Compare EP2 beat anchor fields + src_mid distribution
+    --focus duck_curve    Compare EP6 duck curve / loudness fields
+    --focus all           Compare everything (default)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_metadata(path: str) -> dict[str, Any]:
+    """Load metadata.json from path."""
+    p = Path(path)
+    if not p.exists():
+        print(f"ERROR: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(p, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def safe_get(d: dict, *keys, default=None) -> Any:
+    """Safely traverse nested dict keys."""
+    cur = d
+    for k in keys:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(k, default)
+    return cur
+
+
+def fmt_val(v: Any) -> str:
+    """Format value for display."""
+    if v is None:
+        return "—"
+    if isinstance(v, float):
+        return f"{v:.4f}"
+    if isinstance(v, dict):
+        return json.dumps(v, ensure_ascii=False, indent=2)
+    if isinstance(v, list):
+        return f"[{len(v)} items]"
+    return str(v)
+
+
+def compare_field(
+    baseline: dict, new: dict, path: list[str], label: str
+) -> str:
+    """Compare a single field between baseline and new metadata."""
+    b = safe_get(baseline, *path)
+    n = safe_get(new, *path)
+
+    diff = ""
+    if isinstance(b, (int, float)) and isinstance(n, (int, float)):
+        delta = n - b
+        arrow = "↑" if delta > 0 else ("↓" if delta < 0 else "=")
+        diff = f" ({arrow} {delta:+.4f})"
+
+    return (
+        f"| {label} | `{fmt_val(b)}` | `{fmt_val(n)}` |{diff} |"
+    )
+
+
+def compare_beat_anchor(baseline: dict, new: dict) -> str:
+    """Compare EP2 beat anchor fields."""
+    lines = [
+        "## EP2 — Beat Time Anchor\n",
+        "| Field | Baseline | New | Delta |",
+        "|-------|----------|-----|-------|",
+    ]
+
+    ms_b = safe_get(baseline, "match_summary", default={})
+    ms_n = safe_get(new, "match_summary", default={})
+
+    lines.append(compare_field(
+        baseline, new, ["match_summary", "beat_anchor"], "beat_anchor"
+    ))
+    lines.append(compare_field(
+        baseline, new, ["match_summary", "beat_anchored_count"],
+        "beat_anchored_count"
+    ))
+    lines.append(compare_field(
+        baseline, new, ["match_summary", "segments"], "segments"
+    ))
+
+    # beats_meta comparison
+    bm_b = baseline.get("beats_meta", [])
+    bm_n = new.get("beats_meta", [])
+    lines.append(f"| beats_meta length | {len(bm_b)} | {len(bm_n)} | |")
+
+    # approx_ratio coverage
+    ratio_b = sum(1 for b in bm_b if b.get("approx_ratio") is not None)
+    ratio_n = sum(1 for b in bm_n if b.get("approx_ratio") is not None)
+    lines.append(
+        f"| approx_ratio coverage | {ratio_b}/{len(bm_b)} | "
+        f"{ratio_n}/{len(bm_n)} | |"
+    )
+
+    # src_mid distribution from matches.json
+    matches_b = baseline.get("_matches", [])
+    matches_n = new.get("_matches", [])
+    if matches_b and matches_n:
+        lines.append("\n### src_mid distribution (from matches)\n")
+        lines.append("| Percentile | Baseline | New | Delta |")
+        lines.append("|------------|----------|-----|-------|")
+
+        mids_b = sorted(
+            [(safe_get(m, "src_start", default=0) +
+             safe_get(m, "src_end", default=0)) / 2
+             for m in matches_b if safe_get(m, "src_start") is not None]
+        )
+        mids_n = sorted(
+            [(safe_get(m, "src_start", default=0) + 
+             safe_get(m, "src_end", default=0)) / 2
+             for m in matches_n if safe_get(m, "src_start") is not None]
+        )
+
+        if mids_b and mids_n:
+            max_b = mids_b[-1] if mids_b[-1] > 0 else 1
+            max_n = mids_n[-1] if mids_n[-1] > 0 else 1
+            for pct in [0, 25, 50, 75, 100]:
+                idx_b = min(int(len(mids_b) * pct / 100), len(mids_b) - 1)
+                idx_n = min(int(len(mids_n) * pct / 100), len(mids_n) - 1)
+                val_b = mids_b[idx_b] / max_b if max_b > 0 else 0
+                val_n = mids_n[idx_n] / max_n if max_n > 0 else 0
+                delta = val_n - val_b
+                lines.append(
+                    f"| {pct}% | {val_b:.3f} | {val_n:.3f} | {delta:+.3f} |"
+                )
+
+            # Uniformity check: if baseline is roughly linear (R² > 0.95)
+            # and new deviates, EP2 is working
+            lines.append("\n**判读**: 若基线 src_mid 分位接近线性（0→1 均匀），"
+                        "而新版偏离线性（集中在高光区），则 EP2 beat anchor 生效。")
+
+    return "\n".join(lines)
+
+
+def compare_duck_curve(baseline: dict, new: dict) -> str:
+    """Compare EP6 duck curve / loudness fields."""
+    lines = [
+        "## EP6 — Duck Curve + Loudnorm\n",
+        "| Field | Baseline | New | Delta |",
+        "|-------|----------|-----|-------|",
+    ]
+
+    # bgm_loudnorm
+    lines.append(compare_field(
+        baseline, new, ["bgm_loudnorm"], "bgm_loudnorm"
+    ))
+
+    # bgm_duck_db
+    lines.append(compare_field(
+        baseline, new, ["bgm_duck_db"], "bgm_duck_db"
+    ))
+
+    # mean_volume
+    lines.append(compare_field(
+        baseline, new, ["mean_volume"], "mean_volume (dB)"
+    ))
+
+    # audio_target_dbfs
+    lines.append(compare_field(
+        baseline, new, ["audio_target_dbfs"], "audio_target_dbfs"
+    ))
+
+    # status.bgm
+    lines.append(compare_field(
+        baseline, new, ["status", "bgm"], "status.bgm"
+    ))
+
+    # Check if loudnorm target is met
+    mean_vol_n = safe_get(new, "mean_volume")
+    if mean_vol_n is not None:
+        if -16.0 <= mean_vol_n <= -12.0:
+            lines.append(
+                f"\n✅ 新版 mean_volume={mean_vol_n}dB 在 loudnorm "
+                "目标范围 [-16, -12] dB 内。"
+            )
+        else:
+            lines.append(
+                f"\n⚠️ 新版 mean_volume={mean_vol_n}dB 超出 loudnorm "
+                "目标范围 [-16, -12] dB。"
+            )
+
+    lines.append("\n**判读**: duck 曲线为比例闪避（代码内实现），无法从 metadata "
+                "直接读取包络。需人工听感对比：基线 duck 固定 -10dB，"
+                "新版在人声峰值时 duck 更深、句间抬起更自然。")
+
+    return "\n".join(lines)
+
+
+def compare_match_summary(baseline: dict, new: dict) -> str:
+    """Compare match_summary fields."""
+    lines = [
+        "## Match Summary 对比\n",
+        "| Field | Baseline | New | Delta |",
+        "|-------|----------|-----|-------|",
+    ]
+
+    fields = [
+        (["match_summary", "segments"], "segments"),
+        (["match_summary", "embedding_ratio"], "embedding_ratio"),
+        (["match_summary", "heuristic_ratio"], "heuristic_ratio"),
+        (["match_summary", "score", "avg"], "score.avg"),
+        (["match_summary", "score", "min"], "score.min"),
+        (["match_summary", "score", "max"], "score.max"),
+        (["match_summary", "speed_factor", "avg"], "speed_factor.avg"),
+        (["match_summary", "speed_factor", "min"], "speed_factor.min"),
+        (["match_summary", "speed_factor", "max"], "speed_factor.max"),
+        (["match_summary", "low_score_fallback_count"],
+         "low_score_fallback_count"),
+        (["match_summary", "degraded_reason"], "degraded_reason"),
+        (["match_summary", "timeline_mode"], "timeline_mode"),
+        (["match_summary", "beat_anchor"], "beat_anchor"),
+        (["match_summary", "beat_anchored_count"], "beat_anchored_count"),
+    ]
+
+    for path, label in fields:
+        lines.append(compare_field(baseline, new, path, label))
+
+    # source_counts
+    sc_b = safe_get(baseline, "match_summary", "source_counts", default={})
+    sc_n = safe_get(new, "match_summary", "source_counts", default={})
+    if sc_b or sc_n:
+        lines.append("\n### source_counts\n")
+        lines.append("| Source | Baseline | New | Delta |")
+        lines.append("|--------|----------|-----|-------|")
+        for src in ["embedding", "heuristic", "fallback", "scene"]:
+            b = sc_b.get(src, 0)
+            n = sc_n.get(src, 0)
+            delta = n - b
+            lines.append(f"| {src} | {b} | {n} | {delta:+d} |")
+
+    # diversity
+    div_b = safe_get(baseline, "match_summary", "diversity", default={})
+    div_n = safe_get(new, "match_summary", "diversity", default={})
+    if div_b or div_n:
+        lines.append("\n### diversity\n")
+        lines.append("| Field | Baseline | New | Delta |")
+        lines.append("|-------|----------|-----|-------|")
+        for field in ["swaps", "window", "max_reuse"]:
+            b = div_b.get(field, "—")
+            n = div_n.get(field, "—")
+            lines.append(f"| {field} | {b} | {n} | |")
+
+    return "\n".join(lines)
+
+
+def compare_basic(baseline: dict, new: dict) -> str:
+    """Compare basic pipeline fields."""
+    lines = [
+        "## 基础信息\n",
+        "| Field | Baseline | New | Delta |",
+        "|-------|----------|-----|-------|",
+    ]
+
+    fields = [
+        (["version"], "version"),
+        (["final_mp4_size"], "final.mp4 size (bytes)"),
+        (["final_mp4_duration"], "final.mp4 duration (s)"),
+        (["mean_volume"], "mean_volume (dB)"),
+        (["width"], "width"),
+        (["height"], "height"),
+        (["has_audio"], "has_audio"),
+        (["has_video"], "has_video"),
+    ]
+
+    for path, label in fields:
+        lines.append(compare_field(baseline, new, path, label))
+
+    # status
+    lines.append("\n### Pipeline Status\n")
+    lines.append("| Step | Baseline | New | Match? |")
+    lines.append("|------|----------|-----|--------|")
+    sb = safe_get(baseline, "status", default={})
+    sn = safe_get(new, "status", default={})
+    for step in ["research", "align", "scene", "match", "bgm", "export",
+                 "translate"]:
+        b = sb.get(step, "—")
+        n = sn.get(step, "—")
+        match = "✅" if b == n else "⚠️"
+        lines.append(f"| {step} | {b} | {n} | {match} |")
+
+    return "\n".join(lines)
+
+
+def compare_ep_params(baseline: dict, new: dict) -> str:
+    """Compare EP-specific params."""
+    lines = [
+        "## EP 参数对比\n",
+        "| Param | Baseline | New | Delta |",
+        "|-------|----------|-----|-------|",
+    ]
+
+    params = [
+        "hook_templates",
+        "set_pieces",
+        "render_title_card_sec",
+        "bgm_loudnorm",
+        "bgm_duck_db",
+        "bgm_normalize",
+        "audio_target_dbfs",
+        "vision_captioner",
+        "match_topk",
+        "match_topk_reuse_penalty",
+        "match_timeline_mode",
+    ]
+
+    for p in params:
+        b = baseline.get(p)
+        n = new.get(p)
+        if b is None and n is None:
+            continue
+
+        if isinstance(b, list) and isinstance(n, list):
+            b_str = f"[{len(b)} items]"
+            n_str = f"[{len(n)} items]"
+            delta = f"{len(n) - len(b):+d}"
+        elif isinstance(b, bool) or isinstance(n, bool):
+            b_str = str(b) if b is not None else "—"
+            n_str = str(n) if n is not None else "—"
+            delta = "" if b == n else "CHANGED"
+        elif isinstance(b, (int, float)) and isinstance(n, (int, float)):
+            b_str = str(b)
+            n_str = str(n)
+            delta = f"{n - b:+.4f}"
+        else:
+            b_str = fmt_val(b)
+            n_str = fmt_val(n)
+            delta = "" if b == n else "CHANGED"
+
+        lines.append(f"| `{p}` | {b_str} | {n_str} | {delta} |")
+
+    return "\n".join(lines)
+
+
+def generate_report(
+    baseline: dict, new: dict, focus: str, baseline_path: str, new_path: str
+) -> str:
+    """Generate full comparison report."""
+    lines = [
+        "# L2+ Hand-Test Comparison Report\n",
+        f"- Baseline: `{baseline_path}`",
+        f"- New: `{new_path}`",
+        f"- Focus: `{focus}`",
+        "",
+        "---\n",
+    ]
+
+    if focus in ("all", "basic"):
+        lines.append(compare_basic(baseline, new))
+        lines.append("")
+
+    if focus in ("all", "match"):
+        lines.append(compare_match_summary(baseline, new))
+        lines.append("")
+
+    if focus in ("all", "beat_anchor"):
+        lines.append(compare_beat_anchor(baseline, new))
+        lines.append("")
+
+    if focus in ("all", "duck_curve"):
+        lines.append(compare_duck_curve(baseline, new))
+        lines.append("")
+
+    if focus in ("all", "ep_params"):
+        lines.append(compare_ep_params(baseline, new))
+        lines.append("")
+
+    # Summary verdict
+    lines.append("---\n")
+    lines.append("## 自动判读\n")
+
+    verdicts = []
+
+    # Check EP2
+    beat_anchor_n = safe_get(new, "match_summary", "beat_anchor")
+    if beat_anchor_n is True:
+        verdicts.append("✅ EP2: beat_anchor=true — beat 时间锚已激活")
+    elif beat_anchor_n is False:
+        verdicts.append("⚠️ EP2: beat_anchor=false — LLM 未返回 approx_ratio，"
+                       "回退到 timeline_mode")
+    else:
+        verdicts.append("— EP2: beat_anchor 字段不存在（版本 < v0.4.26?）")
+
+    # Check EP4
+    hook_n = new.get("hook_templates")
+    if hook_n and len(hook_n) > 0:
+        verdicts.append(f"✅ EP4: hook_templates 配置了 {len(hook_n)} 条模板")
+    else:
+        verdicts.append("— EP4: hook_templates 未配置或为空")
+
+    # Check EP5
+    title_card_n = new.get("render_title_card_sec")
+    if title_card_n and title_card_n > 0:
+        verdicts.append(f"✅ EP5: render_title_card_sec={title_card_n}s — "
+                       "标题卡已启用")
+    else:
+        verdicts.append("— EP5: render_title_card_sec=0 — 标题卡未启用")
+
+    # Check EP6
+    loudnorm_n = new.get("bgm_loudnorm")
+    if loudnorm_n is True:
+        verdicts.append("✅ EP6: bgm_loudnorm=true — RMS 响度归一化已启用")
+    else:
+        verdicts.append("— EP6: bgm_loudnorm=false — 使用峰值归一化")
+
+    for v in verdicts:
+        lines.append(f"- {v}")
+
+    lines.append("")
+    lines.append("> 以上为 metadata 层自动判读。主观观感（S/E 项）需人工填写"
+                 "L2_HANDTEST_PLUS checklist。")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare two pipeline run metadata.json files "
+                    "for L2+ hand-test verification."
+    )
+    parser.add_argument(
+        "--baseline", required=True,
+        help="Path to baseline metadata.json"
+    )
+    parser.add_argument(
+        "--new", required=True,
+        help="Path to new metadata.json"
+    )
+    parser.add_argument(
+        "--output", default=None,
+        help="Output file path (default: stdout)"
+    )
+    parser.add_argument(
+        "--focus", default="all",
+        choices=["all", "basic", "match", "beat_anchor", "duck_curve",
+                 "ep_params"],
+        help="Focus area for comparison (default: all)"
+    )
+
+    args = parser.parse_args()
+
+    baseline = load_metadata(args.baseline)
+    new = load_metadata(args.new)
+
+    report = generate_report(
+        baseline, new, args.focus, args.baseline, args.new
+    )
+
+    if args.output:
+        Path(args.output).write_text(report, encoding="utf-8")
+        print(f"Report written to: {args.output}")
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Prepares L2+ hand-test materials for EP2/EP4/EP5/EP6 verification:

### New files
- \docs/checklists/L2_HANDTEST_PLUS.md\ — Extended checklist with EP-specific objective gates (O11-O15) and subjective bonus items
- \scripts/compare_runs.py\ — CLI tool to diff metadata.json files across runs, producing comparison reports for beat_anchor, duck_curve, and ep_params
- \docs/checklists/L2_PLUS_SOP.md\ — Step-by-step standard operating procedure for L2+ hand testing

### Motivation
After merging EP2/EP4/EP5/EP6 features, we need structured hand-test materials to verify the new capabilities work end-to-end before declaring L2+ complete.

### Test plan
- [x] \compare_runs.py\ compiles without errors (\python -m py_compile\)
- [x] Core test suite passes (224 tests)
- [ ] Manual hand-test execution (follow L2_PLUS_SOP.md)