### PR TITLE
feat(v0.5): SDK freeze — entry_points discovery + Services.logger + example plugin + docs

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -1,0 +1,225 @@
+# Plugin Development Guide
+
+This guide covers how to write, package, and distribute plugins for
+movie-narrator using the v0.5 Plugin SDK.
+
+## Overview
+
+movie-narrator v0.5 introduces a plugin system that allows external
+code to extend the pipeline without modifying the core source. Plugins
+can:
+
+- **Add pipeline steps** — inject custom processing logic at any point
+- **Register TTS providers** — add new text-to-speech backends
+- **Register Vision captioners** — add new scene captioning backends
+
+All extensions use the same registry pattern: register at import time,
+discover at runtime.
+
+## Quick Start
+
+### 1. Create a plugin class
+
+A plugin is any object with a `name` attribute and a `register` method
+that accepts a `PluginContext`:
+
+```python
+from movie_narrator import PluginContext, register_step, Context
+
+class MyPlugin:
+    name = "my-plugin"
+
+    def register(self, ctx: PluginContext) -> None:
+        ctx.steps.register(
+            "my_step",
+            my_step_func,
+            after="render_video",
+            soft=True,
+        )
+
+def my_step_func(ctx: Context) -> Context:
+    # Your custom logic here
+    return ctx
+```
+
+### 2. Package it with an entry point
+
+In your `pyproject.toml`:
+
+```toml
+[project.entry-points."movie_narrator.plugins"]
+my-plugin = "my_package:MyPlugin"
+```
+
+### 3. Install and discover
+
+```bash
+pip install my-plugin-package
+```
+
+```python
+from movie_narrator import discover_plugins
+discover_plugins()  # auto-loads all installed plugins
+```
+
+## SDK Surface
+
+The public SDK is importable from `movie_narrator`:
+
+| Symbol | Purpose |
+|--------|---------|
+| `Context` | Pipeline context model (read/modify during steps) |
+| `Services` | Infrastructure container (console, logger) |
+| `Plugin` | Protocol your plugin class must satisfy |
+| `PluginContext` | Passed to `register()`, provides registry access |
+| `load_plugin()` | Manually load a plugin instance |
+| `discover_plugins()` | Auto-discover via entry_points |
+| `list_available_plugins()` | List available plugins without loading |
+| `register_step` | Decorator to register a pipeline step |
+| `register_tts` | Decorator to register a TTS provider factory |
+| `register_vision` | Decorator to register a Vision captioner factory |
+| `step_registry` | Global step registry instance |
+| `tts_registry` | Global TTS provider registry instance |
+| `vision_registry` | Global Vision provider registry instance |
+
+## Pipeline Steps
+
+### Registration
+
+```python
+from movie_narrator import register_step, Context
+
+@register_step("my_step", after="render_video", soft=True)
+def my_step(ctx: Context) -> Context:
+    ctx.metadata["my_step_ran"] = True
+    return ctx
+```
+
+### Ordering
+
+Plugin steps must declare an insertion point:
+
+- `after="render_video"` — inserted immediately after the named step
+- `before="validate_deliverable"` — inserted immediately before the named step
+
+Built-in steps (no `after`/`before`) maintain their fixed order. Plugin
+steps without an insertion point are appended to the end.
+
+### Soft vs Hard Steps
+
+- **Soft steps** (`soft=True`): exceptions are caught and rendered as
+  warnings. The pipeline continues with degraded output. Requires a
+  `status_field` name and a `consequence` message.
+- **Hard steps** (`soft=False`, default): exceptions abort the pipeline.
+
+### Built-in Step Names
+
+The 15 built-in steps in execution order:
+
+1. `resolve_video`
+2. `prepare_assets`
+3. `research_plot` (soft)
+4. `generate_script`
+5. `export_script_md`
+6. `generate_voice`
+7. `align_audio` (soft)
+8. `detect_scenes` (soft)
+9. `match_clips` (soft)
+10. `mix_bgm` (soft)
+11. `translate_subtitles` (soft)
+12. `generate_subtitle`
+13. `render_video`
+14. `validate_deliverable`
+15. `export_clips` (soft)
+
+## TTS Providers
+
+```python
+from movie_narrator import register_tts, Settings
+
+@register_tts("elevenlabs")
+def make_elevenlabs(settings: Settings) -> TTSProvider:
+    from .elevenlabs import ElevenLabsProvider
+    return ElevenLabsProvider(settings)
+```
+
+The factory receives the project `Settings` and must return an object
+satisfying the `TTSProvider` protocol (with `synthesize` method).
+
+## Vision Captioners
+
+```python
+from movie_narrator import register_vision
+
+@register_vision("blip")
+def make_blip(**kwargs) -> VisionCaptioner:
+    from .blip import BlipCaptioner
+    return BlipCaptioner(**kwargs)
+```
+
+The factory receives keyword arguments and must return an object
+satisfying the `VisionCaptioner` protocol (with `caption_frame` and
+`caption_scenes` methods).
+
+## Services
+
+The `Services` container provides infrastructure to steps:
+
+```python
+def my_step(ctx: Context) -> Context:
+    # Console output (always available)
+    ctx.services.console.info("Processing...")
+
+    # Logger (optional, may be None)
+    if ctx.services.logger:
+        ctx.services.logger.info("my_step started")
+
+    return ctx
+```
+
+`Services` fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `console` | `Console` | required | Console output abstraction |
+| `logger` | `Optional[Any]` | `None` | Duck-typed logger (`.info/.warning/.error`) |
+
+## Entry Points
+
+Plugins are discovered via the `movie_narrator.plugins` entry point
+group. Declare in `pyproject.toml`:
+
+```toml
+[project.entry-points."movie_narrator.plugins"]
+my-plugin = "my_package:MyPlugin"
+```
+
+The entry point value can be:
+
+- A class path (`my_package:MyPlugin`) — instantiated with no args
+- A module path (`my_package`) — must have a top-level `plugin` or `Plugin` attribute
+
+## Compatibility Strategy
+
+### What's stable in v0.5
+
+- The `Plugin` protocol (`name` + `register(ctx)`)
+- The `PluginContext` interface (`steps`, `tts`, `vision`)
+- `register_step` decorator signature
+- `register_tts` / `register_vision` decorator signatures
+- Built-in step names and execution order
+- `discover_plugins()` / `load_plugin()` function signatures
+- `Services` field names (`console`, `logger`)
+
+### What may change in v0.6+
+
+- New `Services` fields may be added (always optional, never break existing code)
+- New registry categories may be added (e.g. `subtitles_registry`)
+- Built-in step list may grow (new steps inserted, existing order preserved)
+- `PluginContext` may gain new fields (additive, not breaking)
+
+### What won't change
+
+- Existing built-in step names will not be renamed
+- The `Context -> Context` step function signature will not change
+- The `register(name, func, *, soft, ...)` signature will not change

