### PR TITLE
fix(docs): correct WebSocket and REST API paths in architecture docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,7 @@ The external web package owns the full FastAPI + React stack and consumes the co
 
 ```text
 React SPA (in movie-narrator-web) — form / progress / artifacts view
-    ▼   REST (POST /api/jobs)  +  WebSocket (/ws/jobs/{id})
+    ▼   REST (POST /api/tasks)  +  WebSocket (/ws/task/{task_id})
 FastAPI app (in movie-narrator-web) — uvicorn on :8760
     ▼
 contract.py (core repo — stable API boundary, CONTRACT_VERSION = (0, 5, 0))

--- a/docs/ARCHITECTURE.zh-CN.md
+++ b/docs/ARCHITECTURE.zh-CN.md
@@ -78,7 +78,7 @@ run_pipeline(...) # STEPS 顺序不变
 
 ```text
 React SPA（位于 movie-narrator-web）— 表单 / 进度 / 产物视图
-    ▼   REST (POST /api/jobs)  +  WebSocket (/ws/jobs/{id})
+    ▼   REST (POST /api/tasks)  +  WebSocket (/ws/task/{task_id})
 FastAPI app（位于 movie-narrator-web）— uvicorn 监听 :8760
     ▼
 contract.py（核心 repo — 稳定 API 边界，CONTRACT_VERSION = (0, 5, 0)）


### PR DESCRIPTION
## Problem

Architecture documentation (`ARCHITECTURE.md` and `ARCHITECTURE.zh-CN.md`) referenced outdated endpoint paths that don't match the actual `movie-narrator-web` implementation:

- REST: `POST /api/jobs` (incorrect) → should be `POST /api/tasks`
- WebSocket: `/ws/jobs/{id}` (incorrect) → should be `/ws/task/{task_id}`

## Fix

Updated both English and Chinese architecture docs to use the correct endpoint paths that match the web package's `routes.py` and `ws.py` implementations.

## Verification

Confirmed the actual endpoints in `movie-narrator-web`:
- `routes.py`: `@router.post("/api/tasks")`
- `ws.py`: `@router.websocket("/ws/task/{task_id}")`
- Frontend `api.ts`: `getWsUrl()` uses `/ws/task/${taskId}`