### PR TITLE
docs: consolidate ROADMAP to per-major-version structure

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,265 +53,76 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 - [x] YAML-based job configuration (`mn create --config`)
 - [x] Console / structured-step-state logging refactor (`ctx.services.console`, `StepState`)
 - [x] Multi-language subtitle support (`--subtitle-lang` / `--subtitle-mode`; LLM translation with retry-then-soft-degrade; three-file SRT output)
-- [x] Web UI (Gradio local browser app via `mn web`; requires `[web]` extra) — *superseded by the FastAPI + React refactor in v0.4.10, see below*
+- [x] Web UI (Gradio local browser app via `mn web`; requires `[web]` extra) — *superseded by the FastAPI + React refactor in v0.4.x, see below*
 
 ### v0.3 New CLI flags
 
 - `--subtitle-lang` — Target language tag (`en`, `ja`, `zh-TW`, ...); empty = feature off
 - `--subtitle-mode` — Overlay mode: `original` / `translated` / `bilingual` (default `original`)
 
-### v0.3.5 Web UI (Gradio — legacy)
-
-- `mn web` — Launch local Gradio browser app (requires `pip install "movie-narrator[web]"`)
-- Cooperative cancel at step boundaries (Cancel button in UI)
-- Form fields mirror CLI options; advanced params follow "empty = no override" rule (Settings defaults apply)
-- Uploads go to `mn_web_*` temp dirs, never pollute `output/`
-
-> **Note**: This Gradio-based Web UI is **legacy** and was superseded by the FastAPI + React refactor shipped in **v0.4.10** (see *v0.4.10 WebUI Refactor* below). The `web/` package was removed from the tree in **v0.4.12**.
-
 ## v0.4.x — TTS Abstraction & Infrastructure
 
-- [x] TTS provider abstraction (`TTSProvider` protocol, `BaseTTSProvider`, `EdgeTTSProvider`, `OpenAITTSProvider`, `MimoTTSProvider`)
+> 28 patch releases (v0.4.0 – v0.4.27). Major themes: TTS provider abstraction, config system overhaul, WebUI refactor (Gradio → FastAPI + React), core engine production quality, L2 readiness & hand-test passed, match intelligence (EP1/EP2/EP3), effect portfolio (EP4/EP5/EP6), extensibility (EP8/EP9), and contract layer. Per-release details in [CHANGELOG.md](../CHANGELOG.md).
+
+### Infrastructure
+
+- [x] TTS provider abstraction (`TTSProvider` protocol; Edge / OpenAI / MiMo providers)
 - [x] Provider selection via `MN_TTS_PROVIDER` (`edge` / `openai` / `mimo`)
-- [x] OpenAI TTS support (sync SDK via `asyncio.to_thread`; voice whitelist; credential fallback to `MN_LLM_API_KEY`)
-- [x] MiMo TTS support (3 models: named voice, voice clone, voice design; wav→mp3 conversion; style prompt)
 - [x] Cache key upgrade (sha256, 7 dimensions, two-level fan-out, per-provider version map)