--- a/examples/plugins/watermark/README.md
+++ b/examples/plugins/watermark/README.md
@@ -1,0 +1,48 @@
+# movie-narrator-watermark
+
+Example out-of-tree plugin demonstrating the v0.5 Plugin SDK.
+
+## What it does
+
+Registers a soft pipeline step `add_watermark` that runs immediately
+after `render_video`. The step overlays a watermark image (PNG with
+alpha) onto the final video using ffmpeg's `overlay` filter at 50%
+opacity in the bottom-right corner.
+
+## Installation
+
+```bash
+cd examples/plugins/watermark
+pip install -e .
+```
+
+## Usage
+
+### Auto-discovery (recommended)
+
+After installation, the plugin is automatically discovered when
+`discover_plugins()` is called:
+
+```python
+from movie_narrator import discover_plugins
+discover_plugins()
+```
+
+### Manual loading
+
+```python
+from movie_narrator import load_plugin
+from movie_narrator_watermark import WatermarkPlugin
+load_plugin(WatermarkPlugin())
+```
+
+### Configuration
+
+Set the watermark image path in your job config:
+
+```yaml
+assets:
+  watermark: /path/to/watermark.png
+```
+
+If no watermark is configured, the step is skipped (soft step, no error).

--- a/examples/plugins/watermark/movie_narrator_watermark/__init__.py
+++ b/examples/plugins/watermark/movie_narrator_watermark/__init__.py
@@ -1,0 +1,29 @@
+"""Example out-of-tree plugin: watermark step.
+
+This plugin demonstrates the v0.5 SDK by registering a custom pipeline
+step that burns a watermark image into the final video after rendering.
+
+Installation::
+
+    cd examples/plugins/watermark
+    pip install -e .
+
+After installation, the plugin is auto-discovered via entry points when
+``movie_narrator.discover_plugins()`` is called (or when the pipeline
+runner initializes plugins).
+
+Usage in a pipeline::
+
+    from movie_narrator import discover_plugins
+    discover_plugins()  # loads all installed plugins
+
+Or load manually::
+
+    from movie_narrator import load_plugin
+    from movie_narrator_watermark import WatermarkPlugin
+    load_plugin(WatermarkPlugin())
+"""
+
+from .plugin import WatermarkPlugin
+
+__all__ = ["WatermarkPlugin"]

