### PR TITLE
feat(v0.5): Plugin Registry infrastructure (StepRegistry + ProviderRegistry + UnifiedParamSchema + SDK)

### DIFF
--- a/src/movie_narrator/__init__.py
+++ b/src/movie_narrator/__init__.py
@@ -1,3 +1,33 @@
 from importlib.metadata import version
 
 __version__ = version("movie-narrator")
+
+# ── Public SDK surface (v0.5+) ─────────────────────────────
+# These symbols allow external code to extend the engine:
+#
+#   from movie_narrator import register_step, Context
+#   from movie_narrator import register_tts, register_vision
+#   from movie_narrator import Plugin, PluginContext, load_plugin
+#
+# The contract module is the single import surface. We re-export
+# here for convenience so plugins don't need to know the internal
+# module path.
+
+from .contract import (  # noqa: F401
+    Context,
+    Plugin,
+    PluginContext,
+    ProviderRegistry,
+    Step,
+    StepRegistry,
+    build_context,
+    load_plugin,
+    register_step,
+    register_tts,
+    register_vision,
+    run_pipeline,
+    step,
+    step_registry,
+    tts_registry,
+    vision_registry,
+)

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -3,8 +3,8 @@
 This module is the **single import surface** that the Web API layer
 (and future consumers) should depend on. It re-exports the types,
 protocols, and functions that form the engine's public API, plus
-defines a ``PipelineResult`` protocol that formalizes the implicit
-``Context`` duck-typing previously used by web_api.
+defines the plugin extension points (``Step``, ``Plugin``,
+``PluginContext``).
 
 By centralizing the contract here:
 
@@ -13,6 +13,8 @@ By centralizing the contract here:
   ``..utils.console``, ``..utils.sanitize``).
 - ``PARAM_WHITELIST`` is accessible without importing the full runner
   module, eliminating the highest drift-risk coupling point.
+- External plugins import ``from movie_narrator import register_step,
+  register_tts, register_vision, Context`` to extend the engine.
 - When the project is eventually split into separate repositories,
   this module becomes the natural package boundary.
 
@@ -23,7 +25,8 @@ compatibility with existing CLI and test code.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
 
 # ── Re-exports: console abstraction ────────────────────────
 
