### PR TITLE
feat(WP6): scene filtering — intro skip + dark frame drop + highlight window

### DIFF
--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -676,6 +676,48 @@ def _match_clips_impl(
             for i, s in enumerate(scenes):
                 s.index = i
 
+    # ── WP6: Scene filtering (intro skip + dark frame + highlight window) ──
+    # All three are opt-in via job params. Order: intro → dark → window.
+    # Each filter is independently toggleable; defaults preserve existing
+    # behavior (no filtering when params are absent or zero).
+    from .scene_filter import (
+        apply_source_window,
+        filter_dark_scenes,
+        filter_intro_scenes,
+    )
+
+    skip_intro = ctx.metadata.get("match_skip_intro_sec", 0.0)
+    if skip_intro > 0:
+        scenes, intro_dropped = filter_intro_scenes(scenes, skip_intro)
+        if intro_dropped:
+            ctx.services.console.debug(
+                f"  WP6 intro skip: dropped {intro_dropped} scenes "
+                f"(end <= {skip_intro}s) → {len(scenes)} remaining"
+            )
+            ctx.metadata["wp6_intro_dropped"] = intro_dropped
+
+    dark_luma = ctx.metadata.get("match_drop_dark_luma", 0.0)
+    if dark_luma > 0:
+        scenes, dark_dropped = filter_dark_scenes(
+            scenes, ctx.source_video_path, dark_luma
+        )
+        if dark_dropped:
+            ctx.services.console.debug(
+                f"  WP6 dark drop: removed {dark_dropped} scenes "
+                f"(luma < {dark_luma}) → {len(scenes)} remaining"
+            )
+            ctx.metadata["wp6_dark_dropped"] = dark_dropped
+
+    source_window = ctx.metadata.get("match_source_window")
+    if source_window:
+        scenes, win_dropped = apply_source_window(scenes, source_window)
+        if win_dropped:
+            ctx.services.console.debug(
+                f"  WP6 highlight window {source_window}: "
+                f"dropped {win_dropped} scenes → {len(scenes)} remaining"
+            )
+            ctx.metadata["wp6_window_dropped"] = win_dropped
+
     # Compute total scene span
     scene_start = min(s.start for s in scenes)
     scene_end = max(s.end for s in scenes)

--- a/src/movie_narrator/pipeline/scene_filter.py
+++ b/src/movie_narrator/pipeline/scene_filter.py
@@ -1,0 +1,248 @@
+"""WP6: Scene filtering — intro skip, dark frame drop, highlight window.
+
+These filters run *after* scene detection and *before* match, reducing
+the candidate pool to scenes that are likely to carry meaningful footage.
+
+All three filters are opt-in via job params (defaults preserve existing
+behavior). Each filter is independently toggleable so L2 hand-test can
+isolate the effect of each.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from ..models import Scene
+
+logger = logging.getLogger(__name__)
+
+
+# ── 9.1 Intro skip ─────────────────────────────────────────
+
+
+def filter_intro_scenes(
+    scenes: List[Scene],
+    skip_intro_sec: float,
+) -> Tuple[List[Scene], int]:
+    """Drop scenes that end before ``skip_intro_sec``.
+
+    Studios logos and title cards typically occupy the first 30–90s.
+    If filtering would remove *all* scenes, the original list is
+    returned unchanged (skip is ignored).
+
+    Returns ``(filtered_scenes, dropped_count)``.
+    """
+    if skip_intro_sec <= 0 or not scenes:
+        return scenes, 0
+
+    filtered = [s for s in scenes if s.end > skip_intro_sec]
+    if not filtered:
+        # Don't nuke everything — skip is advisory
+        return scenes, 0
+
+    dropped = len(scenes) - len(filtered)
+    # Re-index
+    for i, s in enumerate(filtered):
+        s.index = i
+    return filtered, dropped
+
+
+# ── 9.2 Dark frame drop ────────────────────────────────────
+
+
+def _video_hash(video_path: str) -> str:
+    """Lightweight cache key from file stat (mtime + size)."""
+    s = os.stat(video_path)
+    raw = f"{s.st_mtime}_{s.st_size}".encode()
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _extract_mid_frame(
+    video_path: str,
+    timestamp: float,
+    output_path: Path,
+) -> bool:
+    """Extract a single frame at *timestamp* using ffmpeg.
+
+    Returns ``True`` on success, ``False`` on failure (ffmpeg missing,
+    corrupt video, etc.).
+    """
+    ffmpeg_bin = shutil.which("ffmpeg")
+    if not ffmpeg_bin:
+        return False
+
+    try:
+        result = subprocess.run(
+            [
+                ffmpeg_bin,
+                "-y",           # overwrite
+                "-ss", str(timestamp),  # seek to timestamp
+                "-i", video_path,
+                "-frames:v", "1",      # extract exactly 1 frame
+                "-q:v", "2",            # high quality JPEG
+                "-f", "image2",
+                str(output_path),
+            ],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0 and output_path.exists()
+    except Exception as e:
+        logger.debug("frame extraction failed at %.1fs: %s", timestamp, e)
+        return False
+
+
+def _compute_mean_luma(image_path: Path) -> Optional[float]:
+    """Compute mean luminance of an image (0–255 scale).
+
+    Uses PIL's ``convert("L")`` (ITU-R 601-2 luma transform).
+    Returns ``None`` when PIL is unavailable or the image is corrupt.
+    """
+    try:
+        from PIL import Image
+        img = Image.open(image_path).convert("L")
+        # Small images: use histogram; for larger ones, downscale first
+        if img.width > 64:
+            img = img.resize((64, 64))
+        pixels = list(img.getdata())
+        if not pixels:
+            return None
+        return sum(pixels) / len(pixels)
+    except Exception as e:
+        logger.debug("luma computation failed: %s", e)
+        return None
+
+
+def filter_dark_scenes(
+    scenes: List[Scene],
+    video_path: Optional[str],
+    luma_threshold: float,
+    cache_dir: Optional[Path] = None,
+) -> Tuple[List[Scene], int]:
+    """Drop scenes whose mid-frame mean luma is below *luma_threshold*.
+
+    Extracts one frame at each scene's midpoint, computes mean luminance
+    via PIL, and drops scenes darker than the threshold (e.g. black
+    screens, fade-to-black transitions).
+
+    If filtering would remove *all* scenes, the original list is
+    returned unchanged. Frames are cached by video hash + scene index
+    to avoid re-extraction on re-runs.
+
+    Returns ``(filtered_scenes, dropped_count)``.
+    """
+    if luma_threshold <= 0 or not scenes or not video_path:
+        return scenes, 0
+
+    # Check ffmpeg availability upfront
+    if not shutil.which("ffmpeg"):
+        logger.debug("ffmpeg not found — dark frame filter skipped")
+        return scenes, 0
+
+    # Check PIL availability
+    try:
+        from PIL import Image  # noqa: F401
+    except ImportError:
+        logger.debug("PIL not found — dark frame filter skipped")
+        return scenes, 0
+
+    vid_hash = _video_hash(video_path)
+    if cache_dir is None:
+        cache_dir = Path(video_path).parent / ".frame_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    kept: List[Scene] = []
+    dropped = 0
+    for scene in scenes:
+        mid_ts = (scene.start + scene.end) / 2.0
+        frame_path = cache_dir / f"{vid_hash}_scene{scene.index}_{mid_ts:.1f}.jpg"
+
+        if not frame_path.exists():
+            if not _extract_mid_frame(video_path, mid_ts, frame_path):
+                # Extraction failed — keep the scene (don't drop on error)
+                kept.append(scene)
+                continue
+
+        luma = _compute_mean_luma(frame_path)
+        if luma is None:
+            # Computation failed — keep the scene
+            kept.append(scene)
+            continue
+
+        if luma < luma_threshold:
+            dropped += 1
+            logger.debug(
+                "  WP6 dark drop: scene %d (luma=%.1f < %.1f)",
+                scene.index, luma, luma_threshold,
+            )
+        else:
+            kept.append(scene)
+
+    if not kept:
+        return scenes, 0
+
+    # Re-index
+    for i, s in enumerate(kept):
+        s.index = i
+    return kept, dropped
+
+
+# ── 9.3 Highlight window ───────────────────────────────────
+
+
+def apply_source_window(
+    scenes: List[Scene],
+    window: Optional[list],
+) -> Tuple[List[Scene], int]:
+    """Restrict scenes to the [start_ratio, end_ratio] time window.
+
+    The window is expressed as ratios of the total scene span.
+    Scenes that fall entirely outside the window are dropped.
+    Scenes that partially overlap are clipped to the window bounds.
+
+    Returns ``(filtered_scenes, dropped_count)``.
+    """
+    if not window or not scenes or len(window) != 2:
+        return scenes, 0
+
+    start_ratio, end_ratio = window[0], window[1]
+    if start_ratio <= 0.0 and end_ratio >= 1.0:
+        return scenes, 0  # no-op for full-span window
+
+    scene_start = min(s.start for s in scenes)
+    scene_end = max(s.end for s in scenes)
+    span = scene_end - scene_start
+    if span <= 0:
+        return scenes, 0
+
+    win_start = scene_start + start_ratio * span
+    win_end = scene_start + end_ratio * span
+
+    kept: List[Scene] = []
+    dropped = 0
+    for scene in scenes:
+        # Scene is entirely before or after the window → drop
+        if scene.end <= win_start or scene.start >= win_end:
+            dropped += 1
+            continue
+        # Clip scene to window bounds
+        new_start = max(scene.start, win_start)
+        new_end = min(scene.end, win_end)
+        kept.append(Scene(
+            index=0,  # re-indexed below
+            start=new_start,
+            end=new_end,
+        ))
+
+    if not kept:
+        return scenes, 0
+
+    for i, s in enumerate(kept):
+        s.index = i
+    return kept, dropped

--- a/src/movie_narrator/presets/base.py
+++ b/src/movie_narrator/presets/base.py
@@ -38,6 +38,10 @@ ALLOWED_PARAM_KEYS: frozenset[str] = frozenset({
     "scene_merge_min_duration",
     "match_drop_scene_min_duration",
     "match_min_score",
+    # WP6: scene filtering
+    "match_skip_intro_sec",
+    "match_drop_dark_luma",
+    "match_source_window",
     # BGM
     "bgm_gain_db",
     "bgm_duck_db",

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -41,6 +41,11 @@ class JobParams(BaseModel):
     # ── Vision (EP8) ──
     # "none" (default) | "stub" | future providers (http_vlm, blip, etc.)
     vision_captioner: Optional[str] = None
+    # ── WP6: scene filtering ──
+    # intro skip, dark frame drop, highlight window (all opt-in, default off)
+    match_skip_intro_sec: Optional[float] = None  # drop scenes ending before this offset (default 0)
+    match_drop_dark_luma: Optional[float] = None  # mean luma threshold for dark frame drop (default 0 = disabled; try 16-30)
+    match_source_window: Optional[list] = None  # [start_ratio, end_ratio] highlight window (default [0.0, 1.0])
     # ── BGM ──
     bgm_gain_db: Optional[float] = None
     bgm_duck_db: Optional[float] = None

--- a/tests/test_wp6_scene_filter.py
+++ b/tests/test_wp6_scene_filter.py
@@ -1,0 +1,370 @@
+"""Tests for WP6 scene filtering — intro skip, dark frame drop, highlight window.
+
+All tests use mocks for ffmpeg/PIL so they run in CI without media extras.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from movie_narrator.models import Scene, Services, SilentConsole
+from movie_narrator.pipeline.scene_filter import (
+    apply_source_window,
+    filter_dark_scenes,
+    filter_intro_scenes,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────
+
+
+def _scenes() -> list[Scene]:
+    """8 scenes spanning 0–80s (10s each)."""
+    return [Scene(index=i, start=i * 10.0, end=(i + 1) * 10.0) for i in range(8)]
+
+
+# ── 9.1 Intro skip ─────────────────────────────────────────
+
+
+class TestFilterIntroScenes:
+    def test_no_skip_returns_unchanged(self):
+        """skip_intro_sec=0 → no filtering."""
+        scenes = _scenes()
+        result, dropped = filter_intro_scenes(scenes, 0.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_negative_skip_returns_unchanged(self):
+        scenes = _scenes()
+        result, dropped = filter_intro_scenes(scenes, -5.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_skip_drops_early_scenes(self):
+        """skip_intro_sec=30 drops scenes ending at 10, 20, 30."""
+        scenes = _scenes()
+        result, dropped = filter_intro_scenes(scenes, 30.0)
+        assert dropped == 3  # scenes 0,1,2 end at 10,20,30
+        assert len(result) == 5
+        # Re-indexed from 0
+        assert result[0].index == 0
+        assert result[0].start == 30.0
+        assert result[-1].end == 80.0
+
+    def test_skip_all_scenes_returns_original(self):
+        """If skip would remove all scenes, return original list."""
+        scenes = _scenes()
+        result, dropped = filter_intro_scenes(scenes, 999.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_empty_scenes_returns_empty(self):
+        result, dropped = filter_intro_scenes([], 30.0)
+        assert result == []
+        assert dropped == 0
+
+    def test_re_index_after_drop(self):
+        """Scene indices are sequential after filtering."""
+        scenes = _scenes()
+        result, _ = filter_intro_scenes(scenes, 25.0)
+        for i, s in enumerate(result):
+            assert s.index == i
+
+
+# ── 9.2 Dark frame drop ────────────────────────────────────
+
+
+class TestFilterDarkScenes:
+    def test_no_threshold_returns_unchanged(self):
+        """luma_threshold=0 → no filtering."""
+        scenes = _scenes()
+        result, dropped = filter_dark_scenes(scenes, "video.mp4", 0.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_no_video_path_returns_unchanged(self):
+        scenes = _scenes()
+        result, dropped = filter_dark_scenes(scenes, None, 20.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_no_ffmpeg_returns_unchanged(self):
+        """When ffmpeg is not available, skip filtering."""
+        scenes = _scenes()
+        with patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value=None):
+            result, dropped = filter_dark_scenes(scenes, "video.mp4", 20.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_no_pil_returns_unchanged(self):
+        """When PIL is not available, skip filtering."""
+        scenes = _scenes()
+        with (
+            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch.dict(sys.modules, {"PIL": None, "PIL.Image": None}),
+        ):
+            result, dropped = filter_dark_scenes(scenes, "video.mp4", 20.0)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_drops_dark_scenes(self, tmp_path):
+        """Scenes with luma below threshold are dropped."""
+        scenes = _scenes()
+        # Create a dummy video file so _video_hash can stat it
+        video_path = tmp_path / "video.mp4"
+        video_path.write_bytes(b"fake_video")
+
+        # Mock ffmpeg extraction to create fake frame files
+        # Mock PIL to return low luma for scenes 0 and 3
+        fake_frames = {}
+
+        def fake_extract(video_path, timestamp, output_path):
+            output_path.write_bytes(b"fake_jpeg")
+            fake_frames[timestamp] = output_path
+            return True
+
+        class FakeImage:
+            def __init__(self, luma_val):
+                self._luma = luma_val
+                self.width = 64
+
+            def convert(self, mode):
+                return self
+
+            def resize(self, size):
+                return self
+
+            def getdata(self):
+                return [self._luma] * (64 * 64)
+
+        luma_map = {
+            5.0: 5.0,    # scene 0 mid → dark
+            15.0: 50.0,  # scene 1 mid → bright
+            25.0: 80.0,  # scene 2 mid → bright
+            35.0: 3.0,   # scene 3 mid → dark
+            45.0: 60.0,  # scene 4 mid → bright
+            55.0: 70.0,  # scene 5 mid → bright
+            65.0: 40.0,  # scene 6 mid → bright
+            75.0: 90.0,  # scene 7 mid → bright
+        }
+
+        def fake_open(path):
+            # Find the matching timestamp
+            for ts, fp in fake_frames.items():
+                if str(fp) == str(path):
+                    return FakeImage(luma_map.get(ts, 50.0))
+            return FakeImage(50.0)
+
+        fake_pil = MagicMock()
+        fake_pil.Image.open = fake_open
+        fake_pil.Image.__name__ = "Image"
+
+        with (
+            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("movie_narrator.pipeline.scene_filter._extract_mid_frame", side_effect=fake_extract),
+            patch.dict(sys.modules, {"PIL": fake_pil, "PIL.Image": fake_pil.Image}),
+        ):
+            result, dropped = filter_dark_scenes(
+                scenes, str(video_path), 20.0,
+                cache_dir=tmp_path / "cache",
+            )
+
+        assert dropped == 2  # scenes 0 and 3
+        assert len(result) == 6
+        for i, s in enumerate(result):
+            assert s.index == i
+
+    def test_extraction_failure_keeps_scene(self, tmp_path):
+        """When frame extraction fails, the scene is kept (not dropped)."""
+        scenes = _scenes()
+        video_path = tmp_path / "video.mp4"
+        video_path.write_bytes(b"fake_video")
+
+        with (
+            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("movie_narrator.pipeline.scene_filter._extract_mid_frame", return_value=False),
+        ):
+            result, dropped = filter_dark_scenes(
+                scenes, str(video_path), 20.0,
+                cache_dir=tmp_path / "cache",
+            )
+
+        assert dropped == 0
+        assert len(result) == 8  # all kept
+
+    def test_all_dark_returns_original(self, tmp_path):
+        """If all scenes would be dropped, return original list."""
+        scenes = _scenes()
+        video_path = tmp_path / "video.mp4"
+        video_path.write_bytes(b"fake_video")
+
+        with (
+            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("movie_narrator.pipeline.scene_filter._extract_mid_frame", return_value=True),
+            patch("movie_narrator.pipeline.scene_filter._compute_mean_luma", return_value=5.0),
+        ):
+            result, dropped = filter_dark_scenes(
+                scenes, str(video_path), 20.0,
+                cache_dir=tmp_path / "cache",
+            )
+
+        # All dark → return original (don't nuke everything)
+        assert result is scenes
+        assert dropped == 0
+
+
+# ── 9.3 Highlight window ───────────────────────────────────
+
+
+class TestApplySourceWindow:
+    def test_no_window_returns_unchanged(self):
+        scenes = _scenes()
+        result, dropped = apply_source_window(scenes, None)
+        assert result is scenes
+        assert dropped == 0
+
+    def test_full_span_window_returns_unchanged(self):
+        """[0.0, 1.0] is a no-op."""
+        scenes = _scenes()
+        result, dropped = apply_source_window(scenes, [0.0, 1.0])
+        assert result is scenes
+        assert dropped == 0
+
+    def test_window_drops_outside_scenes(self):
+        """[0.15, 0.85] drops scenes entirely outside the window."""
+        scenes = _scenes()
+        # Span is 0-80s; window is 12-68s
+        # Scene 0 (0-10) entirely before 12 → drop
+        # Scene 1 (10-20) partially overlaps → clipped to 12-20
+        # Scenes 2-6 fully inside
+        # Scene 7 (70-80) entirely after 68 → drop
+        result, dropped = apply_source_window(scenes, [0.15, 0.85])
+        assert dropped == 2
+        assert len(result) == 6
+        # First remaining scene is clipped scene 1
+        assert result[0].start == 12.0
+        assert result[0].end == 20.0
+        # Last remaining scene is scene 6
+        assert result[-1].start == 60.0
+        assert result[-1].end == 68.0  # clipped to window end
+
+    def test_window_clips_partial_overlap(self):
+        """Scenes partially overlapping the window are clipped."""
+        scenes = _scenes()
+        # Window 15-65 (span 0-80)
+        result, dropped = apply_source_window(scenes, [0.1875, 0.8125])
+        # Scene 0 (0-10) entirely before → dropped
+        # Scene 7 (70-80) entirely after → dropped
+        # Scene 1 (10-20) partially overlaps → clipped to 15-20
+        # Scene 6 (60-70) partially overlaps → clipped to 60-65
+        assert dropped == 2
+        assert len(result) == 6
+        # First remaining scene clipped
+        assert result[0].start == 15.0
+        assert result[0].end == 20.0
+        # Last remaining scene clipped
+        assert result[-1].start == 60.0
+        assert result[-1].end == 65.0
+
+    def test_empty_scenes_returns_empty(self):
+        result, dropped = apply_source_window([], [0.2, 0.8])
+        assert result == []
+        assert dropped == 0
+
+    def test_invalid_window_returns_unchanged(self):
+        scenes = _scenes()
+        result, dropped = apply_source_window(scenes, [0.2])  # only 1 element
+        assert result is scenes
+        assert dropped == 0
+
+    def test_re_index_after_drop(self):
+        scenes = _scenes()
+        result, _ = apply_source_window(scenes, [0.5, 1.0])
+        for i, s in enumerate(result):
+            assert s.index == i
+
+    def test_all_outside_returns_original(self):
+        """If window would drop all scenes, return original."""
+        scenes = [Scene(index=0, start=0.0, end=10.0)]
+        result, dropped = apply_source_window(scenes, [0.9, 1.0])
+        # Window is 9-10; scene 0-10 partially overlaps → clipped, not dropped
+        # So this should return 1 clipped scene
+        assert len(result) == 1
+        assert result[0].start == 9.0
+        assert result[0].end == 10.0
+
+
+# ── Integration: match.py WP6 params ───────────────────────
+
+
+class TestMatchWP6Integration:
+    """Verify that WP6 params flow through match_clips correctly."""
+
+    def _make_ctx(self, tmp_path, scenes, metadata=None):
+        from movie_narrator.models import Context, TimedSegment
+
+        ctx = Context(
+            movie_name="test",
+            output_dir=str(tmp_path),
+            source_video_path=str(tmp_path / "video.mp4"),
+            services=Services(console=SilentConsole()),
+        )
+        ctx.scenes = scenes
+        ctx.status.scene = "success"  # match_clips requires scene status != "disabled"
+        ctx.timed_segments = [
+            TimedSegment(text=f"segment {i}", start=float(i * 5), end=float(i * 5 + 4))
+            for i in range(4)
+        ]
+        if metadata:
+            ctx.metadata.update(metadata)
+        return ctx
+
+    def test_skip_intro_applied_in_match(self, tmp_path):
+        """match_skip_intro_sec filters scenes before matching."""
+        scenes = [Scene(index=i, start=i * 10.0, end=(i + 1) * 10.0) for i in range(8)]
+        ctx = self._make_ctx(tmp_path, scenes, {"match_skip_intro_sec": 30.0})
+
+        # Mock embedding to unavailable so we test heuristic path
+        with patch("movie_narrator.pipeline.match.probe", return_value=(False, "no st")):
+            from movie_narrator.pipeline.match import match_clips
+            match_clips(ctx)
+
+        assert ctx.status.match == "success"
+        assert ctx.metadata.get("wp6_intro_dropped") == 3
+        # Matched clips should reference scenes starting from 30s+
+        for mc in ctx.matched_clips:
+            assert mc.src_start >= 30.0
+
+    def test_source_window_applied_in_match(self, tmp_path):
+        """match_source_window restricts scenes to the window."""
+        scenes = [Scene(index=i, start=i * 10.0, end=(i + 1) * 10.0) for i in range(8)]
+        ctx = self._make_ctx(tmp_path, scenes, {"match_source_window": [0.15, 0.85]})
+
+        with patch("movie_narrator.pipeline.match.probe", return_value=(False, "no st")):
+            from movie_narrator.pipeline.match import match_clips
+            match_clips(ctx)
+
+        assert ctx.status.match == "success"
+        assert ctx.metadata.get("wp6_window_dropped") == 2
+        # All matched clips should be within 12-68s range (window of 0-80 span)
+        for mc in ctx.matched_clips:
+            assert mc.src_start >= 10.0  # first kept scene starts at 10 (clipped to 12)
+            assert mc.src_end <= 70.0    # last kept scene ends at 70 (clipped to 68)
+
+    def test_no_wp6_params_no_change(self, tmp_path):
+        """Without WP6 params, behavior is unchanged."""
+        scenes = [Scene(index=i, start=i * 10.0, end=(i + 1) * 10.0) for i in range(8)]
+        ctx = self._make_ctx(tmp_path, scenes)
+
+        with patch("movie_narrator.pipeline.match.probe", return_value=(False, "no st")):
+            from movie_narrator.pipeline.match import match_clips
+            match_clips(ctx)
+
+        assert ctx.status.match == "success"
+        assert "wp6_intro_dropped" not in ctx.metadata
+        assert "wp6_dark_dropped" not in ctx.metadata
+        assert "wp6_window_dropped" not in ctx.metadata


### PR DESCRIPTION
## WP6 Scene Filtering

Cherry-picks `feature/wp6-scene-filter` onto current main (post-M1/M2).

### Changes
- **`scene_filter.py`**: Three opt-in filters (all default off, zero behavior change)
  - `filter_intro_scenes`: drop scenes ending before a time offset (skip studio logos)
  - `filter_dark_scenes`: drop scenes with mean luma below threshold (skip black frames)
  - `apply_source_window`: keep only scenes within a [start, end] ratio window
- **`match.py`**: Integrates filters into `match_clips` step, applied after scene detection
- **`schema.py`**: Adds `match_skip_intro_sec`, `match_drop_dark_luma`, `match_source_window` to JobParams
- **`presets/base.py`**: Adds WP6 params to ALLOWED_PARAM_KEYS
- **`test_wp6_scene_filter.py`**: 24 tests covering all filters + match integration

### Conflict Resolution
- `schema.py`: Merged both M1 `vision_captioner` field and WP6 scene filter params
- `runner.py`: Kept M1 auto-derived `PARAM_WHITELIST = frozenset(JobParams.model_fields.keys())` — WP6 params are auto-included via JobParams
- `match.py`, `presets/base.py`: Auto-merged cleanly

### Test Results
- 252 core tests passed (zero regressions)
- 24 WP6 tests passed
- CI will validate on 3.10/3.11/3.12/3.13