--- a/examples/plugins/watermark/movie_narrator_watermark/plugin.py
+++ b/examples/plugins/watermark/movie_narrator_watermark/plugin.py
@@ -1,0 +1,107 @@
+"""WatermarkPlugin — reference implementation of the Plugin protocol.
+
+Registers a soft pipeline step ``add_watermark`` that runs immediately
+after ``render_video``. The step overlays a watermark image (PNG with
+alpha) onto the final video using ffmpeg.
+
+This is a teaching example, not a production-ready watermark solution.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from movie_narrator import Context, PluginContext, register_step
+
+
+class WatermarkPlugin:
+    """Plugin that adds a watermark overlay step to the pipeline."""
+
+    name = "watermark"
+
+    def register(self, ctx: PluginContext) -> None:
+        """Register the watermark step with the step registry."""
+        ctx.steps.register(
+            "add_watermark",
+            _add_watermark_step,
+            soft=True,
+            status_field="watermark",
+            consequence="watermark overlay skipped — final video will have no watermark",
+            after="render_video",
+        )
+
+
+def _add_watermark_step(ctx: Context) -> Context:
+    """Burn a watermark image into the final video.
+
+    Reads the watermark path from ``ctx.assets.watermark``. If no
+    watermark is configured, the step is a no-op (status=skipped).
+
+    Uses ffmpeg's ``overlay`` filter to composite the watermark at
+    the bottom-right corner with 50% opacity.
+    """
+    watermark_path = ctx.assets.watermark
+    if not watermark_path:
+        ctx.step_state.result = ctx.step_state.result.__class__("skipped")
+        ctx.step_state.message = "no watermark asset configured"
+        return ctx
+
+    if not ctx.video_path:
+        ctx.step_state.result = ctx.step_state.result.__class__("skipped")
+        ctx.step_state.message = "no video to watermark"
+        return ctx
+
+    video_path = Path(ctx.video_path)
+    if not video_path.exists():
+        ctx.step_state.result = ctx.step_state.result.__class__("skipped")
+        ctx.step_state.message = f"video not found: {video_path}"
+        return ctx
+
+    wm_path = Path(watermark_path)
+    if not wm_path.exists():
+        ctx.step_state.result = ctx.step_state.result.__class__("skipped")
+        ctx.step_state.message = f"watermark not found: {wm_path}"
+        return ctx
+
+    output_path = video_path.with_suffix(".watermarked.mp4")
+
+    ffmpeg_cmd = [
+        "ffmpeg", "-y",
+        "-i", str(video_path),
+        "-i", str(wm_path),
+        "-filter_complex",
+        "[1:v]format=rgba,colorchannelmixer=aa=0.5[wm];"
+        "[0:v][wm]overlay=W-w-20:H-h-20",
+        "-c:a", "copy",
+        str(output_path),
+    ]
+
+    result = subprocess.run(
+        ffmpeg_cmd,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg watermark overlay failed (exit {result.returncode}): "
+            f"{result.stderr[:500]}"
+        )
+
+    # Replace the original video with the watermarked version
+    backup = video_path.with_suffix(".orig.mp4")
+    shutil.move(str(video_path), str(backup))
+    shutil.move(str(output_path), str(video_path))
+
+    ctx.step_state.result = ctx.step_state.result.__class__("success")
+    ctx.step_state.message = f"watermark applied from {wm_path.name}"
+
+    # Log via services.logger if available
+    logger: Any = ctx.services.logger if ctx.services else None
+    if logger and hasattr(logger, "info"):
+        logger.info("WatermarkPlugin: applied %s to %s", wm_path.name, video_path.name)
+
+    return ctx

--- a/examples/plugins/watermark/pyproject.toml
+++ b/examples/plugins/watermark/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "movie-narrator-watermark"
+version = "0.1.0"
+description = "Example plugin for movie-narrator: adds a watermark overlay step."
+requires-python = ">=3.10"
+
+[project.entry-points."movie_narrator.plugins"]
+watermark = "movie_narrator_watermark:WatermarkPlugin"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/src/movie_narrator/__init__.py
+++ b/src/movie_narrator/__init__.py
@@ -8,6 +8,7 @@ __version__ = version("movie-narrator")
 #   from movie_narrator import register_step, Context
 #   from movie_narrator import register_tts, register_vision
 #   from movie_narrator import Plugin, PluginContext, load_plugin
+#   from movie_narrator import discover_plugins  # entry_points discovery
 #
 # The contract module is the single import surface. We re-export
 # here for convenience so plugins don't need to know the internal
@@ -18,9 +19,12 @@ from .contract import (  # noqa: F401
     Plugin,
     PluginContext,
     ProviderRegistry,
+    Services,
     Step,
     StepRegistry,
     build_context,
+    discover_plugins,
+    list_available_plugins,
     load_plugin,
     register_step,
     register_tts,

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -49,7 +49,7 @@ from .pipeline.runner import PARAM_WHITELIST, build_context, run_pipeline
 
 # ── Re-exports: models ─────────────────────────────────────
 
-from .models import Context
+from .models import Context, Services
 
 # ── Re-exports: registries ─────────────────────────────────
 
@@ -175,6 +175,13 @@ def load_plugin(plugin: Plugin) -> None:
     plugin.register(PluginContext.default())
 
 
+# ── Plugin discovery (entry_points) ───────────────────────
+# Imported at the bottom of the module to avoid circular import:
+# plugin_loader imports from contract (Plugin, load_plugin), so we
+# import it after those symbols are defined.
+# The actual import is done lazily below to keep the top-level
+# contract module clean.
+
 # ── Public API ─────────────────────────────────────────────
 
 __all__ = [
@@ -198,6 +205,7 @@ __all__ = [
     "PipelineResult",
     # Models
     "Context",
+    "Services",
     # Registries
     "StepRegistry",
     "ProviderRegistry",
@@ -214,6 +222,8 @@ __all__ = [
     "PluginContext",
     "Plugin",
     "load_plugin",
+    "discover_plugins",
+    "list_available_plugins",
 ]
 
 
@@ -221,3 +231,11 @@ __all__ = [
 # utils/console.py imports from utils/log.py and utils/retention.py,
 # which are safe but we keep the import explicit for contract clarity.
 from .utils.console import SilentConsole  # noqa: E402
+
+# Plugin discovery is imported here (not at top) to avoid circular import:
+# plugin_loader imports from contract (Plugin, load_plugin), so we import
+# it after those symbols are defined.
+from .plugin_loader import (  # noqa: E402
+    discover_plugins,
+    list_available_plugins,
+)

--- a/src/movie_narrator/models.py
+++ b/src/movie_narrator/models.py
@@ -80,7 +80,16 @@ class StepState:
 
 @dataclass
 class Services:
+    """Container for infrastructure services injected into the pipeline.
+
+    Plugins can access ``ctx.services.logger`` to emit structured log
+    messages without importing a specific logging framework. The logger
+    field accepts any object with ``info``, ``warning``, and ``error``
+    methods (duck-typed), defaulting to ``None`` when not configured.
+    """
+
     console: Console
+    logger: Optional[Any] = None
 
 
 class ScriptSegment(BaseModel):

--- a/src/movie_narrator/plugin_loader.py
+++ b/src/movie_narrator/plugin_loader.py
@@ -1,0 +1,129 @@
+"""Plugin discovery via Python entry points.
+
+This module implements automatic plugin discovery using the standard
+``importlib.metadata`` entry points mechanism. Third-party packages
+declare a plugin in their ``pyproject.toml``::
+
+    [project.entry-points."movie_narrator.plugins"]
+    my-plugin = "my_plugin:MyPluginClass"
+
+At runtime, :func:`discover_plugins` scans all installed entry points
+in the ``movie_narrator.plugins`` group, loads each plugin object,
+and registers it via :func:`contract.load_plugin`.
+
+Error handling is per-plugin: a broken plugin produces a warning but
+does not prevent other plugins from loading.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import Any, List
+
+from .contract import Plugin, load_plugin
+
+#: Entry point group name for movie-narrator plugins.
+ENTRY_POINT_GROUP = "movie_narrator.plugins"
+
+
+@dataclass
+class PluginLoadResult:
+    """Result of loading a single plugin."""
+
+    name: str
+    success: bool
+    error: str = ""
+
+
+def _load_entry_point(ep: Any) -> Plugin:
+    """Load an entry point and return the plugin object.
+
+    The entry point must resolve to an object implementing the
+    :class:`~movie_narrator.contract.Plugin` protocol — i.e. it has
+    a ``name`` attribute and a ``register`` method.
+
+    Raises:
+        TypeError: if the loaded object does not satisfy the Plugin protocol.
+        Exception: any exception from the entry point load itself.
+    """
+    obj = ep.load()
+
+    # If it's a class, instantiate it (no-arg constructor expected).
+    # If it's already an instance, use as-is.
+    if isinstance(obj, type):
+        obj = obj()
+
+    if not isinstance(obj, Plugin):
+        raise TypeError(
+            f"Entry point '{ep.name}' loaded object {obj!r} does not "
+            f"implement the Plugin protocol (missing 'name' attribute "
+            f"or 'register' method)."
+        )
+
+    return obj
+
+
+def discover_plugins(*, group: str = ENTRY_POINT_GROUP) -> List[PluginLoadResult]:
+    """Discover and load all plugins registered via entry points.
+
+    Scans the ``movie_narrator.plugins`` entry point group, loads
+    each plugin, and registers it with the global registries via
+    :func:`~movie_narrator.contract.load_plugin`.
+
+    Args:
+        group: Entry point group name. Defaults to
+            ``"movie_narrator.plugins"``.
+
+    Returns:
+        List of :class:`PluginLoadResult` describing each plugin's
+        load outcome. Plugins that failed to load have
+        ``success=False`` and a non-empty ``error`` message.
+
+    This function is idempotent: calling it multiple times will
+    attempt to re-register already-loaded plugins, which will raise
+    ``ValueError`` from the registry (duplicate name). Those errors
+    are caught and reported as failed loads.
+    """
+    results: List[PluginLoadResult] = []
+
+    try:
+        eps = entry_points(group=group)
+    except TypeError:
+        # Python 3.9 fallback (dict interface) — we require 3.10+,
+        # but be defensive in case of unusual environments.
+        all_eps = entry_points()
+        eps = all_eps.get(group, [])
+
+    for ep in eps:
+        try:
+            plugin = _load_entry_point(ep)
+            load_plugin(plugin)
+            results.append(PluginLoadResult(name=plugin.name, success=True))
+        except Exception as exc:
+            msg = f"Failed to load plugin '{ep.name}': {exc}"
+            warnings.warn(msg, stacklevel=2)
+            results.append(
+                PluginLoadResult(name=ep.name, success=False, error=str(exc))
+            )
+
+    return results
+
+
+def list_available_plugins(*, group: str = ENTRY_POINT_GROUP) -> List[str]:
+    """List plugin names available via entry points (without loading).
+
+    Args:
+        group: Entry point group name.
+
+    Returns:
+        List of entry point names in the group.
+    """
+    try:
+        eps = entry_points(group=group)
+    except TypeError:
+        all_eps = entry_points()
+        eps = all_eps.get(group, [])
+
+    return [ep.name for ep in eps]

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -12,9 +12,7 @@ Covers:
 from __future__ import annotations
 
 import logging