-- [x] CI temp-file isolation (silent audio never enters cache)
-- [x] `is_ci()` single source of truth for CI detection
-- [x] `ConfigError` cross-cutting error class
+- [x] Config system overhaul — strict `.env` / `job.yaml` boundary (24 infra fields / 48+ pipeline params)
 - [x] MoviePy 1.x → 2.x upgrade (Python 3.13+ compatibility)
 - [x] Preflight LLM/TTS validation before pipeline execution
 - [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
 - [x] Auto-create `~/.movie-narrator/.env` on first run
-- [x] `export_clips` direct ffmpeg subprocess (design choice)
 
-### v0.4.7 Config system overhaul
+### Web UI
 
-- [x] Strict env/yaml boundary: `.env` = 24 LLM + TTS infrastructure fields only; `job.yaml` = 52 pipeline behavior params
-- [x] YAML auto-discovery: `--config` not passed → `cwd/job.yaml` → packaged example → none
-- [x] `.env.example` and `job.example.yaml` as single sources of truth (no code constants module)
-- [x] All 48 YAML params properly connected through `runner.py` → `ctx.metadata` → pipeline steps
-- [x] Fixed `translate_chunk_chars/size` silently ignored (never copied to `ctx.metadata`)
-- [x] Fixed `export_clips` codecs hardcoded (now uses `ctx.metadata` → inline literal)
-- [x] Fixed `scene_frame_skip` missing from runner copy loop
+- [x] Gradio → FastAPI + React SPA refactor (`web_api/` package, Vite + TypeScript + shadcn/ui)
+- [x] WebSocket real-time progress (`/ws/jobs/{id}` streams `Console.snapshot()`)
+- [x] pip-installable WebUI packaging (SPA bundled in wheel)
+- [x] Legacy Gradio `web/` package removed
 
-### v0.4.10 WebUI Refactor
+### Core Engine Quality
 
-The Web UI is rebuilt from a Gradio single-file app into a decoupled **FastAPI + React SPA** stack. The legacy `web/` (Gradio) package was removed from the tree in v0.4.12.
-
-- [x] **FastAPI backend** — new `src/movie_narrator/web_api/` package (11 modules: `server.py`, `routes.py`, `ws.py`, `tasks.py`, `console.py`, `controller.py`, `form.py`, `models.py`, `utils.py`, `__init__.py`)
-- [x] **React 18 SPA** — new `webui/` project (Vite + TypeScript); FastAPI serves the built bundle as static assets, so `mn web` is a single process
-- [x] **WebSocket real-time progress** — `/ws/jobs/{id}` streams `Console.snapshot()` + status deltas; replaces the old 200ms Gradio polling generator
-- [x] **`[web]` extra changed** — dropped `gradio`; now `fastapi` + `uvicorn` + `python-multipart`
-- [x] **`mn web` port** — moved from `7860` (Gradio default) → `8760`
-- [x] **Frontend stack** — Vite + TypeScript + shadcn/ui + Tailwind CSS
-
-### v0.4.11 WebUI packaging (pip-installable)
-
-> `v0.4.10` shipped the rewrite in git but the SPA was missing from the PyPI wheel. **0.4.11** closes that gap.
-
-- [x] Vite `outDir` → `src/movie_narrator/web_api/static/`; package-data `static/**`
-- [x] `server.py` serves package-relative `static/` (works after `pip install`)
-- [x] Track `webui/package.json` + `package-lock.json` + `tsconfig.json` (root `*.json` gitignore exceptions)
-- [x] CI `webui` job + Publish `npm ci && npm run build` before `python -m build`
-- [x] Publish asserts wheel contains `static/index.html` + hashed JS/CSS
-
-> See `docs/ARCHITECTURE.md` → *Web UI Layer* for the request/WebSocket flow and the `web_api/` module table.
-
-### v0.4.12 Remove Legacy Gradio
-
-- [x] Deleted `src/movie_narrator/web/` (9 files)
-- [x] Removed `gradio` from `[full]` extra
-- [x] Migrated tests: `test_web_form.py` → `web_api.form`, `test_pipeline_cancel.py` → `TaskController`
-- [x] Deleted `test_web_console.py`, `test_web_controller.py` (covered by `test_web_api.py`)
-
-### v0.4.13 Core Engine Production Quality
-
-- [x] Post-render deliverable QA step (`validate_deliverable`) — hard step after `render_video`; ffprobe + ffmpeg fallback; CI skips by default, local runs enable
-- [x] Audio normalize + BGM ducking (`utils/audio_mix.py`) — windowed envelope with attack/release smoothing; skip path normalizes narration
-- [x] Video cover/contain layout (`utils/video_layout.py`) — source footage fitted to canvas; render defaults to `cover`
-- [x] Bottom-safe subtitle layout — `text_image.create_text_image` with CJK wrapping + ellipsis; render always draws overlays (bottom by default)
-- [x] Deliverable QA probes (`utils/deliverable_qa.py`) — structured `QAReport` / `QAIssue`
-- [x] Match defaults tightened — clamp 0.85–1.25, merge 2.0s, drop tiny scenes <0.4s
+- [x] Post-render deliverable QA step (`validate_deliverable` — ffprobe + ffmpeg fallback)
+- [x] Audio normalize + BGM ducking with attack/release smoothing
+- [x] Video cover/contain layout; bottom-safe subtitle layout (CJK wrapping + backdrop bar)
 - [x] Render encode quality — CRF 18, preset `slow`, `+faststart`
-- [x] 15 new `JobParams` fields plumbed (render fit/encode/subtitle, BGM duck/normalize, QA, match drop) — actual count: render_fit_mode, render_crf, render_preset, render_faststart, render_subtitle_position, render_subtitle_max_width_ratio, render_subtitle_bottom_margin_ratio, qa_enabled, qa_max_silence_db, qa_min_duration_ratio, qa_max_duration_ratio, match_drop_scene_min_duration, bgm_duck_db, bgm_normalize, audio_target_dbfs
-- [x] Pipeline 14 → 15 steps; frontend `PIPELINE_STEPS` / `STEP_LABELS` synced
+- [x] Narration preset system (3 built-in: `douyin-fast`, `mainstream-dry`, `bilibili-long`)
+- [x] Two-phase script generation (beats → expansion) with dynamic sentence count
+- [x] Performance contract closure (TTS cache atomic write, style_prompt in cache key, numpy duck rewrite)
 
-### v0.4.14 Publishable Bottom Subtitle
+### L2 Readiness & Validation
 
-- [x] Semi-transparent black backdrop bar (65% alpha, 16px/12px padding) behind bottom subtitle text — matches short-video recap style
-- [x] Thicker stroke (2px → 4px) for legibility on bright footage
-- [x] Bug fix: empty wrapped list early return; per-line height re-measurement via `textbbox`
-- [x] Cross-platform test threshold (60% → 50%) for Linux CI font metrics
+- [x] `match_summary` full schema (21+ fields) in `metadata.json` for L2 jq queries
+- [x] Degradation visibility — `_degraded_steps` + CLI summary for all soft-step failures
+- [x] faster-whisper backend (Windows CPU compatibility; unlocks embedding re-rank without WhisperX)
+- [x] L2 hand-test passed — O1-O10 100% (G1 满江红 + G3 飞驰人生3, `embedding_ratio=1.00`, `degraded_steps=[]`)
+- [x] L2 G2 cross-movie validation — 西虹市首富 (`embedding_topk=18/18`, `qa_report.ok=true`, `degraded_reason=null`)
+- [x] L2+ hand-test toolkit (checklist + `compare_runs.py` + SOP)
 
-### v0.4.15 Narration Preset System (Stage 0.5)
+### Match Intelligence
 
-- [x] Pluggable `Preset` Protocol with closed-vocabulary validation (`ALLOWED_PARAM_KEYS` + `ALLOWED_PROMPT_TAGS`)
-- [x] Three built-in presets: `douyin-fast` (default), `mainstream-dry`, `bilibili-long`
-- [x] CLI `--narration-preset` / `-p` flag + `mn preset` list/show command
-- [x] YAML `narration_preset` top-level field + Web API `FormData.narration_preset`
-- [x] Prompt shaping via closed-vocabulary tags (cadence / register / connectors)
-- [x] Single-source `PARAM_WHITELIST` frozenset (runner.py) — eliminates dual-maintained whitelist
-- [x] Hand-test verified: prompt tags produce perceptible style differences
-- [x] Known limitation fixed in v0.4.16: two-phase generation enforces `prompt_target_sentences`
-- [ ] Stage 2 (future): SPI discover via `entry_points` + opt-in local folder scan
+- [x] EP1 act-weighted timeline partitioning (4-act dramatic pacing, `match_timeline_mode="weighted_acts"`)
+- [x] EP3 top-K rerank with order-backtrack reuse penalty (`match_topk` + `match_topk_reuse_penalty`)
+- [x] EP2 beat time anchor (structured beats with `act` + `approx_ratio`, time-anchored heuristic)
+- [x] Diversity post-processing (sliding-window scene reuse limit)
+- [x] Footage coverage gate (warn-only when below `render_min_footage_coverage`)
 
-### v0.4.16 Two-Phase Script Generation + CLI/Config Improvements
+### Effect Portfolio
 
-- [x] Two-phase script generation: Phase 1 (plot beats, low temp) → Phase 2 (expansion, moderate temp) → fallback trim
-- [x] `prompt_target_sentences` now enforceable (was ignored by LLM in v0.4.15)
-- [x] First-run config notice: `ensure_user_config()` prints one-time message to stderr
-- [x] CLI help: `no_args_is_help=True`, `rich_markup_mode="rich"`, bilingual (中文/English) help
-- [x] `-h` conflict resolved (web command `--host` no longer binds `-h`)
-- [x] Phase 1 None/empty beat filtering + Phase 2 empty text filtering
-- [x] TTS per-segment retry (3 attempts) — single failure no longer kills batch
-- [x] Research step retry (was zero retry, now matches script.py pattern)
-- [x] Degradation warnings: `SOFT_STEP_CONSEQUENCES` + pipeline-end summary
-- [x] Retry failure debug logging
+- [x] EP4 hook templates & set pieces (genre-appropriate scroll-stoppers + named-scene injection)
+- [x] EP5 title card overlay + cover.jpg export + vertical safe area (9:16 subtitle margin tightening)
+- [x] EP6 duck curve & RMS-based loudness normalization
 
-### v0.4.17 Dynamic Sentence Count + L2 E2E Tests
+### Extensibility & Pipeline
 
-- [x] Dynamic sentence count by duration (方案 B): `n = round(duration / prompt_target_segment_duration)`
-- [x] New preset field `prompt_target_segment_duration` (douyin=3.3s, mainstream=5.0s, bilibili=7.5s)
-- [x] max_chars corrected based on R5b real TTS data (3.8 chars/sec): mainstream 18→22, bilibili 22→32
-- [x] `script_target_count` metadata for debugging (distinguishes requested vs actual count)
-- [x] L2 automated E2E smoke tests: CI-runnable pipeline contract verification
-- [x] CI smoke assertions for preset sentence count (R4 regression guard)
+- [x] EP8 VisionCaptioner abstraction (`vision/` package; stub + `http_vlm` OpenAI-compatible provider)
+- [x] EP9 pause/resume (`--pause-at` + `mn resume` + `pipeline_state.json` serialization)
+- [x] Contract layer (`contract.py` — stable API boundary between web_api and core engine)
+- [x] Stage E productization (CLI match summary + RS-07/08/09 render fixes)
 
-### v0.4.26 Stage E + Effect Uplift + EP8/EP9
-
-> 3 PRs landed (#83, #84, #85). Completes Stage E productization (E.5 CLI summary + RS-07/08/09 render fixes), Effect Portfolio EP2/EP4/EP5/EP6, EP8 VisionCaptioner abstraction, and EP9 human-in-the-loop pause/resume.
-
-- [x] **E.5 CLI match summary** — one-line match summary at pipeline end (segments, emb/heur ratio, score, degradation) (#83)
-- [x] **RS-07/08/09 render fixes** — segment duration floor, mux timeout whitelist, tmp directory cleanup (#83)
-- [x] **EP4 hook templates & set pieces** — genre-appropriate hook sentence templates + named-scene injection into beats (#84)
-- [x] **EP2 beat time anchor** — structured beats with `act` + `approx_ratio`, time-anchored heuristic matching (#84)
-- [x] **EP5 title card overlay** — `render_title_card_sec` with centered movie name + fade in/out (#84)
-- [x] **EP6 duck curve & loudnorm** — proportional duck depth + RMS-based loudness normalization (#84)
-- [x] **EP8 VisionCaptioner abstraction** — `vision/` package with ABC + stub + factory; stub labels flagged as fake (#85)
-- [x] **EP9 pause/resume** — `--pause-at` CLI + `mn resume` + `pipeline_state.json` serialization (#85)
-- [x] **5 new params** — `vision_captioner`, `bgm_loudnorm`, `hook_templates`, `set_pieces`, `render_title_card_sec` (4-file whitelist sync) (#83, #84, #85)
-- [x] **39 new tests** — 15 vision + 24 pause/resume (#85)
-- [x] **EP5 remaining** — cover.jpg export (V6) + vertical safe area presets (V5) (#87)
-- [x] **L2+ hand test** — verify EP2/EP4/EP5/EP6 effect on G1/G2 samples (#86)
-
-### v0.4.27 EP5 Completion + L2+ Hand-Test Materials
-
-> 2 PRs landed (#86, #87). Completes EP5 (cover.jpg export + vertical safe area for 9:16) and ships L2+ hand-test toolkit (checklist + run comparison script + SOP). Last checkpoint before L2 real-film validation gate.
-
-- [x] **Cover.jpg export** — `render_cover_export` exports highest-score frame with movie title overlay; non-blocking on failure (#87)
-- [x] **Vertical safe area** — `render_vertical_safe_area` auto-tightens subtitle margins for 9:16 (bottom_margin ≥ 0.15, max_width ≤ 0.82) (#87)
-- [x] **5-file param sync** — `render_cover_export` + `render_vertical_safe_area` across schema/base/load/merge/runner (#87)
-- [x] **Preset injection** — `douyin-fast` and `bilibili-long` enable cover export + vertical safe area by default (#87)
-- [x] **21 new tests** — cover logic, vertical clamping, preset injection, whitelist coverage (#87)
-- [x] **L2+ checklist** — EP-specific objective gates + subjective bonus items (#86)
-- [x] **Run comparison tool** — `compare_runs.py` for metadata.json A/B diff (#86)
-- [x] **L2+ SOP** — step-by-step execution procedure with pass/fail criteria (#86)
-
-### v0.4.25 Contract Layer — Stable API Boundary
-
-> 1 PR landed (#82). Introduces `contract.py` as the single import surface between web_api and the core engine. Formalizes implicit `Context` duck-typing via `PipelineResult` protocol. Prepares the natural package boundary for future repository split.
-
-- [x] **`contract.py`** — re-exports 13 symbols (BaseConsole, Console, SilentConsole, PipelineCancelled, PipelineStrictError, RunController, StepAction, check_cancelled, PARAM_WHITELIST, build_context, run_pipeline, sanitize_filename) from 4 internal modules (#82)
-- [x] **`PipelineResult` protocol** — `runtime_checkable` Protocol formalizing 5 Context attributes (video_path, audio_path, clips_dir, output_dir, subtitle_paths) previously duck-typed by web_api (#82)
-- [x] **web_api import unification** — console.py, tasks.py, utils.py, form.py all import from `..contract` instead of reaching into internal modules (#82)
-- [x] **18 new contract tests** — re-export identity, __all__ completeness, protocol satisfaction, import isolation (#82)
-
-### v0.4.24 EP3 — Top-K Rerank + L2 Cross-Movie Validation
-
-> 2 PRs landed (#80, #81). EP3 top-K rerank with order-backtrack reuse penalty replaces top-1 embedding assignment, letting unused lower-ranked scenes win over recently-used top-1. L2 exit §12.2 §1 achieved with G1 + G2 cross-movie validation.
-
-- [x] **EP3 top-K rerank** — `_greedy_topk_assign()` + `_cosine_topk()` (O(n) argpartition), reuse penalty for recently used scenes (#80)
-- [x] **`MatchedClip.source` expanded** — `"embedding_topk"` / `"embedding_top1"` added to Literal type (#80)
-- [x] **2 new params** — `match_topk` (default 5) + `match_topk_reuse_penalty` (default 0.15), 4-file whitelist sync (#80)
-- [x] **EP3 audit fields** — `match_summary.topk.{k, reuse_penalty, topk_count, top1_count}` + `source_counts.{embedding_topk, embedding_top1}` (#80)
-- [x] **9 new EP3 tests** — reuse penalty swap, top-1 mode, zero-penalty, audit fields, `_cosine_topk` + `_greedy_topk_assign` unit tests (#80)
-- [x] **L2 G2 hand-test passed** — 西虹市首富 (4.45 GB comedy): `embedding_topk=18/18`, `qa_report.ok=true`, `degraded_reason=null` (#81)
-
-### v0.4.23 Performance Contract Closure
-
-> 1 PR landed (#79). Closes §13.2 performance contract group (ST-07/08/09 + AQ-07) + §13.3 audit cleanup (MS-10/AQ-10, AQ-08/ST-10 verified).
-
-- [x] **ST-07 TTS cache atomic write** — `.partial` → `os.replace()`, corrupt cache auto-recovery (#79)
-- [x] **ST-08 style_prompt in TTSCacheKey** — replaces `pause_ms`, schema version 2 → 3 (#79)
-- [x] **ST-09 Phase1 max_tokens scaling** — `max(research_max_tokens, target_count * 60)` prevents truncation (#79)
-- [x] **AQ-07 duck_bgm numpy rewrite** — O(n²) → O(n), 300s ~53s → <2s (#79)
-- [x] **MS-10 min_score comment** — "丢弃" → "回退 heuristic" (#79)
-- [x] **AQ-10 bgm_error metadata** — `mix_bgm` failure writes `ctx.metadata["bgm_error"]` (#79)
-- [x] **AQ-08 empty ASR status** — verified already `skipped`, not `success`
-- [x] **ST-10 CI mock segments** — verified dynamic `range(n)`, not fixed
-
-### v0.4.22 EP1 — Act-Weighted Timeline Partitioning
-
-> 1 PR landed (#78). Highest-value visual quality improvement in Stage D: transforms match from flat proportional mapping to dramatic four-act pacing.
-
-- [x] **EP1 act-weighted match** — `match_timeline_mode="weighted_acts"` partitions scenes into 4 time buckets, allocates segments by weight `[0.15, 0.25, 0.40, 0.20]` (#78)
-- [x] **3 match helpers** — `_partition_scenes_by_act` / `_assign_segments_to_acts` / `_get_act_candidate_indices` (#78)
-- [x] **Heuristic + embedding act-constrained** — both paths restrict candidates to act bucket ± overflow (#78)
-- [x] **Timeline audit** — `match_summary.timeline.{mode, act_weights, segments_per_act}` (#78)
-- [x] **O(n²) → O(n) optimization** — pre-computed `act_seg_map` dict (#78)
-- [x] **18 new tests** — 3 unit classes + 6 integration tests, 495 total passed (#78)
-- [x] **User code review passed** — gating, fallbacks, whitelist sync, fancy indexing safety
-
-### v0.4.21 Stage D Remaining — Pause Feedback + Tail Protection + Draft Profile
-
-> 1 PR landed (#77). Completes WP5 (duration feedback), ST-06 (tail trim), WP7 (draft profile). AQ-02 verified already implemented.
-
-- [x] **WP5 duration pause feedback** — auto-reduce pause_ms when narration exceeds target by >15%, write `duration_metrics` audit (#77)
-- [x] **ST-06 tail climax protection** — `_trim_segments` locks last segment in addition to first 3 hooks (#77)
-- [x] **WP7 draft profile** — `render_profile: draft` overrides crf=28/preset=ultrafast for fast iteration (#77)
-- [x] **AQ-02 soft-step degraded** — verified F3 patch already covers soft-step catch path, no change needed
-- [x] **Full test suite verified** — 499 passed, 1 skipped, 0 failed (user-verified)
-
-### v0.4.20 Stage D Quality Consolidation
-
-> 8 PRs landed in this release (#69–#76). Focus: visual quality guardrails (WP3 diversity, WP5 truncation), system stability (WP4 footage coverage, AQ-04 audio normalization), audit visibility (swaps_log, script_truncated), param whitelist sync, and test isolation fixes.
-
-- [x] **WP3 diversity post-processing** — `_apply_diversity()` with sliding-window scene reuse limit (`match_diversity_window` + `match_max_scene_reuse`) (#70)
-- [x] **WP5 max_chars hard truncation** — `_truncate_to_max_chars()` enforces `prompt_max_chars_per_sentence` after LLM expansion, preferring punctuation breaks (#70)
-- [x] **WP4 footage coverage gate** — `metadata.footage_coverage.ratio` + warn-only `_degraded_steps` flag when coverage below `render_min_footage_coverage` (#69)
-- [x] **AQ-04 `ensure_final_audio()`** — unified BGM normalization across all 4 exit points, idempotent guard (#69)
-- [x] **WP3 swaps_log audit** — `match_summary.diversity.swaps_log` records each swap `{segment_index, old_scene, new_scene}` (#71)
-- [x] **WP5 truncation audit** — `metadata.script_truncated` records `{count, max_chars, details}` (#71)
-- [x] **Param whitelist sync** — 12 params realigned across `schema.py` / `merge.py` / `load.py` / `runner.py` (#72)
-- [x] **Test isolation fixes** — `.env` pollution (`_env_file=None`), faster_whisper probe patching (dual `_align_backend.probe`), lru_cache settings clear (#73, #74, #76)
-- [x] **Audit integration tests** — 4 CI tests replacing 50-min handtest, verify swaps_log trigger + script_truncated schema (#75)
-- [x] **L2+ hand-test passed** — PR #72 whitelist + PR #71 audit schema verified end-to-end (2026-07-23)
-
-### v0.4.19 faster-whisper Backend + L2 Hand-Test Passed
-
-> 6 PRs landed in this release. Focus: resolve WhisperX CPU compatibility blocker with environment-adaptive faster-whisper backend, unlock O10 (embedding_ratio > 0), close L2 hand-test.
-
-- [x] **faster-whisper backend** with `select_align_backend()` — environment-adaptive: GPU/Linux CPU → whisperx (word-level), Windows CPU → faster_whisper (no k2-fsa dependency)
-- [x] **`align_backend` param** in `job.yaml` for explicit override
-- [x] **match.py faster-whisper fallback** — second WhisperX call site (`_transcribe_video_audio`) also gets faster-whisper, unlocking O10
-- [x] **`_remap_segments()` + `_detect_drift()` extraction** — eliminates ~45 lines of duplicated code between WhisperX and faster-whisper paths
-- [x] **`status.align` semantics documented** — `success` for faster-whisper (not `failed`), `align_fallback` flag carries segment-level signal
-- [x] **CI trigger fix** — feature/hotfix pushes no longer trigger CI (only main + PR), eliminating duplicate runs
-- [x] **`collect_artifacts` clips** — per-segment `.mp4` clips now in artifact list
-- [x] **3 stale remote branches deleted** — `feature/core-engine-production-quality`, `feature/docs-sync-with-code`, `release/v0.4.11`
-- [x] **L2 hand-test passed** — O1-O10 100% achieved (G1 满江红 + G3 飞驰人生3, `embedding_ratio=1.00`, `degraded_steps=[]`)
-
-### v0.4.18 Core Engine Hardening (L2-ready observability + degradation visibility)
-
-> 8 PRs landed in this release. Focus: make degradation visible instead of silent, harden the match/align boundaries, surface F4 / C1 / MS-* bugs as metadata for L2 hand-tests.
-
-- [x] **`match_summary` full schema (21 fields + 4 back-compat)** in `metadata.json` for L2 O9/O10 jq queries
-- [x] **`align_backward_skipped` metadata** — segments that kept TTS estimates because the monotonic clamp would have crushed them to 100ms (F4)
-- [x] **Runner `_degraded_steps` for non-exception paths** — soft steps that catch exceptions and set `status='failed'` + `step_state.result=WARNING` (e.g. `align_fallback`) now appear in the CLI summary
-- [x] **CI concurrency**: stale runs cancelled on PR amend + force-push; main pushes run to completion
-- [x] **`docs/ARCHITECTURE.md`**: canonical `match_summary` schema table
-- [x] **C1**: `align_fallback` now sets `status.align='failed'` (was silently `'success'`)
-- [x] **F4**: align backward-jump >50% of original duration → keep TTS estimate, don't clamp to 100ms
-- [x] **MS-01**: 0-scene `ContentDetector` fallback synthesizes one full-length Scene + `scene_detection_degraded`
-- [x] **MS-02**: fake caption detection via explicit `is_fake` flag (no more `label.startswith("scene ")` heuristic)
-- [x] **AQ-01**: single-segment WhisperX with drift >50% is rejected
-- [x] **AQ-05**: `volume_unknown` fail-closed when `volumedetect` fails
-- [x] **M1**: align comment corrected to reflect F3 runner upgrade (not `_degraded_steps`)
-- [x] **B3**: 100ms segment floor rationale documented
-- [x] **B5**: silent `try/except: pass` blocks now `console.debug()` (scenes.py + runner.py)
-
-### v0.4 Environment variables
+### Environment Variables
 
 - `MN_TTS_PROVIDER` — `edge` (default), `openai`, or `mimo`
 - `MN_DEFAULT_VOICE` — Default voice identifier for the selected TTS provider; each provider interprets this string (Edge: `zh-CN-YunxiNeural`, OpenAI: `alloy`, MiMo: voice name / file path / description depending on model)
@@ -323,26 +134,15 @@ The Web UI is rebuilt from a Gradio single-file app into a decoupled **FastAPI +
 - `MN_MIMO_BASE_URL` — MiMo base URL (default `https://api.xiaomimimo.com/v1`)
 - `MN_MIMO_STYLE_PROMPT` — Style description for `mimo-v2.5-tts` user message (default empty)
 
-### v0.4.7 env/yaml boundary (config system overhaul)
+### Config boundary (`.env` / `job.yaml`)
 
-Strict separation: `.env` contains ONLY LLM + TTS infrastructure (24 fields); `job.yaml` contains ALL pipeline behavior (48 params).
+Strict separation: `.env` contains ONLY LLM + TTS infrastructure (24 fields); `job.yaml` contains ALL pipeline behavior (48+ params). See [`.env.example`](../.env.example) and [`job.example.yaml`](../examples/job.example.yaml) as single sources of truth.
 
-**`.env` (Settings) — 24 fields:** See [`.env.example`](../.env.example)
+**`.env` (Settings) — 24 fields:**
 - LLM (14): `MN_LLM_BASE_URL`, `MN_LLM_API_KEY`, `MN_LLM_MODEL`, `MN_LLM_TIMEOUT`, `MN_SCRIPT_TEMPERATURE`, `MN_SCRIPT_EXPAND_TEMPERATURE`, `MN_SCRIPT_MAX_TOKENS`, `MN_SCRIPT_RETRIES`, `MN_SCRIPT_RETRY_DELAY`, `MN_RESEARCH_TEMPERATURE`, `MN_RESEARCH_MAX_TOKENS`, `MN_RESEARCH_RETRIES`, `MN_RESEARCH_RETRY_DELAY`, `MN_TRANSLATE_MAX_TOKENS`
 - TTS (10): `MN_DEFAULT_VOICE`, `MN_TTS_PROVIDER`, `MN_TTS_CACHE_MAX_MB`, `MN_OPENAI_TTS_*`(3), `MN_MIMO_*`(4)
 
-**`job.yaml` (params) — 48 keys:** See [`job.example.yaml`](../examples/job.example.yaml)
-- Scene: `scene_threshold`, `scene_frame_skip`
-- Match: `match_min_score`, `match_speed_clamp_min/max`, `scene_merge_min_duration`, `match_drop_scene_min_duration`, `embedding_model_name`
-- BGM: `bgm_gain_db`, `bgm_duck_db`, `bgm_normalize`, `audio_target_dbfs`
-- TTS pacing: `tts_pause_ms`, `tts_max_concurrent`, `tts_audio_format`, `tts_audio_bitrate`
-- Translate: `translate_source_lang`, `translate_provider`, `translate_retries`, `translate_chunk_chars`, `translate_chunk_size`
-- Research: `research_provider`
-- WhisperX: `whisperx_device/model/language`
-- Render: `render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout`, `render_fit_mode/crf/preset/faststart`, `render_subtitle_position/max_width_ratio/bottom_margin_ratio`
-- QA: `qa_enabled`, `qa_max_silence_db`, `qa_min_duration_ratio`, `qa_max_duration_ratio`
-- Async: `async_timeout`, `async_max_workers`
-- Video: `video_sizes`
+**`job.yaml` (params) — 48+ keys:** See [`job.example.yaml`](../examples/job.example.yaml) for the full list (Scene, Match, BGM, TTS pacing, Translate, Research, WhisperX, Render, QA, Async, Video sizes, Prompt shaping, Effect portfolio, Vision).
 
 ### Provider env-var naming convention
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,6 +3,8 @@
 
 # Roadmap
 
+> Per-release details in [CHANGELOG.md](../CHANGELOG.md). Configuration reference in [`.env.example`](../.env.example) and [`job.example.yaml`](../examples/job.example.yaml).
+
 ## v0.1.x — Core Pipeline
 
 - [x] CLI interface (`mn create`, `mn version`)
@@ -24,28 +26,7 @@
 - [x] Background music integration (BGM mixing)
 - [x] Script markdown export (`script.md`)
 - [x] Scene-level clip output (`clips/`)
-
-### New CLI flags (v0.2)
-
-- `--video` — Source movie file path
-- `--library-dir` — Movie library directory
-- `--research` / `--no-research` — Toggle plot research
-- `--bgm` — Background music file
-- `--no-bgm` — Disable BGM
-- `--no-clips` — Skip clip export
-- `--strict` — Abort on soft step failure
-
-### Extras install
-
-```bash
-pip install "movie-narrator[media]"  # scenedetect
-pip install "movie-narrator[ml]"     # whisperx + sentence-transformers
-pip install "movie-narrator[full]"   # everything
-```
-
-### Graceful degradation
-
-Soft pipeline steps (research, align, scene detect, scene match, BGM, clip export) skip silently when optional dependencies are missing. Pipeline continues end-to-end. Use `--strict` to fail instead.
+- [x] Graceful degradation — soft steps skip silently when optional deps missing
 
 ## v0.3.x — Platform & Workflow
 
@@ -53,108 +34,66 @@ Soft pipeline steps (research, align, scene detect, scene match, BGM, clip expor
 - [x] YAML-based job configuration (`mn create --config`)
 - [x] Console / structured-step-state logging refactor (`ctx.services.console`, `StepState`)
 - [x] Multi-language subtitle support (`--subtitle-lang` / `--subtitle-mode`; LLM translation with retry-then-soft-degrade; three-file SRT output)
-- [x] Web UI (Gradio local browser app via `mn web`; requires `[web]` extra) — *superseded by the FastAPI + React refactor in v0.4.x, see below*
-
-### v0.3 New CLI flags
-
-- `--subtitle-lang` — Target language tag (`en`, `ja`, `zh-TW`, ...); empty = feature off
-- `--subtitle-mode` — Overlay mode: `original` / `translated` / `bilingual` (default `original`)
+- [x] Web UI (Gradio; superseded by v0.4.x FastAPI + React refactor)
 
 ## v0.4.x — TTS Abstraction & Infrastructure
 
-> 28 patch releases (v0.4.0 – v0.4.27). Major themes: TTS provider abstraction, config system overhaul, WebUI refactor (Gradio → FastAPI + React), core engine production quality, L2 readiness & hand-test passed, match intelligence (EP1/EP2/EP3), effect portfolio (EP4/EP5/EP6), extensibility (EP8/EP9), and contract layer. Per-release details in [CHANGELOG.md](../CHANGELOG.md).
+> 28 patch releases (v0.4.0 – v0.4.27). Major themes: TTS provider abstraction, config system overhaul, WebUI refactor, core engine production quality, L2 readiness & hand-test passed, match intelligence, effect portfolio, extensibility, contract layer.
 
 ### Infrastructure
 
-- [x] TTS provider abstraction (`TTSProvider` protocol; Edge / OpenAI / MiMo providers)
-- [x] Provider selection via `MN_TTS_PROVIDER` (`edge` / `openai` / `mimo`)
-- [x] Cache key upgrade (sha256, 7 dimensions, two-level fan-out, per-provider version map)
-- [x] Config system overhaul — strict `.env` / `job.yaml` boundary (24 infra fields / 48+ pipeline params)
+- [x] TTS provider abstraction (Edge / OpenAI / MiMo via `MN_TTS_PROVIDER`)
+- [x] Content-addressable cache (sha256, 7 dimensions, per-provider version map)
+- [x] Config system overhaul — strict `.env` / `job.yaml` boundary
 - [x] MoviePy 1.x → 2.x upgrade (Python 3.13+ compatibility)
 - [x] Preflight LLM/TTS validation before pipeline execution
 - [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
-- [x] Auto-create `~/.movie-narrator/.env` on first run
 
 ### Web UI
 
-- [x] Gradio → FastAPI + React SPA refactor (`web_api/` package, Vite + TypeScript + shadcn/ui)
-- [x] WebSocket real-time progress (`/ws/jobs/{id}` streams `Console.snapshot()`)
+- [x] Gradio → FastAPI + React SPA refactor (Vite + TypeScript + shadcn/ui)
+- [x] WebSocket real-time progress (`/ws/jobs/{id}`)
 - [x] pip-installable WebUI packaging (SPA bundled in wheel)
-- [x] Legacy Gradio `web/` package removed
 
 ### Core Engine Quality
 
-- [x] Post-render deliverable QA step (`validate_deliverable` — ffprobe + ffmpeg fallback)
+- [x] Post-render deliverable QA step (`validate_deliverable`)
 - [x] Audio normalize + BGM ducking with attack/release smoothing
 - [x] Video cover/contain layout; bottom-safe subtitle layout (CJK wrapping + backdrop bar)
 - [x] Render encode quality — CRF 18, preset `slow`, `+faststart`
-- [x] Narration preset system (3 built-in: `douyin-fast`, `mainstream-dry`, `bilibili-long`)
-- [x] Two-phase script generation (beats → expansion) with dynamic sentence count
-- [x] Performance contract closure (TTS cache atomic write, style_prompt in cache key, numpy duck rewrite)
+- [x] Narration preset system (`douyin-fast` / `mainstream-dry` / `bilibili-long`)
+- [x] Two-phase script generation with dynamic sentence count
+- [x] Draft profile mode for fast iteration (`render_profile: draft`)
 
 ### L2 Readiness & Validation
 
 - [x] `match_summary` full schema (21+ fields) in `metadata.json` for L2 jq queries
 - [x] Degradation visibility — `_degraded_steps` + CLI summary for all soft-step failures
-- [x] faster-whisper backend (Windows CPU compatibility; unlocks embedding re-rank without WhisperX)
-- [x] L2 hand-test passed — O1-O10 100% (G1 满江红 + G3 飞驰人生3, `embedding_ratio=1.00`, `degraded_steps=[]`)
-- [x] L2 G2 cross-movie validation — 西虹市首富 (`embedding_topk=18/18`, `qa_report.ok=true`, `degraded_reason=null`)
+- [x] faster-whisper backend (Windows CPU compatibility; unlocks embedding re-rank)
+- [x] L2 hand-test passed — O1-O10 100% (G1 满江红 + G3 飞驰人生3)
+- [x] L2 G2 cross-movie validation — 西虹市首富
 - [x] L2+ hand-test toolkit (checklist + `compare_runs.py` + SOP)
 
 ### Match Intelligence
 
-- [x] EP1 act-weighted timeline partitioning (4-act dramatic pacing, `match_timeline_mode="weighted_acts"`)
-- [x] EP3 top-K rerank with order-backtrack reuse penalty (`match_topk` + `match_topk_reuse_penalty`)
-- [x] EP2 beat time anchor (structured beats with `act` + `approx_ratio`, time-anchored heuristic)
+- [x] EP1 act-weighted timeline partitioning (4-act dramatic pacing)
+- [x] EP3 top-K rerank with order-backtrack reuse penalty
+- [x] EP2 beat time anchor (structured beats with `act` + `approx_ratio`)
 - [x] Diversity post-processing (sliding-window scene reuse limit)
-- [x] Footage coverage gate (warn-only when below `render_min_footage_coverage`)
+- [x] Footage coverage gate (warn-only when below threshold)
 
 ### Effect Portfolio
 
 - [x] EP4 hook templates & set pieces (genre-appropriate scroll-stoppers + named-scene injection)
-- [x] EP5 title card overlay + cover.jpg export + vertical safe area (9:16 subtitle margin tightening)
+- [x] EP5 title card + cover.jpg export + vertical safe area (9:16 subtitle margin tightening)
 - [x] EP6 duck curve & RMS-based loudness normalization
 
 ### Extensibility & Pipeline
 
 - [x] EP8 VisionCaptioner abstraction (`vision/` package; stub + `http_vlm` OpenAI-compatible provider)
-- [x] EP9 pause/resume (`--pause-at` + `mn resume` + `pipeline_state.json` serialization)
+- [x] EP9 pause/resume (`--pause-at` + `mn resume` + `pipeline_state.json`)
 - [x] Contract layer (`contract.py` — stable API boundary between web_api and core engine)
 - [x] Stage E productization (CLI match summary + RS-07/08/09 render fixes)
-
-### Environment Variables
-
-- `MN_TTS_PROVIDER` — `edge` (default), `openai`, or `mimo`
-- `MN_DEFAULT_VOICE` — Default voice identifier for the selected TTS provider; each provider interprets this string (Edge: `zh-CN-YunxiNeural`, OpenAI: `alloy`, MiMo: voice name / file path / description depending on model)
-- `MN_OPENAI_TTS_MODEL` — OpenAI TTS model (default `tts-1`)
-- `MN_OPENAI_TTS_API_KEY` — OpenAI TTS API key (falls back to `MN_LLM_API_KEY`)
-- `MN_OPENAI_TTS_BASE_URL` — OpenAI TTS base URL (falls back to `MN_LLM_BASE_URL`)
-- `MN_MIMO_TTS_MODEL` — MiMo TTS model (default `mimo-v2.5-tts`; also `mimo-v2.5-tts-voiceclone`, `mimo-v2.5-tts-voicedesign`)
-- `MN_MIMO_API_KEY` — MiMo API key (falls back to `MN_LLM_API_KEY`)
-- `MN_MIMO_BASE_URL` — MiMo base URL (default `https://api.xiaomimimo.com/v1`)
-- `MN_MIMO_STYLE_PROMPT` — Style description for `mimo-v2.5-tts` user message (default empty)
-
-### Config boundary (`.env` / `job.yaml`)
-
-Strict separation: `.env` contains ONLY LLM + TTS infrastructure (24 fields); `job.yaml` contains ALL pipeline behavior (48+ params). See [`.env.example`](../.env.example) and [`job.example.yaml`](../examples/job.example.yaml) as single sources of truth.
-
-**`.env` (Settings) — 24 fields:**
-- LLM (14): `MN_LLM_BASE_URL`, `MN_LLM_API_KEY`, `MN_LLM_MODEL`, `MN_LLM_TIMEOUT`, `MN_SCRIPT_TEMPERATURE`, `MN_SCRIPT_EXPAND_TEMPERATURE`, `MN_SCRIPT_MAX_TOKENS`, `MN_SCRIPT_RETRIES`, `MN_SCRIPT_RETRY_DELAY`, `MN_RESEARCH_TEMPERATURE`, `MN_RESEARCH_MAX_TOKENS`, `MN_RESEARCH_RETRIES`, `MN_RESEARCH_RETRY_DELAY`, `MN_TRANSLATE_MAX_TOKENS`
-- TTS (10): `MN_DEFAULT_VOICE`, `MN_TTS_PROVIDER`, `MN_TTS_CACHE_MAX_MB`, `MN_OPENAI_TTS_*`(3), `MN_MIMO_*`(4)
-
-**`job.yaml` (params) — 48+ keys:** See [`job.example.yaml`](../examples/job.example.yaml) for the full list (Scene, Match, BGM, TTS pacing, Translate, Research, WhisperX, Render, QA, Async, Video sizes, Prompt shaping, Effect portfolio, Vision).
-
-### Provider env-var naming convention
-
-Future TTS providers (Azure, ElevenLabs, FishAudio, CosyVoice, ...) follow a uniform pattern:
-
-```
-MN_<PROVIDER>_TTS_MODEL   — model name
-MN_<PROVIDER>_API_KEY     — API key (falls back to MN_LLM_API_KEY)
-MN_<PROVIDER>_BASE_URL    — base URL (provider-specific default)
-```
-
-Provider-specific extras (e.g. `MN_MIMO_STYLE_PROMPT`) are appended as needed.
 
 ## v0.5.x — Ecosystem
 

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -53,151 +53,76 @@ pip install "movie-narrator[full]"   # 全装
 - [x] 基于 YAML 的 job 配置（`mn create --config`）
 - [x] 控制台 / 结构化步骤状态日志重构（`ctx.services.console`、`StepState`）
 - [x] 多语言字幕支持（`--subtitle-lang` / `--subtitle-mode`；LLM 翻译，重试 → 软降级；三文件 SRT 输出）
-- [x] Web UI（Gradio 本地浏览器应用，通过 `mn web` 启动；需 `[web]` extra）—— *在 v0.4.10 由 FastAPI + React 重构后取代，见下文*
+- [x] Web UI（Gradio 本地浏览器应用，通过 `mn web` 启动；需 `[web]` extra）—— *在 v0.4.x 由 FastAPI + React 重构后取代，见下文*
 
 ### v0.3 新增 CLI 标志
 
 - `--subtitle-lang` —— 目标语言标签（`en`、`ja`、`zh-TW`……）；留空 = 功能关闭
 - `--subtitle-mode` —— 叠加模式：`original` / `translated` / `bilingual`（默认 `original`）
 
-### v0.3.5 Web UI（Gradio —— 已弃用）
-
-- `mn web` —— 启动本地 Gradio 浏览器应用（需要 `pip install "movie-narrator[web]"`）
-- 步骤边界上协作式取消（UI 中的 Cancel 按钮）
-- 表单字段与 CLI 选项一一对应；高级参数遵循「空字段不覆盖」规则（直接使用 Settings 默认）
-- 上传文件落到 `mn_web_*` 临时目录，避免污染 `output/`
-
-> **注意**：这个基于 Gradio 的 Web UI 是 **legacy 状态**，在 **v0.4.10** 被 FastAPI + React 重构取代（见下文 *v0.4.10 WebUI Refactor*）。`web/` 包在 **v0.4.12** 中从仓库删除。
-
 ## v0.4.x — TTS 抽象与基础设施
 
-- [x] TTS provider 抽象（`TTSProvider` protocol、`BaseTTSProvider`、`EdgeTTSProvider`、`OpenAITTSProvider`、`MimoTTSProvider`）
+> 28 个 patch 版本（v0.4.0 – v0.4.27）。主线：TTS provider 抽象、配置体系重做、WebUI 重构（Gradio → FastAPI + React）、核心引擎生产级质量、L2 就绪并通过手测、匹配智能（EP1/EP2/EP3）、效果组合（EP4/EP5/EP6）、可扩展性（EP8/EP9）、契约层。逐版本明细见 [CHANGELOG.md](../CHANGELOG.md)。
+
+### 基础设施
+
+- [x] TTS provider 抽象（`TTSProvider` protocol；Edge / OpenAI / MiMo 三个 provider）
 - [x] 通过 `MN_TTS_PROVIDER` 选择 provider（`edge` / `openai` / `mimo`）
-- [x] OpenAI TTS 支持（通过 `asyncio.to_thread` 包装同步 SDK；voice 白名单；凭据回退到 `MN_LLM_API_KEY`）
-- [x] MiMo TTS 支持（3 种模型：命名声、声音克隆、声音设计；wav→mp3 转码；style prompt）
 - [x] 缓存键升级（sha256，7 维，两级扇出，按 provider 版本表）
-- [x] CI 临时文件隔离（静音文件永不进入缓存）
-- [x] `is_ci()`：CI 检测的唯一真理源
-- [x] `ConfigError`：横切配置错误类
+- [x] 配置体系重做 —— 严格的 `.env` / `job.yaml` 边界（24 个基础设施字段 / 48+ 个流水线参数）
 - [x] MoviePy 1.x → 2.x 升级（兼容 Python 3.13+）
 - [x] 流水线执行前的 LLM/TTS Preflight 校验
 - [x] 步骤级重试机制（`--retry` 标志、`StepAction` 枚举）
 - [x] 首次运行自动创建 `~/.movie-narrator/.env`
-- [x] `export_clips` 直接调用 ffmpeg 子进程（设计选择）
 
-### v0.4.7 配置体系重做
+### Web UI
 
-- [x] 严格的 env/yaml 边界：`.env` 仅含 24 个 LLM + TTS 基础设施字段；`job.yaml` 含 48 个流水线行为参数
-- [x] YAML 自动发现：未传 `--config` → `cwd/job.yaml` → 打包内 example → 缺省
-- [x] `.env.example` 与 `job.example.yaml` 作为唯一真理源（无代码常量模块）
-- [x] 48 个 YAML 参数完整接入 `runner.py` → `ctx.metadata` → 流水线步骤
-- [x] 修复 `translate_chunk_chars/size` 静默忽略的 bug（未被拷贝到 `ctx.metadata`）
-- [x] 修复 `export_clips` 编解码硬编码（现使用 `ctx.metadata` → 内联字面值）
-- [x] 修复 `scene_frame_skip` 在 runner 拷贝循环中缺失
+- [x] Gradio → FastAPI + React SPA 重构（`web_api/` 包，Vite + TypeScript + shadcn/ui）
+- [x] WebSocket 实时进度推送（`/ws/jobs/{id}` 流式推送 `Console.snapshot()`）
+- [x] pip 可安装的 WebUI 打包（SPA 打入 wheel）
+- [x] 移除 legacy Gradio `web/` 包
 
-### v0.4.10 WebUI Refactor
+### 核心引擎质量
 
-Web UI 由 Gradio 单文件应用重构成解耦的 **FastAPI + React SPA** 栈。legacy `web/`（Gradio）包在 v0.4.12 从仓库删除。
+- [x] 渲染后产物 QA 步骤（`validate_deliverable` —— ffprobe + ffmpeg 回退）
+- [x] 音频归一化 + BGM ducking（带 attack/release 平滑的窗口化包络）
+- [x] 视频 cover/contain 布局；底部安全字幕布局（CJK 换行 + 半透明衬底条）
+- [x] 渲染编码质量 —— CRF 18、preset `slow`、`+faststart`
+- [x] 解说预设系统（3 个内置预设：`douyin-fast`、`mainstream-dry`、`bilibili-long`）
+- [x] 两段式解说稿生成（节拍 → 展开），按时长动态决定句数
+- [x] 性能合约收尾（TTS 缓存原子写入、style_prompt 入缓存键、duck_bgm numpy 重写）
 
-- [x] **FastAPI 后端** —— 新增 `src/movie_narrator/web_api/` 包（11 个模块：`server.py`、`routes.py`、`ws.py`、`tasks.py`、`console.py`、`controller.py`、`form.py`、`models.py`、`utils.py`、`__init__.py`）
-- [x] **React 18 SPA** —— 新增 `webui/` 工程（Vite + TypeScript）；FastAPI 直接把构建产物作为静态资源托管，因此 `mn web` 是单进程
-- [x] **WebSocket 实时进度** —— `/ws/jobs/{id}` 推送 `Console.snapshot()` + status 增量；取代旧的 200ms Gradio 轮询 generator
-- [x] **`[web]` extra 变更** —— 去掉 `gradio`；改为 `fastapi` + `uvicorn` + `python-multipart`
-- [x] **`mn web` 端口** —— 从 `7860`（Gradio 默认）改为 `8760`
-- [x] **前端技术栈** —— Vite + TypeScript + shadcn/ui + Tailwind CSS
+### L2 就绪与验证
 
-### v0.4.11 WebUI packaging（pip-installable）
+- [x] `metadata.json` 中的 `match_summary` 完整 schema（21+ 字段），供 L2 jq 查询
+- [x] 降级可见性 —— `_degraded_steps` + CLI 摘要覆盖所有软步骤失败
+- [x] faster-whisper 后端（Windows CPU 兼容；无需 WhisperX 即可启用 embedding re-rank）
+- [x] L2 手测通过 —— O1-O10 100%（G1 满江红 + G3 飞驰人生3，`embedding_ratio=1.00`，`degraded_steps=[]`）
+- [x] L2 G2 跨片验证 —— 西虹市首富（`embedding_topk=18/18`，`qa_report.ok=true`，`degraded_reason=null`）
+- [x] L2+ 手测工具包（checklist + `compare_runs.py` + SOP）
 
-> `v0.4.10` 在 git 中带上了重写，但 PyPI wheel 缺了 SPA。**0.4.11** 堵上了这个洞。
+### 匹配智能
 
-- [x] Vite `outDir` → `src/movie_narrator/web_api/static/`；package-data 声明 `static/**`
-- [x] `server.py` 部署相对包内 `static/`（`pip install` 后也能工作）
-- [x] 跟踪 `webui/package.json` + `package-lock.json` + `tsconfig.json`（根 `*.json` 的 gitignore 例外）
-- [x] CI `webui` 任务 + Publish 阶段的 `npm ci && npm run build`（在 `python -m build` 之前）
-- [x] Publish 阶段确认 wheel 包含 `static/index.html` + hashed JS/CSS
+- [x] EP1 幕加权时间线分区（四幕戏剧化节奏，`match_timeline_mode="weighted_acts"`）
+- [x] EP3 top-K 重排，带顺序回溯复用惩罚（`match_topk` + `match_topk_reuse_penalty`）
+- [x] EP2 节拍时间锚（结构化 beats 带 `act` + `approx_ratio`，时间锚定启发式匹配）
+- [x] 多样性后处理（滑动窗口场景复用限制）
+- [x] 素材覆盖率门控（低于 `render_min_footage_coverage` 时仅告警）
 
-> 请求 / WebSocket 流和 `web_api/` 模块表见 `docs/ARCHITECTURE.md` → *Web UI Layer*。
+### 效果组合
 
-### v0.4.12 删除 legacy Gradio
+- [x] EP4 钩子模板与名场面注入（按类型的开场钩子句 + 命名场景注入 beats）
+- [x] EP5 标题卡叠加 + cover.jpg 导出 + 竖屏安全区（9:16 字幕边距收紧）
+- [x] EP6 duck 曲线 + 基于 RMS 的响度归一化
 
-- [x] 删除 `src/movie_narrator/web/`（9 个文件）
-- [x] 从 `[full]` extra 移除 `gradio`
-- [x] 迁移测试：`test_web_form.py` → `web_api.form`，`test_pipeline_cancel.py` → `TaskController`
-- [x] 删除 `test_web_console.py`、`test_web_controller.py`（已被 `test_web_api.py` 覆盖）
+### 可扩展性与流水线
 
-### v0.4.13 核心引擎生产级质量
+- [x] EP8 VisionCaptioner 抽象（`vision/` 包；stub + `http_vlm` OpenAI 兼容 provider）
+- [x] EP9 暂停/恢复（`--pause-at` + `mn resume` + `pipeline_state.json` 序列化）
+- [x] 契约层（`contract.py` —— web_api 与核心引擎之间的稳定 API 边界）
+- [x] Stage E 产品化（CLI 匹配摘要 + RS-07/08/09 渲染修复）
 
-- [x] 渲染后产物 QA 步骤（`validate_deliverable`）—— `render_video` 之后的硬步骤；ffprobe + ffmpeg 回退；CI 默认跳过，本地默认启用
-- [x] 音频归一化 + BGM ducking（`utils/audio_mix.py`）—— 带 attack/release 平滑的窗口化包络；跳过路径会对解说做归一化
-- [x] 视频 cover/contain 布局（`utils/video_layout.py`）—— 源素材适配画布；render 默认 `cover`
-- [x] 底部安全字幕布局 —— `text_image.create_text_image` 支持 CJK 换行 + 省略号；render 始终绘制叠加层（默认在底部）
-- [x] 产物 QA 探测（`utils/deliverable_qa.py`）—— 结构化 `QAReport` / `QAIssue`
-- [x] Match 默认收紧 —— 速度因子截断 0.85–1.25，merge 2.0s，丢弃 <0.4s 的微小 scene
-- [x] Render 编码质量 —— CRF 18、preset `slow`、`+faststart`
-- [x] 接入 15 个新 `JobParams` 字段（render fit/encode/subtitle、BGM duck/normalize、QA、match drop）—— 实际列表：render_fit_mode、render_crf、render_preset、render_faststart、render_subtitle_position、render_subtitle_max_width_ratio、render_subtitle_bottom_margin_ratio、qa_enabled、qa_max_silence_db、qa_min_duration_ratio、qa_max_duration_ratio、match_drop_scene_min_duration、bgm_duck_db、bgm_normalize、audio_target_dbfs
-- [x] 流水线 14 → 15 步骤；前端 `PIPELINE_STEPS` / `STEP_LABELS` 同步更新
-
-### v0.4.14 可发布的底部字幕
-
-- [x] 底部字幕文本下方的半透明黑色衬底（65% alpha、16px/12px padding），匹配短视频解说风格
-- [x] 更粗的描边（2px → 4px）以增强在亮色画面上的可读性
-- [x] Bug 修复：空折行列表早返回；通过 `textbbox` 重新测量每行高度
-- [x] Linux CI 字体度量跨平台测试阈值（60% → 50%）
-
-### v0.4.15 解说预设系统（Stage 0.5）
-
-- [x] 可插拔 `Preset` Protocol，含封闭词汇校验（`ALLOWED_PARAM_KEYS` + `ALLOWED_PROMPT_TAGS`）
-- [x] 三个内置预设：`douyin-fast`（默认）、`mainstream-dry`、`bilibili-long`
-- [x] CLI `--narration-preset` / `-p` 标志 + `mn preset` 的 list/show 子命令
-- [x] YAML 顶层字段 `narration_preset` + Web API 的 `FormData.narration_preset`
-- [x] 通过封闭词汇标签塑造 prompt（节律 / 语域 / 连词）
-- [x] `PARAM_WHITELIST` 冻结集（runner.py）作为唯一来源 —— 消除双份维护的白名单
-- [x] 手测验证：prompt 标签能产生可感知的风格差异
-- [x] v0.4.16 中修复已知局限：两段式生成严格按 `prompt_target_sentences` 执行
-- [ ] Stage 2（未来）：通过 `entry_points` SPI 发现 + opt-in 本地目录扫描
-
-### v0.4.16 两段式解说稿生成 + CLI/配置改进
-
-- [x] 两段式解说稿生成：阶段 1（剧情节拍，低温） → 阶段 2（展开，中温） → 回退 trim
-- [x] `prompt_target_sentences` 现在真正生效（v0.4.15 中 LLM 实际忽略）
-- [x] 首次运行配置提示：`ensure_user_config()` 向 stderr 打印一次性消息
-- [x] CLI 帮助：`no_args_is_help=True`、`rich_markup_mode="rich"`、中英双语 `--help`
-- [x] 解决 `-h` 冲突（`web` 命令的 `--host` 不再占用 `-h`）
-- [x] 阶段 1 过滤 None/空节拍 + 阶段 2 过滤空文本
-- [x] TTS 单段重试（3 次）—— 单段失败不再拖垮整批
-- [x] 资料步骤重试（之前零次重试，现对齐 `script.py` 模式）
-- [x] 降级提示：`SOFT_STEP_CONSEQUENCES` + 流水线末尾摘要
-- [x] 重试失败的调试日志
-
-### v0.4.17 动态句数 + L2 E2E 测试
-
-- [x] 按时长动态决定句数（方案 B）：`n = round(duration / prompt_target_segment_duration)`
-- [x] 新增预设字段 `prompt_target_segment_duration`（douyin=3.3s、mainstream=5.0s、bilibili=7.5s）
-- [x] 根据 R5b 真实 TTS 数据（3.8 字 / 秒）修正 max_chars：mainstream 18→22，bilibili 22→32
-- [x] `script_target_count` 元数据用于调试（区分请求数与实际数）
-- [x] L2 自动化 E2E smoke test：可在 CI 跑的流水线合约验证
-- [x] CI smoke 断言预设句数（R4 回归防护）
-
-### v0.4.18 核心引擎硬化（L2 级可观测性 + 降级可见性）
-
-> 本版本合计 8 个 PR。重心：把降级从「沉默」变为「可见」，硬化 match/align 边界，把 F4 / C1 / MS-* 等 bug 通过 metadata 暴露给 L2 手测。
-
-- [x] `metadata.json` 中的 **`match_summary` 完整 schema（21 字段 + 4 向后兼容）**，供 L2 O9/O10 的 jq 查询
-- [x] **`align_backward_skipped` 元数据** —— 因单调截断会被压成 100ms 而沿用 TTS 估计的段数（F4）
-- [x] **Runner `_degraded_steps` 支持非异常路径** —— 内部 try/except 并设置 `status='failed'` + `step_state.result=WARNING` 的软步骤（例如 `align_fallback`）现在会出现在 CLI 摘要中
-- [x] **CI 并发控制**：PR 的 amend + force-push 时取消旧 run；main 分支 push 时跑到底
-- [x] **`docs/ARCHITECTURE.md`**：规范的 `match_summary` schema 表
-- [x] **C1**：`align_fallback` 现在设置 `status.align='failed'`（之前静默 `'success'`）
-- [x] **F4**：align backward-jump 超过原时长 50% 时保留 TTS 估计，不再被截断为 100ms
-- [x] **MS-01**：`ContentDetector` 返回 0 scene 时回退为单个全时长 Scene，并标记 `scene_detection_degraded`
-- [x] **MS-02**：通过显式 `is_fake` 标志检测 fake caption（不再依赖脆弱的 `label.startswith("scene ")` 字符串启发式）
-- [x] **AQ-01**：单段 WhisperX 输出且时长漂移 >50% 时被拒绝
-- [x] **AQ-05**：`volumedetect` 失败时 `volume_unknown` 走 fail-closed
-- [x] **M1**：align 注释修正以反映 F3 runner 升级（而非 `_degraded_steps`）
-- [x] **B3**：100ms 段长下界的原理被记录
-- [x] **B5**：静默 `try/except: pass` 块现在 `console.debug()`（scenes.py + runner.py）
-
-### v0.4 环境变量
+### 环境变量
 
 - `MN_TTS_PROVIDER` —— `edge`（默认）、`openai` 或 `mimo`
 - `MN_DEFAULT_VOICE` —— 所选 TTS provider 的默认语音标识；各 provider 自行解释该字符串（Edge：`zh-CN-YunxiNeural`，OpenAI：`alloy`，MiMo：视模型为 名字 / 文件路径 / 描述）
@@ -209,26 +134,15 @@ Web UI 由 Gradio 单文件应用重构成解耦的 **FastAPI + React SPA** 栈�
 - `MN_MIMO_BASE_URL` —— MiMo base URL（默认 `https://api.xiaomimimo.com/v1`）
 - `MN_MIMO_STYLE_PROMPT` —— `mimo-v2.5-tts` user message 的风格描述（默认空）
 
-### v0.4.7 env/yaml 边界（配置体系重做）
+### 配置边界（`.env` / `job.yaml`）
 
-严格切分：`.env` 仅含 LLM + TTS 基础设施（24 字段）；`job.yaml` 含全部流水线行为（48 参数）。
+严格切分：`.env` 仅含 LLM + TTS 基础设施（24 字段）；`job.yaml` 含全部流水线行为（48+ 参数）。以 [`.env.example`](../.env.example) 和 [`job.example.yaml`](../examples/job.example.yaml) 为唯一真理源。
 
-**`.env`（Settings）—— 24 字段：** 见 [`.env.example`](../.env.example)
+**`.env`（Settings）—— 24 字段：**
 - LLM（14）：`MN_LLM_BASE_URL`、`MN_LLM_API_KEY`、`MN_LLM_MODEL`、`MN_LLM_TIMEOUT`、`MN_SCRIPT_TEMPERATURE`、`MN_SCRIPT_EXPAND_TEMPERATURE`、`MN_SCRIPT_MAX_TOKENS`、`MN_SCRIPT_RETRIES`、`MN_SCRIPT_RETRY_DELAY`、`MN_RESEARCH_TEMPERATURE`、`MN_RESEARCH_MAX_TOKENS`、`MN_RESEARCH_RETRIES`、`MN_RESEARCH_RETRY_DELAY`、`MN_TRANSLATE_MAX_TOKENS`
 - TTS（10）：`MN_DEFAULT_VOICE`、`MN_TTS_PROVIDER`、`MN_TTS_CACHE_MAX_MB`、`MN_OPENAI_TTS_*`（3 个）、`MN_MIMO_*`（4 个）
 
-**`job.yaml`（params）—— 48 键：** 见 [`job.example.yaml`](../examples/job.example.yaml)
-- Scene：`scene_threshold`、`scene_frame_skip`
-- Match：`match_min_score`、`match_speed_clamp_min/max`、`scene_merge_min_duration`、`match_drop_scene_min_duration`、`embedding_model_name`
-- BGM：`bgm_gain_db`、`bgm_duck_db`、`bgm_normalize`、`audio_target_dbfs`
-- TTS pacing：`tts_pause_ms`、`tts_max_concurrent`、`tts_audio_format`、`tts_audio_bitrate`
-- Translate：`translate_source_lang`、`translate_provider`、`translate_retries`、`translate_chunk_chars`、`translate_chunk_size`
-- Research：`research_provider`
-- WhisperX：`whisperx_device/model/language`
-- Render：`render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout`、`render_fit_mode/crf/preset/faststart`、`render_subtitle_position/max_width_ratio/bottom_margin_ratio`
-- QA：`qa_enabled`、`qa_max_silence_db`、`qa_min_duration_ratio`、`qa_max_duration_ratio`
-- Async：`async_timeout`、`async_max_workers`
-- Video：`video_sizes`
+**`job.yaml`（params）—— 48+ 键：** 见 [`job.example.yaml`](../examples/job.example.yaml) 完整列表（Scene、Match、BGM、TTS pacing、Translate、Research、WhisperX、Render、QA、Async、Video sizes、Prompt shaping、Effect portfolio、Vision）。
 
 ### Provider 环境变量命名约定
 

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -3,6 +3,8 @@
 
 # 路线图
 
+> 逐版本明细见 [CHANGELOG.md](../CHANGELOG.md)。配置参考见 [`.env.example`](../.env.example) 和 [`job.example.yaml`](../examples/job.example.yaml)。
+
 ## v0.1.x — 核心流水线
 
 - [x] CLI 接口（`mn create`、`mn version`）
@@ -24,28 +26,7 @@
 - [x] 背景音乐（BGM）混音
 - [x] 解说稿 markdown 导出（`script.md`）
 - [x] 场景级片段输出（`clips/`）
-
-### v0.2 新增 CLI 标志
-
-- `--video` —— 源影片路径
-- `--library-dir` —— 影片库目录
-- `--research` / `--no-research` —— 切换是否启用剧情资料
-- `--bgm` —— 背景音乐文件
-- `--no-bgm` —— 关闭 BGM
-- `--no-clips` —— 跳过片段导出
-- `--strict` —— 软步骤失败即终止
-
-### Extras 安装
-
-```bash
-pip install "movie-narrator[media]"  # scenedetect
-pip install "movie-narrator[ml]"     # whisperx + sentence-transformers
-pip install "movie-narrator[full]"   # 全装
-```
-
-### 优雅降级
-
-软步骤（资料、对齐、场景检测、场景匹配、BGM、片段导出）在可选依赖缺失时会静默跳过。流水线仍能跑完整链路。改用 `--strict` 可让失败时终止。
+- [x] 优雅降级 —— 可选依赖缺失时软步骤静默跳过
 
 ## v0.3.x — 平台与工作流
 
@@ -53,108 +34,66 @@ pip install "movie-narrator[full]"   # 全装
 - [x] 基于 YAML 的 job 配置（`mn create --config`）
 - [x] 控制台 / 结构化步骤状态日志重构（`ctx.services.console`、`StepState`）
 - [x] 多语言字幕支持（`--subtitle-lang` / `--subtitle-mode`；LLM 翻译，重试 → 软降级；三文件 SRT 输出）
-- [x] Web UI（Gradio 本地浏览器应用，通过 `mn web` 启动；需 `[web]` extra）—— *在 v0.4.x 由 FastAPI + React 重构后取代，见下文*
-
-### v0.3 新增 CLI 标志
-
-- `--subtitle-lang` —— 目标语言标签（`en`、`ja`、`zh-TW`……）；留空 = 功能关闭
-- `--subtitle-mode` —— 叠加模式：`original` / `translated` / `bilingual`（默认 `original`）
+- [x] Web UI（Gradio；在 v0.4.x 由 FastAPI + React 重构后取代）
 
 ## v0.4.x — TTS 抽象与基础设施
 
-> 28 个 patch 版本（v0.4.0 – v0.4.27）。主线：TTS provider 抽象、配置体系重做、WebUI 重构（Gradio → FastAPI + React）、核心引擎生产级质量、L2 就绪并通过手测、匹配智能（EP1/EP2/EP3）、效果组合（EP4/EP5/EP6）、可扩展性（EP8/EP9）、契约层。逐版本明细见 [CHANGELOG.md](../CHANGELOG.md)。
+> 28 个 patch 版本（v0.4.0 – v0.4.27）。主线：TTS provider 抽象、配置体系重做、WebUI 重构、核心引擎生产级质量、L2 就绪并通过手测、匹配智能、效果组合、可扩展性、契约层。
 
 ### 基础设施
 
-- [x] TTS provider 抽象（`TTSProvider` protocol；Edge / OpenAI / MiMo 三个 provider）
-- [x] 通过 `MN_TTS_PROVIDER` 选择 provider（`edge` / `openai` / `mimo`）
-- [x] 缓存键升级（sha256，7 维，两级扇出，按 provider 版本表）
-- [x] 配置体系重做 —— 严格的 `.env` / `job.yaml` 边界（24 个基础设施字段 / 48+ 个流水线参数）
+- [x] TTS provider 抽象（Edge / OpenAI / MiMo，通过 `MN_TTS_PROVIDER` 选择）
+- [x] 内容寻址缓存（sha256，7 维，按 provider 版本表）
+- [x] 配置体系重做 —— 严格的 `.env` / `job.yaml` 边界
 - [x] MoviePy 1.x → 2.x 升级（兼容 Python 3.13+）
 - [x] 流水线执行前的 LLM/TTS Preflight 校验
 - [x] 步骤级重试机制（`--retry` 标志、`StepAction` 枚举）
-- [x] 首次运行自动创建 `~/.movie-narrator/.env`
 
 ### Web UI
 
-- [x] Gradio → FastAPI + React SPA 重构（`web_api/` 包，Vite + TypeScript + shadcn/ui）
-- [x] WebSocket 实时进度推送（`/ws/jobs/{id}` 流式推送 `Console.snapshot()`）
+- [x] Gradio → FastAPI + React SPA 重构（Vite + TypeScript + shadcn/ui）
+- [x] WebSocket 实时进度推送（`/ws/jobs/{id}`）
 - [x] pip 可安装的 WebUI 打包（SPA 打入 wheel）
-- [x] 移除 legacy Gradio `web/` 包
 
 ### 核心引擎质量
 
-- [x] 渲染后产物 QA 步骤（`validate_deliverable` —— ffprobe + ffmpeg 回退）
-- [x] 音频归一化 + BGM ducking（带 attack/release 平滑的窗口化包络）
+- [x] 渲染后产物 QA 步骤（`validate_deliverable`）
+- [x] 音频归一化 + BGM ducking（带 attack/release 平滑）
 - [x] 视频 cover/contain 布局；底部安全字幕布局（CJK 换行 + 半透明衬底条）
 - [x] 渲染编码质量 —— CRF 18、preset `slow`、`+faststart`
-- [x] 解说预设系统（3 个内置预设：`douyin-fast`、`mainstream-dry`、`bilibili-long`）
-- [x] 两段式解说稿生成（节拍 → 展开），按时长动态决定句数
-- [x] 性能合约收尾（TTS 缓存原子写入、style_prompt 入缓存键、duck_bgm numpy 重写）
+- [x] 解说预设系统（`douyin-fast` / `mainstream-dry` / `bilibili-long`）
+- [x] 两段式解说稿生成，按时长动态决定句数
+- [x] 草稿模式快速迭代（`render_profile: draft`）
 
 ### L2 就绪与验证
 
 - [x] `metadata.json` 中的 `match_summary` 完整 schema（21+ 字段），供 L2 jq 查询
 - [x] 降级可见性 —— `_degraded_steps` + CLI 摘要覆盖所有软步骤失败
-- [x] faster-whisper 后端（Windows CPU 兼容；无需 WhisperX 即可启用 embedding re-rank）
-- [x] L2 手测通过 —— O1-O10 100%（G1 满江红 + G3 飞驰人生3，`embedding_ratio=1.00`，`degraded_steps=[]`）
-- [x] L2 G2 跨片验证 —— 西虹市首富（`embedding_topk=18/18`，`qa_report.ok=true`，`degraded_reason=null`）
+- [x] faster-whisper 后端（Windows CPU 兼容；解锁 embedding re-rank）
+- [x] L2 手测通过 —— O1-O10 100%（G1 满江红 + G3 飞驰人生3）
+- [x] L2 G2 跨片验证 —— 西虹市首富
 - [x] L2+ 手测工具包（checklist + `compare_runs.py` + SOP）
 
 ### 匹配智能
 
-- [x] EP1 幕加权时间线分区（四幕戏剧化节奏，`match_timeline_mode="weighted_acts"`）
-- [x] EP3 top-K 重排，带顺序回溯复用惩罚（`match_topk` + `match_topk_reuse_penalty`）
-- [x] EP2 节拍时间锚（结构化 beats 带 `act` + `approx_ratio`，时间锚定启发式匹配）
+- [x] EP1 幕加权时间线分区（四幕戏剧化节奏）
+- [x] EP3 top-K 重排，带顺序回溯复用惩罚
+- [x] EP2 节拍时间锚（结构化 beats 带 `act` + `approx_ratio`）
 - [x] 多样性后处理（滑动窗口场景复用限制）
-- [x] 素材覆盖率门控（低于 `render_min_footage_coverage` 时仅告警）
+- [x] 素材覆盖率门控（低于阈值时仅告警）
 
 ### 效果组合
 
 - [x] EP4 钩子模板与名场面注入（按类型的开场钩子句 + 命名场景注入 beats）
-- [x] EP5 标题卡叠加 + cover.jpg 导出 + 竖屏安全区（9:16 字幕边距收紧）
+- [x] EP5 标题卡 + cover.jpg 导出 + 竖屏安全区（9:16 字幕边距收紧）
 - [x] EP6 duck 曲线 + 基于 RMS 的响度归一化
 
 ### 可扩展性与流水线
 
 - [x] EP8 VisionCaptioner 抽象（`vision/` 包；stub + `http_vlm` OpenAI 兼容 provider）
-- [x] EP9 暂停/恢复（`--pause-at` + `mn resume` + `pipeline_state.json` 序列化）
+- [x] EP9 暂停/恢复（`--pause-at` + `mn resume` + `pipeline_state.json`）
 - [x] 契约层（`contract.py` —— web_api 与核心引擎之间的稳定 API 边界）
 - [x] Stage E 产品化（CLI 匹配摘要 + RS-07/08/09 渲染修复）
-
-### 环境变量
-
-- `MN_TTS_PROVIDER` —— `edge`（默认）、`openai` 或 `mimo`
-- `MN_DEFAULT_VOICE` —— 所选 TTS provider 的默认语音标识；各 provider 自行解释该字符串（Edge：`zh-CN-YunxiNeural`，OpenAI：`alloy`，MiMo：视模型为 名字 / 文件路径 / 描述）
-- `MN_OPENAI_TTS_MODEL` —— OpenAI TTS 模型（默认 `tts-1`）
-- `MN_OPENAI_TTS_API_KEY` —— OpenAI TTS API key（回退到 `MN_LLM_API_KEY`）
-- `MN_OPENAI_TTS_BASE_URL` —— OpenAI TTS base URL（回退到 `MN_LLM_BASE_URL`）
-- `MN_MIMO_TTS_MODEL` —— MiMo TTS 模型（默认 `mimo-v2.5-tts`；亦可为 `mimo-v2.5-tts-voiceclone`、`mimo-v2.5-tts-voicedesign`）
-- `MN_MIMO_API_KEY` —— MiMo API key（回退到 `MN_LLM_API_KEY`）
-- `MN_MIMO_BASE_URL` —— MiMo base URL（默认 `https://api.xiaomimimo.com/v1`）
-- `MN_MIMO_STYLE_PROMPT` —— `mimo-v2.5-tts` user message 的风格描述（默认空）
-
-### 配置边界（`.env` / `job.yaml`）
-
-严格切分：`.env` 仅含 LLM + TTS 基础设施（24 字段）；`job.yaml` 含全部流水线行为（48+ 参数）。以 [`.env.example`](../.env.example) 和 [`job.example.yaml`](../examples/job.example.yaml) 为唯一真理源。
-
-**`.env`（Settings）—— 24 字段：**
-- LLM（14）：`MN_LLM_BASE_URL`、`MN_LLM_API_KEY`、`MN_LLM_MODEL`、`MN_LLM_TIMEOUT`、`MN_SCRIPT_TEMPERATURE`、`MN_SCRIPT_EXPAND_TEMPERATURE`、`MN_SCRIPT_MAX_TOKENS`、`MN_SCRIPT_RETRIES`、`MN_SCRIPT_RETRY_DELAY`、`MN_RESEARCH_TEMPERATURE`、`MN_RESEARCH_MAX_TOKENS`、`MN_RESEARCH_RETRIES`、`MN_RESEARCH_RETRY_DELAY`、`MN_TRANSLATE_MAX_TOKENS`
-- TTS（10）：`MN_DEFAULT_VOICE`、`MN_TTS_PROVIDER`、`MN_TTS_CACHE_MAX_MB`、`MN_OPENAI_TTS_*`（3 个）、`MN_MIMO_*`（4 个）
-
-**`job.yaml`（params）—— 48+ 键：** 见 [`job.example.yaml`](../examples/job.example.yaml) 完整列表（Scene、Match、BGM、TTS pacing、Translate、Research、WhisperX、Render、QA、Async、Video sizes、Prompt shaping、Effect portfolio、Vision）。
-
-### Provider 环境变量命名约定
-
-未来新增的 TTS provider（Azure、ElevenLabs、FishAudio、CosyVoice……）遵循统一模式：
-
-```
-MN_<PROVIDER>_TTS_MODEL   —— 模型名
-MN_<PROVIDER>_API_KEY     —— API key（回退到 MN_LLM_API_KEY）
-MN_<PROVIDER>_BASE_URL    —— base URL（视 provider 有不同默认值）
-```
-
-Provider 特定的扩展（例如 `MN_MIMO_STYLE_PROMPT`）按需追加。
 
 ## v0.5.x — 生态
 


### PR DESCRIPTION
## Changes

Both \ROADMAP.md\ (EN) and \ROADMAP.zh-CN.md\ (ZH) restructured:

**Before:** Each patch release (v0.4.7, v0.4.10, v0.4.11, ..., v0.4.27) had its own \### v0.4.XX\ section with detailed bullets — 20+ sub-sections, 376 lines (EN) / 263 lines (ZH, stuck at v0.4.18).

**After:** Single \## v0.4.x\ section organized by theme:
- Infrastructure
- Web UI
- Core Engine Quality
- L2 Readiness & Validation
- Match Intelligence
- Effect Portfolio
- Extensibility & Pipeline
- Environment Variables (reference)
- Config boundary (reference)

Per-release details remain in CHANGELOG.md. ROADMAP now shows WHAT was built at the major-version level; CHANGELOG shows the per-release details.

**Stats:** EN 376→129 lines, ZH 263→129 lines (now parallel). ZH updated to v0.4.27 (was v0.4.18).