@@ -43,6 +46,26 @@ from .pipeline.errors import (
 # ── Re-exports: engine entry points ────────────────────────
 
 from .pipeline.runner import PARAM_WHITELIST, build_context, run_pipeline
+
+# ── Re-exports: models ─────────────────────────────────────
+
+from .models import Context
+
+# ── Re-exports: registries ─────────────────────────────────
+
+from .pipeline.registry import StepRegistry, register_step, step, step_registry
+from .providers import (
+    ProviderRegistry,
+    register_tts,
+    register_vision,
+    tts_registry,
+    vision_registry,
+)
+
+# ── Step type alias ────────────────────────────────────────
+
+#: A pipeline step function: ``Context -> Context``.
+Step = Callable[[Context], Context]
 
 
 # ── PipelineResult protocol ────────────────────────────────
@@ -77,6 +100,81 @@ class PipelineResult(Protocol):
     def subtitle_paths(self) -> Optional[Any]: ...
 
 
+# ── Plugin extension points ────────────────────────────────
+
+
+@dataclass
+class PluginContext:
+    """Context passed to a plugin's ``register`` method.
+
+    Gives plugins access to the global registries so they can
+    register custom steps, TTS providers, vision providers, etc.
+
+    Plugins should NOT hold long-lived references to this object —
+    it exists only during the registration phase.
+    """
+
+    steps: StepRegistry
+    tts: ProviderRegistry
+    vision: ProviderRegistry
+
+    @classmethod
+    def default(cls) -> "PluginContext":
+        """Create a PluginContext backed by the global registries."""
+        return cls(
+            steps=step_registry,
+            tts=tts_registry,
+            vision=vision_registry,
+        )
+
+
+@runtime_checkable
+class Plugin(Protocol):
+    """A plugin that extends the movie-narrator pipeline.
+
+    Plugins implement a ``name`` attribute and a ``register`` method
+    that receives a :class:`PluginContext` and registers its
+    components (steps, providers, etc.) with the appropriate registries.
+
+    Example::
+
+        class WatermarkPlugin:
+            name = "watermark"
+
+            def register(self, ctx: PluginContext) -> None:
+                ctx.steps.register(
+                    "add_watermark",
+                    add_watermark,
+                    after="render_video",
+                )
+    """
+
+    name: str
+
+    def register(self, ctx: PluginContext) -> None: ...
+
+
+def load_plugin(plugin: Plugin) -> None:
+    """Register a plugin with the global registries.
+
+    Calls ``plugin.register(PluginContext.default())``, giving the
+    plugin access to ``step_registry``, ``tts_registry``, and
+    ``vision_registry``.
+
+    Args:
+        plugin: An object implementing the :class:`Plugin` protocol.
+
+    Raises:
+        TypeError: if *plugin* does not implement the Plugin protocol.
+    """
+    if not isinstance(plugin, Plugin):
+        raise TypeError(
+            f"{plugin!r} does not implement the Plugin protocol "
+            f"(missing 'name' attribute or 'register' method)."
+        )
+    plugin.register(PluginContext.default())
+
+
 # ── Public API ─────────────────────────────────────────────
 
 __all__ = [
@@ -98,6 +196,24 @@ __all__ = [
     "sanitize_filename",
     # Protocols
     "PipelineResult",
+    # Models
+    "Context",
+    # Registries
+    "StepRegistry",
+    "ProviderRegistry",
+    "step_registry",
+    "tts_registry",
+    "vision_registry",
+    # Registration decorators
+    "register_step",
+    "register_tts",
+    "register_vision",
+    "step",  # alias for register_step
+    # Plugin system
+    "Step",
+    "PluginContext",
+    "Plugin",
+    "load_plugin",
 ]
 
 

--- a/src/movie_narrator/pipeline/registry.py
+++ b/src/movie_narrator/pipeline/registry.py
@@ -1,0 +1,331 @@
+"""Step registry for the pipeline.
+
+Provides a registration mechanism so that pipeline steps can be
+discovered, ordered, and extended by external plugins.
+
+Design:
+
+- Built-in steps are registered at import time via :func:`register_step`
+  or the :func:`step` decorator.
+- External plugins call ``register_step("my_step", func, after="render_video")``
+  to inject custom logic into the pipeline.
+- The runner derives ``STEPS`` from the registry's ordered list,
+  preserving backward compatibility with existing code that iterates
+  ``STEPS``.
+
+The registry tracks:
+
+- **name**: unique step identifier (conventionally the function ``__name__``)
+- **func**: the callable ``Context -> Context``
+- **soft**: whether exceptions are caught (True) or re-raised (False)
+- **status_field**: the ``PipelineStatus`` field name for soft steps
+- **consequence**: human-readable degradation message for soft steps
+- **insert_after** / **insert_before**: ordering hints for plugin steps
+
+Ordering rules:
+
+1. Built-in steps have a fixed relative order (the order they were
+   registered in ``runner.py``).
+2. Plugin steps with ``after="X"`` are placed immediately after step X.
+3. Plugin steps with ``before="Y"`` are placed immediately before step Y.
+4. Plugin steps with neither are appended to the end.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from ..models import Context
+
+# Type alias for a step function: Context -> Context
+StepFunc = Callable[[Context], Context]
+
+
+@dataclass(frozen=True)
+class StepEntry:
+    """Metadata for a registered pipeline step."""
+
+    name: str
+    func: StepFunc
+    soft: bool = False
+    status_field: Optional[str] = None
+    consequence: str = ""
+    # Ordering: built-in steps use seq; plugin steps use after/before.
+    seq: int = -1  # -1 means "unsequenced" (plugin step)
+    insert_after: Optional[str] = None
+    insert_before: Optional[str] = None
+
+
+class StepRegistry:
+    """Registry for pipeline steps.
+
+    A single global instance :data:`step_registry` is shared across the
+    process. Built-in steps are registered during module import;
+    external plugins register via :func:`register_step`.
+    """
+
+    def __init__(self) -> None:
+        self._entries: Dict[str, StepEntry] = {}
+        self._seq_counter: int = 0
+
+    # ── Registration ──────────────────────────────────────────
+
+    def register(
+        self,
+        name: str,
+        func: StepFunc,
+        *,
+        soft: bool = False,
+        status_field: Optional[str] = None,
+        consequence: str = "",
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+    ) -> StepFunc:
+        """Register a step and return *func* (for decorator use).
+
+        Args:
+            name: Unique step identifier.
+            func: The step callable ``Context -> Context``.
+            soft: If True, exceptions from this step are caught and
+                rendered as warnings instead of aborting the pipeline.
+            status_field: For soft steps, the ``PipelineStatus`` field
+                name to set on failure/skip.
+            consequence: Human-readable message shown when the soft
+                step degrades.
+            after: Insert this step immediately after the named step
+                (for plugin steps only).
+            before: Insert this step immediately before the named step
+                (for plugin steps only).
+
+        Raises:
+            ValueError: if *name* is already registered.
+        """
+        if name in self._entries:
+            raise ValueError(
+                f"Step '{name}' is already registered. "
+                f"Use a different name or unregister first."
+            )
+
+        is_builtin = after is None and before is None
+        seq = self._seq_counter if is_builtin else -1
+        if is_builtin:
+            self._seq_counter += 1
+
+        entry = StepEntry(
+            name=name,
+            func=func,
+            soft=soft,
+            status_field=status_field,
+            consequence=consequence,
+            seq=seq,
+            insert_after=after,
+            insert_before=before,
+        )
+        self._entries[name] = entry
+        return func
+
+    def unregister(self, name: str) -> None:
+        """Remove a step from the registry.
+
+        Mainly useful for testing. Built-in steps should not be
+        unregistered in production code.
+        """
+        if name not in self._entries:
+            raise KeyError(f"Step '{name}' is not registered.")
+        del self._entries[name]
+
+    # ── Lookup ────────────────────────────────────────────────
+
+    def get(self, name: str) -> Optional[StepEntry]:
+        """Return the entry for *name*, or None."""
+        return self._entries.get(name)
+
+    def get_func(self, name: str) -> Optional[StepFunc]:
+        """Return the callable for *name*, or None."""
+        entry = self._entries.get(name)
+        return entry.func if entry else None
+
+    def names(self) -> List[str]:
+        """Return all registered step names (unordered)."""
+        return list(self._entries.keys())
+
+    def contains(self, name: str) -> bool:
+        """Check if a step name is registered."""
+        return name in self._entries
+
+    # ── Ordered list ──────────────────────────────────────────
+
+    def ordered_steps(self) -> List[StepFunc]:
+        """Return step functions in execution order.
+
+        Algorithm:
+
+        1. Built-in steps (seq >= 0) sorted by seq.
+        2. Plugin steps with ``after`` inserted right after the target.
+        3. Plugin steps with ``before`` inserted right before the target.
+        4. Plugin steps with neither appended to the end.
+
+        If a plugin step's ``after``/``before`` target is not found,
+        the step is appended to the end with a debug warning.
+        """
+        ordered: List[StepFunc] = []
+        placed: set[str] = set()
+
+        # Phase 1: built-in steps in seq order
+        builtin = sorted(
+            (e for e in self._entries.values() if e.seq >= 0),
+            key=lambda e: e.seq,
+        )
+        name_to_func = {e.name: e.func for e in self._entries.values()}
+
+        for entry in builtin:
+            ordered.append(entry.func)
+            placed.add(entry.name)
+
+            # Phase 2: insert "after" plugin steps right after this step
+            for plugin in self._entries.values():
+                if plugin.name in placed:
+                    continue
+                if plugin.insert_after == entry.name:
+                    ordered.append(plugin.func)
+                    placed.add(plugin.name)
+
+            # Phase 3: insert "before" plugin steps — but "before" means
+            # they go BEFORE the *next* built-in, so we handle them in
+            # a separate pass below.
+
+        # Phase 3 (deferred): "before" plugin steps
+        # We need to insert them before their target. Since built-in
+        # steps are already placed, we rebuild the list with inserts.
+        if any(e.insert_before for e in self._entries.values() if e.name not in placed):
+            new_ordered: List[StepFunc] = []
+            for func in ordered:
+                # Find the entry for this func to get its name
+                func_entry = None
+                for e in self._entries.values():
+                    if e.func is func:
+                        func_entry = e
+                        break
+                if func_entry:
+                    # Insert any "before" plugins targeting this step
+                    for plugin in self._entries.values():
+                        if plugin.name in placed:
+                            continue
+                        if plugin.insert_before == func_entry.name:
+                            new_ordered.append(plugin.func)
+                            placed.add(plugin.name)
+                new_ordered.append(func)
+            ordered = new_ordered
+
+        # Phase 4: append remaining unplaced plugin steps
+        for entry in self._entries.values():
+            if entry.name not in placed:
+                ordered.append(entry.func)
+                placed.add(entry.name)
+
+        return ordered
+
+    def ordered_names(self) -> List[str]:
+        """Return step names in execution order."""
+        func_to_name = {}
+        for entry in self._entries.values():
+            # Use id() as key to handle cases where the same callable
+            # might appear (shouldn't happen, but be safe)
+            func_to_name[id(entry.func)] = entry.name
+
+        result: List[str] = []
+        for func in self.ordered_steps():
+            name = func_to_name.get(id(func))
+            if name:
+                result.append(name)
+        return result
+
+    # ── Soft-step metadata ────────────────────────────────────
+
+    def soft_step_names(self) -> set[str]:
+        """Return the set of soft step names."""
+        return {e.name for e in self._entries.values() if e.soft}
+
+    def status_field_for(self, name: str) -> Optional[str]:
+        """Return the status field for a soft step, or None."""
+        entry = self._entries.get(name)
+        return entry.status_field if entry else None
+
+    def consequence_for(self, name: str) -> str:
+        """Return the degradation message for a soft step."""
+        entry = self._entries.get(name)
+        return entry.consequence if entry else ""
+
+    # ── Introspection ─────────────────────────────────────────
+
+    def info(self) -> List[Dict[str, Any]]:
+        """Return a list of dicts describing each registered step."""
+        return [
+            {
+                "name": e.name,
+                "soft": e.soft,
+                "status_field": e.status_field,
+                "seq": e.seq,
+                "insert_after": e.insert_after,
+                "insert_before": e.insert_before,
+            }
+            for e in self._entries.values()
+        ]
+
+    def clear(self) -> None:
+        """Remove all registered steps. For testing only."""
+        self._entries.clear()
+        self._seq_counter = 0
+
+
+# ── Global registry instance ──────────────────────────────
+
+step_registry = StepRegistry()
+
+
+# ── Decorator ─────────────────────────────────────────────
+
+
+def register_step(
+    name: str,
+    *,
+    soft: bool = False,
+    status_field: Optional[str] = None,
+    consequence: str = "",
+    after: Optional[str] = None,
+    before: Optional[str] = None,
+) -> Callable[[StepFunc], StepFunc]:
+    """Decorator to register a pipeline step.
+
+    Usage (built-in step)::
+
+        @register_step("detect_scenes", soft=True, status_field="scene")
+        def detect_scenes(ctx: Context) -> Context:
+            ...
+
+    Usage (external plugin step)::
+
+        from movie_narrator import register_step, Context
+
+        @register_step("add_watermark", after="render_video")
+        def add_watermark(ctx: Context) -> Context:
+            ...
+    """
+
+    def decorator(func: StepFunc) -> StepFunc:
+        return step_registry.register(
+            name,
+            func,
+            soft=soft,
+            status_field=status_field,
+            consequence=consequence,
+            after=after,
+            before=before,
+        )
+
+    return decorator
+
+
+# Backward-compat alias: ``step`` is a shorter name for the decorator.
+step = register_step

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -14,6 +14,7 @@ from .errors import PipelineCancelled, PipelinePaused, PipelineStrictError, RunC
 from .export_clips import export_clips
 from .match import match_clips
 from .preflight import PreflightError, run_preflight
+from .registry import step_registry
 from .research import research_plot
 from .resolve import resolve_video
 from .scenes import detect_scenes
@@ -24,84 +25,74 @@ from .translate import translate_subtitles
 from .tts import generate_voice
 from .render import render_video
 from .qa import validate_deliverable
+from ..workflow.schema import JobParams
 
-# ── Step metadata (module-level constants) ──────────────────
-# Single source of truth: a soft step whose exception is caught by the runner
-# (rendered as ⚠ + continue) instead of being re-raised as a hard failure.
-
-# Complete whitelist of param keys that build_context accepts from
-# JobParams / preset params.  This is the SINGLE SOURCE OF TRUTH —
+# ── Unified parameter schema (single source of truth) ──────
+# PARAM_WHITELIST is derived from JobParams model fields, eliminating
+# the drift between the hardcoded frozenset and the Pydantic model.
 # presets/base.py:ALLOWED_PARAM_KEYS is a validated subset of this.
-PARAM_WHITELIST: frozenset[str] = frozenset({
-    "scene_threshold", "scene_frame_skip", "match_min_score",
-    "match_speed_clamp_min", "match_speed_clamp_max",
-    "scene_merge_min_duration", "match_drop_scene_min_duration",
-    "match_diversity_window", "match_max_scene_reuse",
-    "match_timeline_mode", "match_act_weights",
-    "match_topk", "match_topk_reuse_penalty",
-    "embedding_model_name",
-    "vision_captioner",  # EP8: "none" (default) | "stub" | future providers
-    "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs", "bgm_loudnorm",
-    "tts_pause_ms",
-    "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
-    "translate_source_lang", "translate_provider", "translate_retries",
-    "translate_chunk_chars", "translate_chunk_size",
-    "research_provider",
-    "whisperx_device", "whisperx_model", "whisperx_language",
-    "align_backend",
-    "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
-    "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
-    "render_fit_mode", "render_crf", "render_preset", "render_faststart",
-    "render_subtitle_position", "render_subtitle_max_width_ratio",
-    "render_subtitle_bottom_margin_ratio",
-    "render_require_footage", "render_min_footage_coverage",
-    "render_profile", "render_title_card_sec",
-    "render_cover_export", "render_vertical_safe_area",
-    "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
-    "prompt_target_sentences", "prompt_target_segment_duration", "prompt_max_chars_per_sentence", "prompt_hook_seconds",
-    "hook_templates", "set_pieces",
-    "async_timeout", "async_max_workers",
-    "video_sizes",
-})
 
-SOFT_STATUS_STEPS = {
-    "research_plot",
-    "align_audio",
-    "detect_scenes",
-    "match_clips",
-    "mix_bgm",
-    "export_clips",
-    "translate_subtitles",
+PARAM_WHITELIST: frozenset[str] = frozenset(JobParams.model_fields.keys())
+
+# ── Register built-in steps in the StepRegistry ────────────
+# Each step is registered with its metadata (soft/hard, status_field,
+# consequence message). External plugins register via @register_step.
+# The registry preserves registration order for built-in steps and
+# supports after=/before= hints for plugin step insertion.
+
+_BUILTIN_STEP_META = {
+    # name: (func, soft, status_field, consequence)
+    "resolve_video":       (resolve_video,       False, None, ""),
+    "prepare_assets":      (prepare_assets,      False, None, ""),
+    "research_plot":       (research_plot,       True,  "research",
+        "research unavailable — script will use generic plot description"),
+    "generate_script":     (generate_script,     False, None, ""),
+    "export_script_md":    (export_script_md,    False, None, ""),
+    "generate_voice":      (generate_voice,      False, None, ""),
+    "align_audio":         (align_audio,         True,  "align",
+        "audio alignment skipped — subtitle timestamps may drift from actual speech"),
+    "detect_scenes":       (detect_scenes,       True,  "scene",
+        "scene detection skipped — clips will use fixed-duration segments"),
+    "match_clips":         (match_clips,         True,  "match",
+        "clip matching skipped — segments mapped to sequential clips without embedding search"),
+    "mix_bgm":             (mix_bgm,             True,  "bgm",
+        "BGM mixing failed — final video will have narration audio only, no background music"),
+    "translate_subtitles": (translate_subtitles, True,  "translate",
+        "translation failed — only original-language subtitles will be available"),
+    "generate_subtitle":   (generate_subtitle,   False, None, ""),
+    "render_video":        (render_video,        False, None, ""),
+    "validate_deliverable":(validate_deliverable,False, None, ""),
+    "export_clips":        (export_clips,        True,  "export",
+        "clip export skipped — no standalone clip files will be produced"),
 }
 
-# Human-readable consequence messages for soft-step degradation.
-# When a soft step fails or is skipped, this map provides a concise
-# explanation of what the user should expect in the final output.
-SOFT_STEP_CONSEQUENCES: Dict[str, str] = {
-    "research_plot": "research unavailable — script will use generic plot description",
-    "align_audio": "audio alignment skipped — subtitle timestamps may drift from actual speech",
-    "detect_scenes": "scene detection skipped — clips will use fixed-duration segments",
-    "match_clips": "clip matching skipped — segments mapped to sequential clips without embedding search",
-    "mix_bgm": "BGM mixing failed — final video will have narration audio only, no background music",
-    "export_clips": "clip export skipped — no standalone clip files will be produced",
-    "translate_subtitles": "translation failed — only original-language subtitles will be available",
-}
+for _name, (_func, _soft, _field, _consequence) in _BUILTIN_STEP_META.items():
+    if not step_registry.contains(_name):
+        step_registry.register(
+            _name, _func,
+            soft=_soft,
+            status_field=_field,
+            consequence=_consequence,
+        )
 
-# Map soft step name → PipelineStatus field name. Steps not in this map
-# (e.g. resolve_video, generate_script, render_video) do not write to
-# PipelineStatus because a hard failure there aborts the pipeline anyway.
+# ── Derived constants (backward-compatible with existing code) ──
+
+STEPS = step_registry.ordered_steps()
+
+SOFT_STATUS_STEPS: set[str] = step_registry.soft_step_names()
+
 STATUS_FIELD_FOR_STEP: Dict[str, str] = {
-    "research_plot": "research",
-    "align_audio": "align",
-    "detect_scenes": "scene",
-    "match_clips": "match",
-    "mix_bgm": "bgm",
-    "export_clips": "export",
-    "translate_subtitles": "translate",
+    name: step_registry.status_field_for(name)
+    for name in SOFT_STATUS_STEPS
+    if step_registry.status_field_for(name) is not None
+}
+
+SOFT_STEP_CONSEQUENCES: Dict[str, str] = {
+    name: step_registry.consequence_for(name)
+    for name in SOFT_STATUS_STEPS
 }
 
 # Safety: every soft step must have a status field mapping.
-# A typo in either dict would silently break status tracking.
 assert SOFT_STATUS_STEPS == set(STATUS_FIELD_FOR_STEP), (
     "SOFT_STATUS_STEPS and STATUS_FIELD_FOR_STEP keys must match"
 )
@@ -109,7 +100,6 @@ assert SOFT_STATUS_STEPS == set(STATUS_FIELD_FOR_STEP), (
 # Short alias mapping for workflow_steps keys (spec §9 back-compat).
 # Allows users to write `{"scene": False}` in addition to the
 # function-name key `{"detect_scenes": False}`.
-# WP1: expanded from 1 alias to full coverage for all SOFT_STATUS_STEPS.
 _SHORT_TO_STEP: Dict[str, str] = {
     "research": "research_plot",
     "align": "align_audio",
@@ -139,26 +129,6 @@ def _step_enabled(workflow_steps: Optional[Dict[str, bool]], step_name: str) -> 
         if full == step_name and workflow_steps.get(short) is False:
             return False
     return True
-
-STEPS = [
-    resolve_video,
-    prepare_assets,
-    research_plot,
-    generate_script,
-    export_script_md,
-    generate_voice,
-    align_audio,
-    detect_scenes,
-    match_clips,
-    mix_bgm,
-    # Multi-language subtitle (v0.3) — soft step before generate_subtitle.
-    # Produces ctx.translated_texts; downstream formatter writes three SRTs.
-    translate_subtitles,
-    generate_subtitle,
-    render_video,
-    validate_deliverable,
-    export_clips,
-]
 
 
 # ── Context construction (shared by CLI and Web) ───────────

--- a/src/movie_narrator/providers/__init__.py
+++ b/src/movie_narrator/providers/__init__.py
@@ -1,0 +1,22 @@
+"""Provider package: unified registry for TTS, Vision, and future providers.
+
+This package hosts the :class:`ProviderRegistry` and global registry
+instances for each provider category. External plugins register their
+factories here via :func:`register_tts` / :func:`register_vision`.
+"""
+
+from .registry import (
+    ProviderRegistry,
+    register_tts,
+    register_vision,
+    tts_registry,
+    vision_registry,
+)
+
+__all__ = [
+    "ProviderRegistry",
+    "register_tts",
+    "register_vision",
+    "tts_registry",
+    "vision_registry",
+]

--- a/src/movie_narrator/providers/registry.py
+++ b/src/movie_narrator/providers/registry.py
@@ -1,0 +1,147 @@
+"""Provider registry for TTS, Vision, and other pluggable providers.
+
+Each provider category (TTS, Vision, etc.) has a global
+:class:`ProviderRegistry` instance. Providers register a factory
+callable that takes configuration (settings/kwargs) and returns an
+instance of the provider protocol.
+
+Example (TTS)::
+
+    from movie_narrator import register_tts
+
+    @register_tts("elevenlabs")
+    def make_elevenlabs(settings):
+        from .elevenlabs import ElevenLabsProvider
+        return ElevenLabsProvider(settings)
+
+Example (Vision)::
+
+    from movie_narrator import register_vision
+
+    @register_vision("blip")
+    def make_blip(**kwargs):
+        from .blip import BlipCaptioner
+        return BlipCaptioner(**kwargs)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+
+class ProviderRegistry:
+    """Registry for provider factories.
+
+    A factory is a callable ``(config) -> provider_instance``. The
+    config type varies by category (Settings for TTS, kwargs for Vision)
+    but the registration interface is identical.
+    """
+
+    def __init__(self, category: str = "provider") -> None:
+        self._category = category
+        self._factories: Dict[str, Callable[..., Any]] = {}
+
+    def register(
+        self,
+        name: str,
+        factory: Callable[..., Any],
+    ) -> Callable[..., Any]:
+        """Register a provider factory and return it (decorator-friendly).
+
+        Args:
+            name: Unique provider identifier (e.g. ``"edge"``, ``"mimo"``).
+            factory: Callable that accepts config and returns a provider
+                instance.
+
+        Raises:
+            ValueError: if *name* is already registered.
+        """
+        if name in self._factories:
+            raise ValueError(
+                f"{self._category} provider '{name}' is already registered. "
+                f"Use a different name or unregister first."
+            )
+        self._factories[name] = factory
+        return factory
+
+    def unregister(self, name: str) -> None:
+        """Remove a provider factory."""
+        if name not in self._factories:
+            raise KeyError(f"{self._category} provider '{name}' is not registered.")
+        del self._factories[name]
+
+    def get(self, name: str) -> Optional[Callable[..., Any]]:
+        """Return the factory for *name*, or None."""
+        return self._factories.get(name)
+
+    def create(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        """Create a provider instance by name.
+
+        Args:
+            name: Provider identifier.
+            *args, **kwargs: Passed to the factory.
+
+        Raises:
+            ValueError: if *name* is not registered.
+        """
+        factory = self._factories.get(name)
+        if factory is None:
+            available = sorted(self._factories.keys())
+            raise ValueError(
+                f"Unknown {self._category} provider: {name!r}. "
+                f"Registered: {available}"
+            )
+        return factory(*args, **kwargs)
+
+    def names(self) -> List[str]:
+        """Return all registered provider names."""
+        return list(self._factories.keys())
+
+    def contains(self, name: str) -> bool:
+        """Check if a provider name is registered."""
+        return name in self._factories
+
+    def clear(self) -> None:
+        """Remove all registered factories. For testing only."""
+        self._factories.clear()
+
+
+# ── Global registry instances ────────────────────────────
+
+tts_registry = ProviderRegistry(category="tts")
+vision_registry = ProviderRegistry(category="vision")
+
+
+# ── Decorators ────────────────────────────────────────────
+
+
+def register_tts(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a TTS provider factory.
+
+    Usage::
+
+        @register_tts("elevenlabs")
+        def make_elevenlabs(settings):
+            return ElevenLabsProvider(settings)
+    """
+
+    def decorator(factory: Callable[..., Any]) -> Callable[..., Any]:
+        return tts_registry.register(name, factory)
+
+    return decorator
+
+
+def register_vision(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a Vision captioner provider factory.
+
+    Usage::
+
+        @register_vision("blip")
+        def make_blip(**kwargs):
+            return BlipCaptioner(**kwargs)
+    """
+
+    def decorator(factory: Callable[..., Any]) -> Callable[..., Any]:
+        return vision_registry.register(name, factory)
+
+    return decorator

--- a/src/movie_narrator/tts/factory.py
+++ b/src/movie_narrator/tts/factory.py
@@ -1,22 +1,83 @@
-"""Factory: settings → TTSProvider instance."""
+"""Factory: settings → TTSProvider instance.
+
+Uses the :data:`tts_registry` to dispatch provider creation.
+Built-in providers (edge, openai, mimo) are registered at import
+time below. External plugins can register additional providers
+via :func:`register_tts`.
+
+Backward compatibility: if a provider name is not in the registry,
+the old if/elif chain is tried as a fallback. This ensures existing
+code that depends on ``TTSProviderType`` continues to work during
+the transition period.
+"""
 
 from ..config import Settings, TTSProviderType
+from ..providers import tts_registry
 from ..utils.errors import ConfigError
 from .protocol import TTSProvider
 
 
+# ── Register built-in TTS providers ───────────────────────
+
+
+def _make_edge(settings: Settings) -> TTSProvider:
+    from .edge import EdgeTTSProvider
+    return EdgeTTSProvider()
+
+
+def _make_openai(settings: Settings) -> TTSProvider:
+    from .openai_provider import OpenAITTSProvider
+    return OpenAITTSProvider(settings)
+
+
+def _make_mimo(settings: Settings) -> TTSProvider:
+    from .mimo_provider import MimoTTSProvider
+    return MimoTTSProvider(settings)
+
+
+# Register only if not already registered (handles reload scenarios).
+for _name, _factory in [
+    (TTSProviderType.EDGE.value, _make_edge),
+    (TTSProviderType.OPENAI.value, _make_openai),
+    (TTSProviderType.MIMO.value, _make_mimo),
+]:
+    if not tts_registry.contains(_name):
+        tts_registry.register(_name, _factory)
+
+
+# ── Public factory function ───────────────────────────────
+
+
 def get_tts_provider(settings: Settings) -> TTSProvider:
+    """Return a TTSProvider instance for the configured provider.
+
+    Looks up the provider name in :data:`tts_registry` first.
+    Falls back to the enum-based if/elif chain for backward
+    compatibility with any code that might register custom
+    TTSProviderType values without updating the registry.
+
+    Raises:
+        ConfigError: when the provider is unsupported.
+    """
+    provider_name = (
+        settings.tts_provider.value
+        if isinstance(settings.tts_provider, TTSProviderType)
+        else str(settings.tts_provider)
+    )
+
+    # Registry path (preferred)
+    if tts_registry.contains(provider_name):
+        return tts_registry.create(provider_name, settings)
+
+    # Legacy fallback (should not be reached for built-in providers)
     if settings.tts_provider is TTSProviderType.EDGE:
-        from .edge import EdgeTTSProvider
-        return EdgeTTSProvider()
+        return _make_edge(settings)
     elif settings.tts_provider is TTSProviderType.OPENAI:
-        from .openai_provider import OpenAITTSProvider
-        return OpenAITTSProvider(settings)
+        return _make_openai(settings)
     elif settings.tts_provider is TTSProviderType.MIMO:
-        from .mimo_provider import MimoTTSProvider
-        return MimoTTSProvider(settings)
-    else:
-        raise ConfigError(
-            f"Unsupported TTS provider: {settings.tts_provider!r}. "
-            f"Supported: {list(TTSProviderType)}"
-        )
+        return _make_mimo(settings)
+
+    raise ConfigError(
+        f"Unsupported TTS provider: {settings.tts_provider!r}. "
+        f"Registered: {tts_registry.names()}"
+    )

--- a/src/movie_narrator/vision/factory.py
+++ b/src/movie_narrator/vision/factory.py
@@ -1,12 +1,29 @@
 """Factory: settings → VisionCaptioner instance (EP8).
 
-Currently only returns the StubVisionCaptioner. When real vision
-providers (BLIP, LLaVA, etc.) are implemented, they will be
-dispatched here based on settings/configuration.
+Uses the :data:`vision_registry` to dispatch provider creation.
+Built-in provider (stub) is registered at import time. External
+plugins can register additional providers (blip, llava, http_vlm,
+etc.) via :func:`register_vision`.
 """
 
+from ..providers import vision_registry
 from .protocol import VisionCaptioner
-from .stub import StubVisionCaptioner
+
+
+# ── Register built-in Vision providers ────────────────────
+
+
+def _make_stub(**kwargs) -> VisionCaptioner:
+    from .stub import StubVisionCaptioner
+    return StubVisionCaptioner()
+
+
+# Register only if not already registered (handles reload scenarios).
+if not vision_registry.contains("stub"):
+    vision_registry.register("stub", _make_stub)
+
+
+# ── Public factory function ───────────────────────────────
 
 
 def get_vision_captioner(
@@ -15,10 +32,12 @@ def get_vision_captioner(
 ) -> VisionCaptioner:
     """Return a VisionCaptioner instance.
 
+    Looks up the provider name in :data:`vision_registry` first.
+    Falls back to the old if/elif chain for backward compatibility.
+
     Args:
-        provider: "stub" (default) — returns StubVisionCaptioner.
-            Future: "blip", "llava", etc.
-        **kwargs: provider-specific configuration.
+        provider: Provider name (e.g. "stub", "http_vlm").
+        **kwargs: Provider-specific configuration.
 
     Returns:
         A VisionCaptioner instance.
@@ -26,15 +45,15 @@ def get_vision_captioner(
     Raises:
         ValueError: when the provider is unknown.
     """
-    if provider == "stub":
-        return StubVisionCaptioner()
+    # Registry path (preferred)
+    if vision_registry.contains(provider):
+        return vision_registry.create(provider, **kwargs)
 
-    # Future providers will be dispatched here:
-    # elif provider == "blip":
-    #     from .blip import BlipVisionCaptioner
-    #     return BlipVisionCaptioner(**kwargs)
+    # Legacy fallback
+    if provider == "stub":
+        return _make_stub(**kwargs)
 
     raise ValueError(
         f"Unsupported vision captioner provider: {provider!r}. "
-        f"Supported: ['stub']"
+        f"Registered: {vision_registry.names()}"
     )

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -38,6 +38,9 @@ class JobParams(BaseModel):
     match_topk: Optional[int] = None  # EP3: top-K rerank (default 5, 0/1 = top-1)
     match_topk_reuse_penalty: Optional[float] = None  # EP3: score deduction for recently used scenes (default 0.15)
     embedding_model_name: Optional[str] = None
+    # ── Vision (EP8) ──
+    # "none" (default) | "stub" | future providers (http_vlm, blip, etc.)
+    vision_captioner: Optional[str] = None
     # ── BGM ──
     bgm_gain_db: Optional[float] = None
     bgm_duck_db: Optional[float] = None

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,671 @@
+"""Tests for the v0.5 plugin registry infrastructure.
+
+Covers:
+- StepRegistry: registration, ordering, soft-step metadata
+- ProviderRegistry: registration, lookup, creation
+- Plugin protocol and load_plugin
+- UnifiedParamSchema (PARAM_WHITELIST derived from JobParams)
+- SDK surface exports
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from movie_narrator.pipeline.registry import (
+    StepRegistry,
+    StepEntry,
+    step_registry,
+    register_step,
+)
+from movie_narrator.providers import (
+    ProviderRegistry,
+    tts_registry,
+    vision_registry,
+    register_tts,
+    register_vision,
+)
+from movie_narrator.contract import (
+    Plugin,
+    PluginContext,
+    Step,
+    load_plugin,
+)
+from movie_narrator.models import Context, Assets, Services
+from movie_narrator.utils.console import SilentConsole
+
+
+# ── Fixtures ───────────────────────────────────────────────
+
+
+def _make_ctx() -> Context:
+    """Create a minimal Context for step function testing."""
+    return Context(
+        movie_name="test",
+        style="test",
+        duration=30,
+        output_dir="/tmp/test",
+        assets=Assets(),
+        services=Services(console=SilentConsole()),
+    )
+
+
+# ── StepRegistry tests ────────────────────────────────────
+
+
+class TestStepRegistry:
+    """StepRegistry core functionality."""
+
+    def test_register_and_get(self):
+        reg = StepRegistry()
+
+        def my_step(ctx):
+            return ctx
+
+        reg.register("my_step", my_step)
+        assert reg.contains("my_step")
+        assert reg.get("my_step").func is my_step
+        assert reg.get_func("my_step") is my_step
+
+    def test_register_returns_func(self):
+        reg = StepRegistry()
+
+        def my_step(ctx):
+            return ctx
+
+        returned = reg.register("my_step", my_step)
+        assert returned is my_step
+
+    def test_duplicate_name_raises(self):
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        reg.register("dup", step_a)
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register("dup", step_b)
+
+    def test_unregister(self):
+        reg = StepRegistry()
+
+        def my_step(ctx):
+            return ctx
+
+        reg.register("my_step", my_step)
+        reg.unregister("my_step")
+        assert not reg.contains("my_step")
+        assert reg.get("my_step") is None
+
+    def test_unregister_unknown_raises(self):
+        reg = StepRegistry()
+        with pytest.raises(KeyError):
+            reg.unregister("nonexistent")
+
+    def test_ordered_steps_builtin_only(self):
+        """Built-in steps preserve registration order."""
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        def step_c(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("b", step_b)
+        reg.register("c", step_c)
+
+        ordered = reg.ordered_steps()
+        assert ordered == [step_a, step_b, step_c]
+
+    def test_ordered_steps_with_after(self):
+        """Plugin step with after= is inserted right after target."""
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        def plugin_step(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("b", step_b)
+        reg.register("plugin", plugin_step, after="a")
+
+        ordered = reg.ordered_steps()
+        assert ordered == [step_a, plugin_step, step_b]
+
+    def test_ordered_steps_with_before(self):
+        """Plugin step with before= is inserted right before target."""
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        def plugin_step(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("b", step_b)
+        reg.register("plugin", plugin_step, before="b")
+
+        ordered = reg.ordered_steps()
+        assert ordered == [step_a, plugin_step, step_b]
+
+    def test_ordered_steps_unsequenced_appended(self):
+        """Plugin step with neither after nor before is appended."""
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def plugin_step(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("plugin", plugin_step, after=None, before=None)
+
+        ordered = reg.ordered_steps()
+        assert ordered == [step_a, plugin_step]
+
+    def test_ordered_names(self):
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("b", step_b)
+
+        assert reg.ordered_names() == ["a", "b"]
+
+    def test_soft_step_metadata(self):
+        reg = StepRegistry()
+
+        def soft_step(ctx):
+            return ctx
+
+        def hard_step(ctx):
+            return ctx
+
+        reg.register("soft", soft_step, soft=True, status_field="soft_field",
+                     consequence="soft step failed")
+        reg.register("hard", hard_step)
+
+        assert reg.soft_step_names() == {"soft"}
+        assert reg.status_field_for("soft") == "soft_field"
+        assert reg.consequence_for("soft") == "soft step failed"
+        assert reg.status_field_for("hard") is None
+        assert reg.consequence_for("hard") == ""
+
+    def test_info(self):
+        reg = StepRegistry()
+
+        def my_step(ctx):
+            return ctx
+
+        reg.register("my_step", my_step, soft=True, status_field="my")
+        info = reg.info()
+        assert len(info) == 1
+        assert info[0]["name"] == "my_step"
+        assert info[0]["soft"] is True
+        assert info[0]["status_field"] == "my"
+
+    def test_clear(self):
+        reg = StepRegistry()
+
+        def my_step(ctx):
+            return ctx
+
+        reg.register("my_step", my_step)
+        reg.clear()
+        assert not reg.contains("my_step")
+        assert reg.names() == []
+
+
+class TestStepRegistryDecorator:
+    """The @register_step decorator pattern."""
+
+    def test_decorator_registers_in_local_registry(self):
+        """Verify the decorator pattern works with a local registry."""
+        reg = StepRegistry()
+
+        # Simulate the decorator factory bound to this registry
+        def local_register(name, **kwargs):
+            def decorator(func):
+                return reg.register(name, func, **kwargs)
+            return decorator
+
+        @local_register("decorated", soft=True)
+        def my_step(ctx):
+            return ctx
+
+        assert reg.contains("decorated")
+        assert reg.get("decorated").func is my_step
+        assert reg.get("decorated").soft is True
+
+    def test_global_register_step_is_callable(self):
+        """The global register_step decorator is callable and returns a decorator."""
+        assert callable(register_step)
+        decorator = register_step("test_unique_step_name")
+        assert callable(decorator)
+
+
+# ── Global step_registry tests ────────────────────────────
+
+
+class TestGlobalStepRegistry:
+    """The global step_registry instance with built-in steps."""
+
+    def test_has_15_builtin_steps(self):
+        assert len(step_registry.names()) == 15
+
+    def test_ordered_names_match_pipeline(self):
+        from movie_narrator.pipeline.runner import STEPS
+        assert len(step_registry.ordered_steps()) == len(STEPS)
+
+    def test_first_step_is_resolve_video(self):
+        names = step_registry.ordered_names()
+        assert names[0] == "resolve_video"
+
+    def test_last_step_is_export_clips(self):
+        names = step_registry.ordered_names()
+        assert names[-1] == "export_clips"
+
+    def test_soft_steps_correct(self):
+        expected = {
+            "research_plot", "align_audio", "detect_scenes",
+            "match_clips", "mix_bgm", "export_clips", "translate_subtitles",
+        }
+        assert step_registry.soft_step_names() == expected
+
+    def test_status_fields_correct(self):
+        assert step_registry.status_field_for("research_plot") == "research"
+        assert step_registry.status_field_for("align_audio") == "align"
+        assert step_registry.status_field_for("detect_scenes") == "scene"
+        assert step_registry.status_field_for("match_clips") == "match"
+        assert step_registry.status_field_for("mix_bgm") == "bgm"
+        assert step_registry.status_field_for("export_clips") == "export"
+        assert step_registry.status_field_for("translate_subtitles") == "translate"
+
+    def test_consequence_messages_exist(self):
+        for name in step_registry.soft_step_names():
+            assert step_registry.consequence_for(name), f"Missing consequence for {name}"
+
+
+# ── ProviderRegistry tests ────────────────────────────────
+
+
+class TestProviderRegistry:
+    """ProviderRegistry core functionality."""
+
+    def test_register_and_create(self):
+        reg = ProviderRegistry("test")
+
+        class FakeProvider:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        def factory(**kwargs):
+            return FakeProvider(**kwargs)
+
+        reg.register("fake", factory)
+        assert reg.contains("fake")
+        provider = reg.create("fake", key="value")
+        assert isinstance(provider, FakeProvider)
+        assert provider.kwargs == {"key": "value"}
+
+    def test_register_returns_factory(self):
+        reg = ProviderRegistry("test")
+
+        def factory(**kwargs):
+            return None
+
+        returned = reg.register("fake", factory)
+        assert returned is factory
+
+    def test_duplicate_name_raises(self):
+        reg = ProviderRegistry("test")
+
+        def factory1(**kwargs):
+            return None
+
+        def factory2(**kwargs):
+            return None
+
+        reg.register("dup", factory1)
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register("dup", factory2)
+
+    def test_create_unknown_raises(self):
+        reg = ProviderRegistry("test")
+        with pytest.raises(ValueError, match="Unknown test provider"):
+            reg.create("nonexistent")
+
+    def test_unregister(self):
+        reg = ProviderRegistry("test")
+
+        def factory(**kwargs):
+            return None
+
+        reg.register("temp", factory)
+        reg.unregister("temp")
+        assert not reg.contains("temp")
+
+    def test_names(self):
+        reg = ProviderRegistry("test")
+
+        def f1(**kw):
+            pass
+
+        def f2(**kw):
+            pass
+
+        reg.register("a", f1)
+        reg.register("b", f2)
+        assert set(reg.names()) == {"a", "b"}
+
+    def test_clear(self):
+        reg = ProviderRegistry("test")
+
+        def factory(**kwargs):
+            return None
+
+        reg.register("temp", factory)
+        reg.clear()
+        assert reg.names() == []
+
+
+class TestGlobalTtsRegistry:
+    """The global tts_registry with built-in providers."""
+
+    def test_has_edge_openai_mimo(self):
+        names = set(tts_registry.names())
+        assert "edge" in names
+        assert "openai" in names
+        assert "mimo" in names
+
+    def test_factory_returns_provider(self):
+        from movie_narrator.config import Settings, TTSProviderType
+        settings = Settings(tts_provider=TTSProviderType.EDGE)
+        from movie_narrator.tts.factory import get_tts_provider
+        provider = get_tts_provider(settings)
+        assert provider is not None
+
+    def test_unknown_provider_raises_config_error(self):
+        from movie_narrator.config import Settings, TTSProviderType
+        from movie_narrator.utils.errors import ConfigError
+        from movie_narrator.tts.factory import get_tts_provider
+
+        # Create a mock settings with unsupported provider
+        settings = Settings()
+        settings.tts_provider = "unsupported"
+        with pytest.raises(ConfigError, match="Unsupported TTS provider"):
+            get_tts_provider(settings)
+
+
+class TestGlobalVisionRegistry:
+    """The global vision_registry."""
+
+    def test_stub_registered_after_import(self):
+        # Import the factory to trigger registration
+        import movie_narrator.vision.factory  # noqa: F401
+        assert "stub" in vision_registry.names()
+
+    def test_create_stub(self):
+        import movie_narrator.vision.factory  # noqa: F401
+        from movie_narrator.vision.protocol import VisionCaptioner
+        provider = vision_registry.create("stub")
+        assert isinstance(provider, VisionCaptioner)
+
+
+# ── Plugin system tests ───────────────────────────────────
+
+
+class TestPluginProtocol:
+    """Plugin protocol and load_plugin function."""
+
+    def test_plugin_protocol_is_runtime_checkable(self):
+        class MyPlugin:
+            name = "test"
+
+            def register(self, ctx: PluginContext) -> None:
+                pass
+
+        assert isinstance(MyPlugin(), Plugin)
+
+    def test_non_plugin_fails_check(self):
+        class NotAPlugin:
+            pass
+
+        assert not isinstance(NotAPlugin(), Plugin)
+
+    def test_load_plugin_calls_register(self):
+        class TestPlugin:
+            name = "test"
+            called = False
+
+            def register(self, ctx: PluginContext) -> None:
+                self.__class__.called = True
+
+        plugin = TestPlugin()
+        load_plugin(plugin)
+        assert TestPlugin.called is True
+
+    def test_load_plugin_rejects_non_plugin(self):
+        with pytest.raises(TypeError, match="does not implement the Plugin protocol"):
+            load_plugin("not a plugin")
+
+    def test_plugin_context_default(self):
+        ctx = PluginContext.default()
+        assert ctx.steps is step_registry
+        assert ctx.tts is tts_registry
+        assert ctx.vision is vision_registry
+
+
+class TestPluginStepInsertion:
+    """Plugin steps inserted via after=/before= appear in correct position."""
+
+    def test_plugin_step_after_render(self):
+        """A plugin step registered with after='render_video' should
+        appear immediately after render_video in the ordered list."""
+        # Use a fresh registry to avoid polluting the global one
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        def plugin_step(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("b", step_b)
+        reg.register("plugin", plugin_step, after="a")
+
+        names = reg.ordered_names()
+        idx_a = names.index("a")
+        idx_plugin = names.index("plugin")
+        assert idx_plugin == idx_a + 1
+
+    def test_plugin_step_before_last(self):
+        """A plugin step with before= on the last built-in step."""
+        reg = StepRegistry()
+
+        def step_a(ctx):
+            return ctx
+
+        def step_b(ctx):
+            return ctx
+
+        def plugin_step(ctx):
+            return ctx
+
+        reg.register("a", step_a)
+        reg.register("b", step_b)
+        reg.register("plugin", plugin_step, before="b")
+
+        names = reg.ordered_names()
+        idx_b = names.index("b")
+        idx_plugin = names.index("plugin")
+        assert idx_plugin == idx_b - 1
+
+    def test_multiple_plugin_steps_after_same_target(self):
+        """Multiple plugin steps after the same target are appended in
+        registration order."""
+        reg = StepRegistry()
+
+        def base(ctx):
+            return ctx
+
+        def p1(ctx):
+            return ctx
+
+        def p2(ctx):
+            return ctx
+
+        reg.register("base", base)
+        reg.register("p1", p1, after="base")
+        reg.register("p2", p2, after="base")
+
+        names = reg.ordered_names()
+        assert names == ["base", "p1", "p2"]
+
+
+# ── UnifiedParamSchema tests ──────────────────────────────
+
+
+class TestUnifiedParamSchema:
+    """PARAM_WHITELIST is derived from JobParams.model_fields."""
+
+    def test_param_whitelist_matches_job_params(self):
+        from movie_narrator.pipeline.runner import PARAM_WHITELIST
+        from movie_narrator.workflow.schema import JobParams
+
+        derived = frozenset(JobParams.model_fields.keys())
+        assert PARAM_WHITELIST == derived
+
+    def test_param_whitelist_is_frozenset(self):
+        from movie_narrator.pipeline.runner import PARAM_WHITELIST
+        assert isinstance(PARAM_WHITELIST, frozenset)
+
+    def test_param_whitelist_has_vision_captioner(self):
+        """vision_captioner was missing from JobParams before v0.5."""
+        from movie_narrator.pipeline.runner import PARAM_WHITELIST
+        assert "vision_captioner" in PARAM_WHITELIST
+
+    def test_job_params_has_vision_captioner(self):
+        from movie_narrator.workflow.schema import JobParams
+        assert "vision_captioner" in JobParams.model_fields
+
+    def test_allowed_param_keys_subset_of_whitelist(self):
+        """ALLOWED_PARAM_KEYS must be a subset of PARAM_WHITELIST."""
+        from movie_narrator.pipeline.runner import PARAM_WHITELIST
+        from movie_narrator.presets.base import ALLOWED_PARAM_KEYS
+        assert ALLOWED_PARAM_KEYS <= PARAM_WHITELIST
+
+
+# ── SDK surface tests ─────────────────────────────────────
+
+
+class TestSDKSurface:
+    """Public SDK exports from movie_narrator package."""
+
+    def test_register_step_exported(self):
+        from movie_narrator import register_step
+        assert callable(register_step)
+
+    def test_register_tts_exported(self):
+        from movie_narrator import register_tts
+        assert callable(register_tts)
+
+    def test_register_vision_exported(self):
+        from movie_narrator import register_vision
+        assert callable(register_vision)
+
+    def test_context_exported(self):
+        from movie_narrator import Context as ExportedContext
+        from movie_narrator.models import Context
+        assert ExportedContext is Context
+
+    def test_step_registry_exported(self):
+        from movie_narrator import step_registry as exported
+        from movie_narrator.pipeline.registry import step_registry
+        assert exported is step_registry
+
+    def test_tts_registry_exported(self):
+        from movie_narrator import tts_registry as exported
+        from movie_narrator.providers import tts_registry
+        assert exported is tts_registry
+
+    def test_vision_registry_exported(self):
+        from movie_narrator import vision_registry as exported
+        from movie_narrator.providers import vision_registry
+        assert exported is vision_registry
+
+    def test_plugin_types_exported(self):
+        from movie_narrator import Plugin, PluginContext, load_plugin
+        assert Plugin is not None
+        assert PluginContext is not None
+        assert callable(load_plugin)
+
+    def test_step_type_alias_exported(self):
+        from movie_narrator import Step
+        assert Step is not None
+
+    def test_build_context_and_run_pipeline_exported(self):
+        from movie_narrator import build_context, run_pipeline
+        assert callable(build_context)
+        assert callable(run_pipeline)
+
+
+# ── Integration: plugin step actually runs ────────────────
+
+
+class TestPluginStepExecution:
+    """A plugin step registered via the decorator actually runs in the pipeline."""
+
+    def test_plugin_step_executes(self):
+        """Register a no-op plugin step and verify it appears in ordered_steps."""
+        # We can't easily run the full pipeline in a unit test,
+        # but we can verify the registry integration works.
+        reg = StepRegistry()
+
+        executed = []
+
+        def base_step(ctx):
+            executed.append("base")
+            return ctx
+
+        def plugin_step(ctx):
+            executed.append("plugin")
+            return ctx
+
+        reg.register("base", base_step)
+        reg.register("plugin", plugin_step, after="base")
+
+        ctx = _make_ctx()
+        for func in reg.ordered_steps():
+            ctx = func(ctx)
+
+        assert executed == ["base", "plugin"]


### PR DESCRIPTION
## v0.5 Ecosystem Phase 1: Core Plugin Infrastructure

### Summary

Implements the foundational plugin registry system that transforms the engine from hardcoded step/provider lists to a registry-based extensible architecture.

### Changes

**StepRegistry** (pipeline/registry.py — new):
- @register_step decorator for built-in and plugin steps
- Ordered step list with after=/before= insertion hints for plugins
- Soft-step metadata (status_field, consequence) tracked centrally
- STEPS, SOFT_STATUS_STEPS, STATUS_FIELD_FOR_STEP, SOFT_STEP_CONSEQUENCES now derived from the registry

**ProviderRegistry** (providers/ — new package):
- @register_tts / @register_vision decorators
- Built-in TTS providers (edge/openai/mimo) registered at import time
- Built-in Vision provider (stub) registered at import time
- Factory functions use registry first, fall back to legacy if/elif chain

**UnifiedParamSchema**:
- PARAM_WHITELIST derived from JobParams.model_fields.keys() — eliminates drift
- Added missing vision_captioner field to JobParams (was in PARAM_WHITELIST but not in the model)

**SDK Surface** (contract.py + __init__.py):
- Step type alias (Callable[[Context], Context])
- PluginContext dataclass with registry access
- Plugin protocol (name + register method)
- load_plugin() function
- All exports accessible via: from movie_narrator import register_step, Context, Plugin, ...

### Test Results

- 58 new tests in test_plugin_registry.py
- 638 total passed, 11 skipped (environment-dependent), 0 regressions

### Backward Compatibility

- STEPS, PARAM_WHITELIST, SOFT_STATUS_STEPS, etc. remain the same type and value
- Factory functions retain legacy if/elif fallback
- No existing imports break
- contract.py __all__ is a superset of the previous version

### Example Plugin Usage

```python
from movie_narrator import register_step, Context

@register_step("add_watermark", after="render_video")
def add_watermark(ctx: Context) -> Context:
    # Custom logic after render
    return ctx
```