-from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
-from importlib.metadata import EntryPoint
 
 import pytest
 
@@ -34,14 +32,35 @@ from movie_narrator.utils.console import SilentConsole
 # ── Helpers ───────────────────────────────────────────────
 
 
-def _make_fake_entry_point(name: str, obj) -> EntryPoint:
-    """Create a fake EntryPoint that loads *obj*."""
-    # EntryPoint is a namedtuple-like in 3.10+, but we use the
-    # real class with load() patched.
-    ep = EntryPoint(name=name, group=ENTRY_POINT_GROUP, value="fake:Fake")
-    # Monkey-patch load to return our object
+def _make_fake_entry_point(name: str, obj) -> MagicMock:
+    """Create a fake EntryPoint that loads *obj*.
+
+    Uses ``MagicMock`` instead of the real ``EntryPoint`` class because
+    ``EntryPoint`` became a frozen dataclass in Python 3.11+, making its
+    attributes immutable. ``MagicMock`` provides the same duck-typed
+    interface (``.name``, ``.group``, ``.load()``) that
+    ``_load_entry_point`` and ``discover_plugins`` rely on.
+    """
+    ep = MagicMock()
+    ep.name = name
+    ep.group = ENTRY_POINT_GROUP
+    ep.value = "fake:Fake"
     ep.load = MagicMock(return_value=obj)
     return ep
+
+
+@pytest.fixture(autouse=True)
+def _clean_step_registry():
+    """Auto-cleanup: remove any steps registered during a test.
+
+    Prevents test pollution when a test fails mid-way after calling
+    ``load_plugin()`` but before its explicit cleanup runs.
+    """
+    before = set(step_registry.names())
+    yield
+    after = set(step_registry.names())
+    for name in after - before:
+        step_registry.unregister(name)
 
 
 class FakePlugin:

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -1,0 +1,343 @@
+"""Tests for plugin discovery via entry_points and Services extension.
+
+Covers:
+- discover_plugins() with mocked entry points
+- list_available_plugins()
+- PluginLoadResult dataclass
+- _load_entry_point helper (class vs instance)
+- Services.logger optional field
+- SDK exports for discover_plugins / list_available_plugins
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import FrozenInstanceError
+from unittest.mock import MagicMock, patch
+from importlib.metadata import EntryPoint
+
+import pytest
+
+from movie_narrator.plugin_loader import (
+    ENTRY_POINT_GROUP,
+    PluginLoadResult,
+    _load_entry_point,
+    discover_plugins,
+    list_available_plugins,
+)
+from movie_narrator.contract import Plugin, PluginContext, load_plugin
+from movie_narrator.models import Context, Services, Assets
+from movie_narrator.pipeline.registry import step_registry
+from movie_narrator.utils.console import SilentConsole
+
+
+# ── Helpers ───────────────────────────────────────────────
+
+
+def _make_fake_entry_point(name: str, obj) -> EntryPoint:
+    """Create a fake EntryPoint that loads *obj*."""
+    # EntryPoint is a namedtuple-like in 3.10+, but we use the
+    # real class with load() patched.
+    ep = EntryPoint(name=name, group=ENTRY_POINT_GROUP, value="fake:Fake")
+    # Monkey-patch load to return our object
+    ep.load = MagicMock(return_value=obj)
+    return ep
+
+
+class FakePlugin:
+    """A minimal valid plugin for testing.
+
+    Uses a unique step name per instance to avoid cross-test
+    contamination of the global step_registry.
+    """
+
+    _counter = 0
+
+    def __init__(self):
+        self.registered = False
+        FakePlugin._counter += 1
+        self.name = f"fake-{FakePlugin._counter}"
+        self._step_name = f"fake_step_{FakePlugin._counter}"
+
+    def register(self, ctx: PluginContext) -> None:
+        self.registered = True
+        # Register a dummy step to verify registry integration
+        def my_step(ctx):
+            return ctx
+
+        ctx.steps.register(self._step_name, my_step, after="resolve_video")
+
+
+class FakePluginClass:
+    """A plugin class (not instance) for testing class instantiation."""
+
+    name = "fake-class"
+
+    def register(self, ctx: PluginContext) -> None:
+        pass
+
+
+class NotAPlugin:
+    """Does not implement the Plugin protocol."""
+
+    pass
+
+
+# ── PluginLoadResult tests ───────────────────────────────
+
+
+class TestPluginLoadResult:
+    """PluginLoadResult dataclass."""
+
+    def test_success_result(self):
+        r = PluginLoadResult(name="test", success=True)
+        assert r.name == "test"
+        assert r.success is True
+        assert r.error == ""
+
+    def test_failure_result(self):
+        r = PluginLoadResult(name="bad", success=False, error="boom")
+        assert r.name == "bad"
+        assert r.success is False
+        assert r.error == "boom"
+
+
+# ── _load_entry_point tests ──────────────────────────────
+
+
+class TestLoadEntryPoint:
+    """_load_entry_point helper function."""
+
+    def test_loads_instance(self):
+        plugin = FakePlugin()
+        ep = _make_fake_entry_point("fake", plugin)
+        loaded = _load_entry_point(ep)
+        assert loaded is plugin
+
+    def test_loads_class_and_instantiates(self):
+        ep = _make_fake_entry_point("fake-class", FakePluginClass)
+        loaded = _load_entry_point(ep)
+        assert isinstance(loaded, FakePluginClass)
+        assert loaded.name == "fake-class"
+
+    def test_rejects_non_plugin(self):
+        ep = _make_fake_entry_point("bad", NotAPlugin())
+        with pytest.raises(TypeError, match="does not implement the Plugin protocol"):
+            _load_entry_point(ep)
+
+
+# ── discover_plugins tests ───────────────────────────────
+
+
+class TestDiscoverPlugins:
+    """discover_plugins() function."""
+
+    def test_no_plugins_returns_empty_list(self):
+        """When no entry points exist, returns empty list."""
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = []
+            results = discover_plugins()
+            assert results == []
+
+    def test_loads_valid_plugin(self):
+        """A valid plugin is loaded and registered."""
+        plugin = FakePlugin()
+        ep = _make_fake_entry_point(plugin.name, plugin)
+
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep]
+            results = discover_plugins()
+
+        assert len(results) == 1
+        assert results[0].name == plugin.name
+        assert results[0].success is True
+        assert plugin.registered is True
+
+        # Cleanup
+        step_registry.unregister(plugin._step_name)
+
+    def test_broken_plugin_does_not_block_others(self):
+        """A broken plugin produces a failure result but others still load."""
+        good_plugin = FakePlugin()
+        ep_good = _make_fake_entry_point(good_plugin.name, good_plugin)
+        ep_bad = _make_fake_entry_point("bad", NotAPlugin())
+
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep_bad, ep_good]
+            results = discover_plugins()
+
+        assert len(results) == 2
+        # The broken one should fail
+        bad_result = next(r for r in results if r.name == "bad")
+        assert bad_result.success is False
+        assert "does not implement" in bad_result.error
+        # The good one should succeed
+        good_result = next(r for r in results if r.name == good_plugin.name)
+        assert good_result.success is True
+
+        # Cleanup
+        step_registry.unregister(good_plugin._step_name)
+
+    def test_duplicate_plugin_name_fails_gracefully(self):
+        """Loading a plugin whose step name is already taken fails gracefully."""
+        plugin1 = FakePlugin()
+        load_plugin(plugin1)  # Pre-register its step
+
+        plugin2 = FakePlugin()
+        # Force plugin2 to use the same step name as plugin1
+        plugin2._step_name = plugin1._step_name
+        ep1 = _make_fake_entry_point("fake1", plugin1)
+        ep2 = _make_fake_entry_point("fake2", plugin2)
+
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep1, ep2]
+            results = discover_plugins()
+
+        # First should fail (already loaded), second should fail (duplicate step)
+        assert results[0].success is False
+        assert "already registered" in results[0].error
+        assert results[1].success is False
+        assert "already registered" in results[1].error
+
+        # Cleanup
+        step_registry.unregister(plugin1._step_name)
+
+    def test_emits_warning_on_failure(self, recwarn):
+        """Failed plugin loads emit a UserWarning."""
+        ep = _make_fake_entry_point("bad", NotAPlugin())
+
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep]
+            discover_plugins()
+
+        assert len(recwarn) >= 1
+        assert any("Failed to load plugin" in str(w.message) for w in recwarn)
+
+
+# ── list_available_plugins tests ─────────────────────────
+
+
+class TestListAvailablePlugins:
+    """list_available_plugins() function."""
+
+    def test_returns_entry_point_names(self):
+        ep1 = _make_fake_entry_point("plugin-a", FakePlugin())
+        ep2 = _make_fake_entry_point("plugin-b", FakePlugin())
+
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep1, ep2]
+            names = list_available_plugins()
+
+        assert "plugin-a" in names
+        assert "plugin-b" in names
+
+    def test_empty_when_no_plugins(self):
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = []
+            names = list_available_plugins()
+        assert names == []
+
+
+# ── Services logger tests ────────────────────────────────
+
+
+class TestServicesLogger:
+    """Services.logger optional field."""
+
+    def test_logger_defaults_to_none(self):
+        svc = Services(console=SilentConsole())
+        assert svc.logger is None
+
+    def test_logger_can_be_set(self):
+        logger = logging.getLogger("test")
+        svc = Services(console=SilentConsole(), logger=logger)
+        assert svc.logger is logger
+
+    def test_logger_accepts_duck_typed_object(self):
+        """Any object with info/warning/error methods works."""
+        fake_logger = MagicMock()
+        svc = Services(console=SilentConsole(), logger=fake_logger)
+        svc.logger.info("test message")
+        fake_logger.info.assert_called_once_with("test message")
+
+    def test_context_services_logger_accessible(self):
+        """ctx.services.logger is accessible from step functions."""
+        fake_logger = MagicMock()
+        ctx = Context(
+            movie_name="test",
+            output_dir="/tmp/test",
+            services=Services(console=SilentConsole(), logger=fake_logger),
+        )
+        assert ctx.services.logger is fake_logger
+
+
+# ── SDK export tests ─────────────────────────────────────
+
+
+class TestSDKExports:
+    """Verify new SDK symbols are exported from movie_narrator."""
+
+    def test_discover_plugins_exported(self):
+        from movie_narrator import discover_plugins
+        assert callable(discover_plugins)
+
+    def test_list_available_plugins_exported(self):
+        from movie_narrator import list_available_plugins
+        assert callable(list_available_plugins)
+
+    def test_services_exported(self):
+        from movie_narrator import Services as ExportedServices
+        from movie_narrator.models import Services
+        assert ExportedServices is Services
+
+    def test_entry_point_group_constant(self):
+        assert ENTRY_POINT_GROUP == "movie_narrator.plugins"
+
+    def test_discover_plugins_in_contract_all(self):
+        from movie_narrator import contract
+        assert "discover_plugins" in contract.__all__
+        assert "list_available_plugins" in contract.__all__
+        assert "Services" in contract.__all__
+
+
+# ── Integration: full discovery flow ─────────────────────
+
+
+class TestDiscoveryIntegration:
+    """End-to-end: entry point -> load_plugin -> registry."""
+
+    def test_discovered_plugin_registers_step(self):
+        """A plugin discovered via entry_points actually registers a step."""
+        plugin = FakePlugin()
+        ep = _make_fake_entry_point(plugin.name, plugin)
+
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep]
+            results = discover_plugins()
+
+        assert results[0].success is True
+        assert step_registry.contains(plugin._step_name)
+
+        # Verify ordering: plugin step should be after resolve_video
+        names = step_registry.ordered_names()
+        if "resolve_video" in names:
+            assert names.index(plugin._step_name) > names.index("resolve_video")
+
+        # Cleanup
+        step_registry.unregister(plugin._step_name)
+
+    def test_manual_load_then_discover_idempotency(self):
+        """Manually loading then discovering reports duplicate as failure."""
+        plugin = FakePlugin()
+        load_plugin(plugin)
+
+        ep = _make_fake_entry_point(plugin.name, plugin)
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
+            mock_ep.return_value = [ep]
+            results = discover_plugins()
+
+        assert results[0].success is False
+        assert "already registered" in results[0].error
+
+        # Cleanup
+        step_registry.unregister(plugin._step_name)


### PR DESCRIPTION
## M2 — SDK 冻结

### 新增

**1. Plugin 自动发现 (entry_points)**
- `plugin_loader.py`: `discover_plugins()` 通过 `importlib.metadata` 扫描 `movie_narrator.plugins` entry point group
- 每个插件独立错误隔离 — 一个插件加载失败不影响其他插件
- `list_available_plugins()`: 列出可用插件名（不加载）
- `PluginLoadResult`: 记录每个插件的加载结果

**2. Services 扩展**
- `Services.logger`: 可选字段（默认 None），接受任何有 `.info/.warning/.error` 方法的对象
- 插件可通过 `ctx.services.logger` 输出结构化日志，无需依赖特定日志框架

**3. 参考插件 (examples/plugins/watermark/)**
- 完整的 out-of-tree 插件示例：水印叠加步骤
- 演示 entry_points 声明、Plugin 协议实现、软步骤注册、ffmpeg 集成
- 可 `pip install -e .` 安装后自动发现

**4. 插件开发指南 (docs/PLUGIN_DEVELOPMENT.md)**
- Quick Start、SDK 表面清单、步骤注册/排序/软硬分类
- TTS/Vision provider 注册示例
- 兼容策略文档（v0.5 稳定保证 + v0.6 变更预期）

**5. 测试 (tests/test_plugin_discovery.py)**
- 23 个测试覆盖：entry_points 发现、加载、错误隔离、重复检测
- Services.logger 字段验证、SDK 导出验证、端到端集成测试

### 验证
- 275 核心测试通过，零回归
- 81 个插件相关测试通过（58 registry + 23 discovery）

### 文件变更
```
 docs/PLUGIN_DEVELOPMENT.md                          |  新增
 examples/plugins/watermark/README.md                |  新增
 examples/plugins/watermark/movie_narrator_watermark/__init__.py |  新增
 examples/plugins/watermark/movie_narrator_watermark/plugin.py    |  新增
 examples/plugins/watermark/pyproject.toml           |  新增
 src/movie_narrator/__init__.py                      |  修改 (导出 discover_plugins, Services)
 src/movie_narrator/contract.py                      |  修改 (导出 discover_plugins, Services)
 src/movie_narrator/models.py                        |  修改 (Services.logger 字段)
 src/movie_narrator/plugin_loader.py                 |  新增
 tests/test_plugin_discovery.py                      |  新增
```