### PR TITLE
docs: align all documentation with v0.5.0 status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 #### M2 — SDK freeze (#92)
 
-- **Plugin discovery via entry_points** (`plugin_loader.py`): automatic discovery of installed plugins through Python `importlib.metadata` entry points under the `movie_narrator.steps` and `movie_narrator.providers` groups (#92).
+- **Plugin discovery via entry_points** (`plugin_loader.py`): automatic discovery of installed plugins through Python `importlib.metadata` entry points under the `movie_narrator.plugins` group (#92).
 - **Services extension** (`models.py`): `Services` model now includes optional `logger` field for structured logging in plugins. `SilentConsole` remains the fallback when not provided (#92).
-- **Out-of-tree example plugin** (`examples/example_plugin/`): reference implementation showing step + provider registration, entry point declaration, and plugin lifecycle (#92).
-- **SDK compatibility docs** (`docs/sdk/`): plugin development guide, API reference, and compatibility matrix (#92).
+- **Out-of-tree example plugin** (`examples/plugins/watermark/`): reference implementation showing step + provider registration, entry point declaration, and plugin lifecycle (#92).
+- **SDK examples** (`examples/plugins/watermark/`): plugin development reference included in the example plugin README, covering `@register_step`, `@register_tts`, `Plugin` protocol, and entry point declaration (#92).
 - **EntryPoint immutability fix**: tests updated to use `MagicMock` for `EntryPoint` on Python 3.11+ where `EntryPoint` objects became immutable (#92).
 
 #### WP6 — Scene filtering (#93)

--- a/README.md
+++ b/README.md
@@ -468,15 +468,17 @@ movie-narrator/
 - [x] `export_clips` direct ffmpeg subprocess (design choice, not workaround)
 - [x] Config system overhaul: strict env/yaml boundary — `.env` (Settings) contains 21 LLM + TTS infrastructure fields only; `job.yaml` (params) contains all 32 pipeline behavior keys; YAML auto-discovery (`--config` not passed → `cwd/job.yaml` → packaged example); `.env.example` and `job.example.yaml` are the single sources of truth; no code constants module — inline literals match example files
 
-### v0.5.x — Ecosystem (Planned)
+### v0.5.x — Ecosystem
 
 > **Goal**: Freeze the public API surface (Pipeline, Workflow, Plugin, SDK) before Cloud features depend on it.
 
-- [ ] Plugin API for custom pipeline steps (step registration, lifecycle hooks, dependency declaration)
-- [ ] Python SDK for programmatic usage (`from movie_narrator import ...`)
-- [ ] Custom pipeline step registration (`@register_step`)
-- [ ] Third-party provider extensions (TTS, LLM, research backends via Plugin API)
-- [ ] Community extension discovery and packaging conventions
+- [x] Plugin API — StepRegistry + ProviderRegistry with `@register_step` / `@register_provider` decorators (#91)
+- [x] Python SDK — `from movie_narrator import ...` with stable `contract.py` surface (#92)
+- [x] Plugin discovery via `importlib.metadata` entry points (`movie_narrator.plugins` group) (#92)
+- [x] `Services.logger` for structured logging in plugins (#92)
+- [x] Out-of-tree example plugin (`examples/plugins/watermark/`) (#92)
+- [x] WP6 scene filtering — intro skip, dark frame detection, highlight window (#93)
+- [x] WebUI split — `movie-narrator-web` standalone repo, core engine is now pure CLI (#94, #95)
 
 > SDK and Plugin API are designed together — both must stabilize in the same release.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -458,15 +458,17 @@ movie-narrator/
 - [x] `export_clips` 直调 ffmpeg 子进程（设计选择，非临时方案）
 - [x] 配置系统全面重构：严格 env/yaml 边界 — `.env`（Settings）仅含 21 个 LLM + TTS 基础配置字段；`job.yaml`（params）含全部 32 个流水线行为键；YAML 自动发现（未传 `--config` → `cwd/job.yaml` → 打包示例）；`.env.example` 和 `job.example.yaml` 作为单一真相源；无代码常量模块——内联字面量与示例文件一致
 
-### v0.5.x — 生态系统（规划中）
+### v0.5.x — 生态系统
 
 > **目标**：在 Cloud 功能依赖之前，冻结公开 API 表面（Pipeline、Workflow、Plugin、SDK）。
 
-- [ ] 插件 API（自定义流水线步骤：步骤注册、生命周期钩子、依赖声明）
-- [ ] Python SDK（`from movie_narrator import ...`）
-- [ ] 自定义步骤注册（`@register_step`）
-- [ ] 第三方 Provider 扩展（TTS、LLM、研究后端，通过插件 API）
-- [ ] 社区扩展发现与打包规范
+- [x] 插件 API —— StepRegistry + ProviderRegistry，支持 `@register_step` / `@register_provider` 装饰器 (#91)
+- [x] Python SDK —— `from movie_narrator import ...`，稳定的 `contract.py` 接口 (#92)
+- [x] 通过 `importlib.metadata` entry points 发现插件（`movie_narrator.plugins` 组）(#92)
+- [x] `Services.logger` 供插件结构化日志使用 (#92)
+- [x] 树外示例插件（`examples/plugins/watermark/`）(#92)
+- [x] WP6 场景过滤 —— 片头跳过、黑帧检测、高亮窗口 (#93)
+- [x] WebUI 拆分 —— `movie-narrator-web` 独立仓库，核心引擎现为纯 CLI (#94, #95)
 
 > SDK 与 Plugin API 一起设计——两者必须在同一版本中稳定。
 

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -102,9 +102,13 @@ CI=1 mn create --movie "CI-Test" --style "测试" --duration 10 --keep-cache
 src/movie_narrator/
 ├── cli.py               # Typer CLI 入口（mn 命令）
 ├── config.py            # Settings（pydantic-settings，MN_* 环境变量）
-├── models.py            # Context、PipelineStatus、StepState 等数据模型
+├── models.py            # Context、PipelineStatus、StepState、Services 等数据模型
+├── contract.py          # 稳定 API 边界（CONTRACT_VERSION = (0, 5, 0)，web 包通过它消费引擎）
+├── plugin_loader.py     # 插件发现（entry_points）、StepRegistry、Plugin protocol、PluginContext
 ├── pipeline/
 │   ├── runner.py        # 15 步流水线编排（STEPS 列表 + build_context）
+│   ├── registry.py      # StepRegistry 与 runner 集成
+│   ├── scene_filter.py  # WP6 场景过滤（片头跳过、黑帧检测、高亮窗口）
 │   ├── resolve.py       # 源视频查找
 │   ├── script.py        # LLM 脚本生成（两阶段：beats → expansion）
 │   ├── tts.py           # TTS 编排（缓存 + 并发）
@@ -113,10 +117,11 @@ src/movie_narrator/
 │   ├── qa.py            # 成片质检（ffprobe）
 │   └── errors.py        # PipelineStrictError, PipelineCancelled, StepAction
 ├── tts/                 # TTS 抽象层（edge / openai / mimo）
+├── providers/           # ProviderRegistry（register_tts、register_vision）
+├── vision/              # VisionCaptioner 抽象（stub + http_vlm）
 ├── workflow/            # YAML 配置加载与合并
 ├── presets/             # 解说风格预设（douyin-fast / mainstream-dry / bilibili-long）
-├── utils/               # 工具函数（llm、font、json_parser 等）
-└── contract.py          # 核心 API 边界（web 包通过它消费引擎，见 movie-narrator-web）
+└── utils/               # 工具函数（llm、font、json_parser 等）
 ```
 
 > Web UI（FastAPI + React SPA）位于独立仓库 [`movie-narrator-web`](https://github.com/zcbacxc/movie-narrator-web)，通过 `pip install movie-narrator-web` 安装、`mn-web` 启动。核心 repo 不含 `web_api/` 或 `webui/` 目录。
@@ -133,6 +138,19 @@ src/movie_narrator/
 | env/yaml boundary | `.env` = LLM + TTS 凭证（24 项）；`job.yaml` = 行为参数（52 项） |
 
 ## 添加新 Pipeline 步骤
+
+### 推荐：插件 API（v0.5+）
+
+使用 `@register_step` 装饰器添加步骤，无需修改 runner：
+
+1. 创建步骤函数 `def my_step(ctx: Context) -> Context`
+2. 使用 `@register_step("my_step", soft=True, after="render_video")` 注册
+3. 在 `pyproject.toml` 中声明 entry point：`[project.entry-points."movie_narrator.plugins"]`
+4. 安装后自动发现
+
+参考实现：`examples/plugins/watermark/`
+
+### 旧方式：直接修改 STEPS
 
 1. 在 `src/movie_narrator/pipeline/` 新建模块，暴露 `def step_name(ctx: Context) -> Context`
 2. 软步骤：设置 `ctx.status.<field>` + `ctx.step_state`，失败时追加 `metadata.warnings`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ run_pipeline(...) # STEPS order unchanged
 - Soft steps honor `metadata["workflow_steps"][<field>] is False` → `status.<field> = "disabled"`
 - Params whitelist (48 keys: scene_threshold, scene_frame_skip, match_min_score, match_speed_clamp_min/max, scene_merge_min_duration, match_drop_scene_min_duration, embedding_model_name, bgm_gain_db, bgm_duck_db, bgm_normalize, audio_target_dbfs, tts_pause_ms, tts_max_concurrent, tts_audio_format, tts_audio_bitrate, translate_source_lang, translate_provider, translate_retries, translate_chunk_chars, translate_chunk_size, research_provider, whisperx_device/model/language, render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout, render_fit_mode/crf/preset/faststart, render_subtitle_position/max_width_ratio/bottom_margin_ratio, qa_enabled/qa_max_silence_db/qa_min_duration_ratio/qa_max_duration_ratio, prompt_target_sentences/prompt_target_segment_duration/prompt_max_chars_per_sentence/prompt_hook_seconds, async_timeout, async_max_workers, video_sizes) land in `ctx.metadata` via `build_context` copy loop
 - Multi-language subtitle top-level keys: `subtitle_lang`, `subtitle_mode` (validated in `JobConfig` — `subtitle_mode ∈ {translated, bilingual}` without `subtitle_lang` raises `JobConfigError` at merge time)
-- `STEPS` remains the single source of step order; no DAG / plugins in v0.3
+- `STEPS` remains the single source of step order; since v0.5, custom steps can be added via `@register_step` plugin API (see Plugin System section below)
 - YAML auto-discovery: `--config` not passed → `cwd/job.yaml` → packaged `examples/job.example.yaml` → none
 - `.env.example` is the single source of truth for first-run config (read by `ensure_user_config()`, not a divergent inline template)
 - Strict env/yaml boundary: `.env` (Settings) = 24 LLM + TTS infrastructure fields only; `job.yaml` (params) = 48 pipeline behavior keys; no code constants module — inline literals match example files
@@ -125,6 +125,14 @@ movie-narrator-web  →  contract.py  →  pipeline/runner.py (build_context, ru
 | `RunController` / `StepAction` / `check_cancelled` | pipeline/errors.py | Cooperative cancel + retry protocol |
 | `sanitize_filename` | utils/sanitize.py | Cross-platform filename sanitization |
 | `CONTRACT_VERSION` | contract.py | `(0, 5, 0)` — version the external `movie-narrator-web` package checks against at import time |
+| `StepRegistry` / `step_registry` | plugin_loader.py | Central registry for pipeline step plugins; `step_registry` is the global instance |
+| `ProviderRegistry` / `tts_registry` / `vision_registry` | providers/registry.py | Provider registration system for TTS, vision, and future provider types |
+| `register_step` / `step` | plugin_loader.py | Decorator-based step registration (`@register_step("name", ...)` or `@step("name")`) |
+| `register_tts` / `register_vision` | providers/registry.py | Decorator-based provider registration for TTS and vision providers |
+| `Plugin` / `PluginContext` | plugin_loader.py | `Plugin` protocol (`name` + `register(ctx)`) and `PluginContext` (holds `steps`, `tts`, `vision`, `services`) |
+| `load_plugin` / `discover_plugins` / `list_available_plugins` | plugin_loader.py | Manual plugin loading, entry_points auto-discovery, and plugin listing |
+| `Step` | plugin_loader.py | Dataclass describing a registered step (name, func, soft, before, after) |
+| `list_presets` / `get_preset` | presets/ | Public SDK exports for narration preset introspection |
 
 ### Modules — `vision/` (Visual scene captioning, v0.4.26+)
 
@@ -399,12 +407,67 @@ segment's end. This is preferable to a 100ms flash on screen.
 
 ## Extension Points
 
-- **New pipeline step**: append to `STEPS` in `pipeline/runner.py`. Signature must be `(ctx: Context) -> Context`.
+- **New pipeline step (recommended)**: use `@register_step("name", ...)` decorator via the Plugin API. The step is auto-discovered if packaged as an entry_points plugin, or can be loaded manually via `load_plugin()`. See `examples/plugins/watermark/` for a reference implementation.
+- **New pipeline step (legacy)**: append directly to `STEPS` in `pipeline/runner.py`. Signature must be `(ctx: Context) -> Context`.
 - **Swap TTS/renderer/LLM**: replace `pipeline/tts.py`, `pipeline/render.py`, or `utils/llm.py` while keeping the step function signature.
-- **New VisionCaptioner provider**: implement `VisionCaptioner` ABC in `vision/`, register in `vision/factory.py`. See `vision/stub.py` for reference. Match logic auto-detects fake vs real captions via `is_stub` flag.
+- **New TTS/Vision provider (recommended)**: use `@register_tts("name")` or `@register_vision("name")` decorator via the Provider Registry. The provider is auto-discovered if packaged as an entry_points plugin.
+- **New VisionCaptioner provider (legacy)**: implement `VisionCaptioner` ABC in `vision/`, register in `vision/factory.py`. See `vision/stub.py` for reference. Match logic auto-detects fake vs real captions via `is_stub` flag.
 - **Pipeline pause/resume**: `--pause-at script|match` pauses after the step; `mn resume <output_dir>` continues. State serialized to `pipeline_state.json`.
 - **New CLI command**: add `@app.command()` in `cli.py`.
 - **Frontend / WebUI**: the React SPA and FastAPI backend now live in the external repo [`movie-narrator-web`](https://github.com/zcbacxc/movie-narrator-web) (Vite + TypeScript + shadcn/ui + Tailwind CSS, served on port 8760 via the `mn-web` command). To extend the web layer, work inside that repository — the core `movie-narrator` repo no longer ships `web_api/` or `webui/`, and there is no `mn web` command or `[web]` extra here. Any new engine capability the web package needs must be exposed through `contract.py` (bump `CONTRACT_VERSION` accordingly). See `docs/CONTRIBUTING.md` → *Frontend Development*.
+
+## Plugin System (v0.5+)
+
+The Plugin API (M1/M2) provides a stable extension mechanism for adding custom pipeline steps and providers without forking the core engine:
+
+```text
+Third-party package (pyproject.toml entry_points)
+    ▼
+discover_plugins() — importlib.metadata entry_points("movie_narrator.plugins")
+    ▼
+Plugin.register(ctx: PluginContext) — calls @register_step / @register_tts / @register_vision
+    ▼
+StepRegistry / ProviderRegistry — central registries
+    ▼
+runner.py — inserts registered steps into STEPS at before/after positions
+```
+
+### Key modules
+
+| Module | Responsibility |
+|--------|---------------|
+| `plugin_loader.py` | `StepRegistry`, `Plugin` protocol, `PluginContext`, `load_plugin()`, `discover_plugins()`, `list_available_plugins()` |
+| `providers/registry.py` | `ProviderRegistry`, `register_tts`, `register_vision`, `tts_registry`, `vision_registry` |
+| `presets/` | Narration preset system (`list_presets()`, `get_preset()`) |
+
+### Plugin protocol
+
+A plugin is any object with a `name` property and a `register(ctx: PluginContext)` method:
+
+```python
+from movie_narrator import PluginContext, register_step
+
+class MyPlugin:
+    name = "my-plugin"
+
+    def register(self, ctx: PluginContext) -> None:
+        ctx.steps.register("my_step", my_func, soft=True, after="render_video")
+        ctx.services.logger.info("My plugin registered")
+```
+
+Plugins are discovered via `importlib.metadata` entry points under the `movie_narrator.plugins` group. See `examples/plugins/watermark/` for a complete reference implementation.
+
+## WP6 — Scene Filtering (v0.5+)
+
+The `pipeline/scene_filter.py` module provides three scene-filtering features that improve narration quality by removing non-content segments and biasing selection toward highlights:
+
+| Feature | Param | Description |
+|---------|-------|-------------|
+| **Intro skip** | `scene_skip_intro` | Auto-detects and skips intro/logo sequences at the start of videos using luminance and motion analysis |
+| **Dark frame detection** | `scene_dark_threshold` | Filters near-black frames (below luminance threshold) that would waste narration budget on non-content segments |
+| **Highlight window** | `scene_highlight_window` | Configurable time-window-based scene prioritization — bias scene selection toward user-specified highlight ranges |
+
+These params are added to `PARAM_WHITELIST` via the UnifiedParamSchema and flow through the standard `build_context` → `ctx.metadata` path.
 
 ## Key Design Decisions
 

--- a/docs/ARCHITECTURE.zh-CN.md
+++ b/docs/ARCHITECTURE.zh-CN.md
@@ -56,7 +56,7 @@ run_pipeline(...) # STEPS 顺序不变
 - 软步骤遵守 `metadata["workflow_steps"][<field>] is False` → `status.<field> = "disabled"`
 - 在 `ctx.metadata` 中通过 `build_context` 拷贝循环注入的参数白名单（48 个键：scene_threshold, scene_frame_skip, match_min_score, match_speed_clamp_min/max, scene_merge_min_duration, match_drop_scene_min_duration, embedding_model_name, bgm_gain_db, bgm_duck_db, bgm_normalize, audio_target_dbfs, tts_pause_ms, tts_max_concurrent, tts_audio_format, tts_audio_bitrate, translate_source_lang, translate_provider, translate_retries, translate_chunk_chars, translate_chunk_size, research_provider, whisperx_device/model/language, render_fps/video_codec/audio_codec/threads/bg_color/font_size/output_name/ffmpeg_timeout, render_fit_mode/crf/preset/faststart, render_subtitle_position/max_width_ratio/bottom_margin_ratio, qa_enabled/qa_max_silence_db/qa_min_duration_ratio/qa_max_duration_ratio, prompt_target_sentences/prompt_target_segment_duration/prompt_max_chars_per_sentence/prompt_hook_seconds, async_timeout, async_max_workers, video_sizes）
 - 多语言字幕顶层键：`subtitle_lang`、`subtitle_mode`（在 `JobConfig` 中校验 —— 设置 `subtitle_mode ∈ {translated, bilingual}` 但缺 `subtitle_lang` 时会在 merge 阶段抛 `JobConfigError`）
-- `STEPS` 仍是步骤顺序的唯一来源；v0.3 没有 DAG / 插件机制
+- `STEPS` 仍是步骤顺序的唯一来源；自 v0.5 起，可通过 `@register_step` 插件 API 添加自定义步骤（见下方插件系统章节）
 - YAML 自动发现：未传 `--config` 时按 `cwd/job.yaml` → 随包 `examples/job.example.yaml` → 缺省 顺序查找
 - `.env.example` 是首次运行配置的真理源头（由 `ensure_user_config()` 读取，避免内联模板漂移）
 - 严格的 env/yaml 边界：`.env`（Settings）= 24 个 LLM + TTS 基础设施字段；`job.yaml`（params）= 48 个流水线行为键；无代码常量模块 —— 内联字面值与示例文件保持一致
@@ -121,6 +121,14 @@ movie-narrator-web  →  contract.py  →  pipeline/runner.py (build_context, ru
 | `RunController` / `StepAction` / `check_cancelled` | pipeline/errors.py | 协作式取消 + 重试 protocol |
 | `sanitize_filename` | utils/sanitize.py | 跨平台文件名清洗 |
 | `CONTRACT_VERSION` | contract.py | `(0, 5, 0)` —— 外部 `movie-narrator-web` 包在 import 时校验的版本号 |
+| `StepRegistry` / `step_registry` | plugin_loader.py | 流水线步骤插件中央注册表；`step_registry` 是全局实例 |
+| `ProviderRegistry` / `tts_registry` / `vision_registry` | providers/registry.py | TTS、vision 及未来 provider 类型的注册系统 |
+| `register_step` / `step` | plugin_loader.py | 装饰器式步骤注册（`@register_step("name", ...)` 或 `@step("name")`） |
+| `register_tts` / `register_vision` | providers/registry.py | 装饰器式 TTS 和 vision provider 注册 |
+| `Plugin` / `PluginContext` | plugin_loader.py | `Plugin` protocol（`name` + `register(ctx)`）和 `PluginContext`（持有 `steps`、`tts`、`vision`、`services`） |
+| `load_plugin` / `discover_plugins` / `list_available_plugins` | plugin_loader.py | 手动插件加载、entry_points 自动发现、插件列表 |
+| `Step` | plugin_loader.py | 描述已注册步骤的 dataclass（name, func, soft, before, after） |
+| `list_presets` / `get_preset` | presets/ | SDK 公开导出，用于解说预设内省 |
 
 ## TTS 抽象层
 
@@ -242,10 +250,67 @@ output/<movie>/
 
 ## 扩展点
 
-- **新增流水线步骤**：在 `pipeline/runner.py` 的 `STEPS` 末尾追加。函数签名必须是 `(ctx: Context) -> Context`
+- **新增流水线步骤（推荐）**：通过插件 API 使用 `@register_step("name", ...)` 装饰器注册。若打包为 entry_points 插件则自动发现，也可通过 `load_plugin()` 手动加载。参考实现见 `examples/plugins/watermark/`。
+- **新增流水线步骤（旧方式）**：直接在 `pipeline/runner.py` 的 `STEPS` 末尾追加。函数签名必须是 `(ctx: Context) -> Context`。
 - **替换 TTS / 渲染器 / LLM**：直接替换 `pipeline/tts.py`、`pipeline/render.py` 或 `utils/llm.py`，保留步骤函数签名即可
+- **新增 TTS / Vision provider（推荐）**：通过 Provider Registry 使用 `@register_tts("name")` 或 `@register_vision("name")` 装饰器注册。若打包为 entry_points 插件则自动发现。
+- **新增 VisionCaptioner provider（旧方式）**：在 `vision/` 中实现 `VisionCaptioner` ABC，在 `vision/factory.py` 注册。参考 `vision/stub.py`。匹配逻辑通过 `is_stub` 标志自动区分 fake 与真实字幕。
+- **流水线暂停 / 恢复**：`--pause-at script|match` 在指定步骤后暂停；`mn resume <output_dir>` 继续。状态序列化到 `pipeline_state.json`。
 - **新增 CLI 命令**：在 `cli.py` 加 `@app.command()`
 - **前端 / WebUI**：React SPA 与 FastAPI 后端现位于外部 repo [`movie-narrator-web`](https://github.com/zcbacxc/movie-narrator-web)（Vite + TypeScript + shadcn/ui + Tailwind CSS，通过 `mn-web` 命令在端口 8760 启动）。要扩展 web 层，请在该仓库内工作 —— 核心 `movie-narrator` repo 不再包含 `web_api/` 或 `webui/`，也没有 `mn web` 命令或 `[web]` extra。web 包需要的任何新引擎能力都必须通过 `contract.py` 暴露（并相应升级 `CONTRACT_VERSION`）。见 `docs/CONTRIBUTING.md` → *Frontend Development*
+
+## 插件系统（v0.5+）
+
+插件 API（M1/M2）提供了稳定的扩展机制，无需 fork 核心引擎即可添加自定义流水线步骤和 provider：
+
+```text
+第三方包（pyproject.toml entry_points）
+    ▼
+discover_plugins() — importlib.metadata entry_points("movie_narrator.plugins")
+    ▼
+Plugin.register(ctx: PluginContext) — 调用 @register_step / @register_tts / @register_vision
+    ▼
+StepRegistry / ProviderRegistry — 中央注册表
+    ▼
+runner.py — 将已注册步骤插入 STEPS 的 before/after 位置
+```
+
+### 关键模块
+
+| 模块 | 职责 |
+|------|------|
+| `plugin_loader.py` | `StepRegistry`、`Plugin` protocol、`PluginContext`、`load_plugin()`、`discover_plugins()`、`list_available_plugins()` |
+| `providers/registry.py` | `ProviderRegistry`、`register_tts`、`register_vision`、`tts_registry`、`vision_registry` |
+| `presets/` | 解说预设系统（`list_presets()`、`get_preset()`） |
+
+### Plugin protocol
+
+插件是任何具有 `name` 属性和 `register(ctx: PluginContext)` 方法的对象：
+
+```python
+from movie_narrator import PluginContext, register_step
+
+class MyPlugin:
+    name = "my-plugin"
+
+    def register(self, ctx: PluginContext) -> None:
+        ctx.steps.register("my_step", my_func, soft=True, after="render_video")
+        ctx.services.logger.info("My plugin registered")
+```
+
+插件通过 `importlib.metadata` entry points 的 `movie_narrator.plugins` 组自动发现。完整参考实现见 `examples/plugins/watermark/`。
+
+## WP6 — 场景过滤（v0.5+）
+
+`pipeline/scene_filter.py` 模块提供三个场景过滤功能，通过移除非内容片段和偏向高亮区域来提升解说质量：
+
+| 功能 | 参数 | 说明 |
+|------|------|------|
+| **片头跳过** | `scene_skip_intro` | 通过亮度和运动分析自动检测并跳过视频开头的 intro/logo 序列 |
+| **黑帧检测** | `scene_dark_threshold` | 过滤低于亮度阈值的近黑帧，避免浪费解说预算在非内容片段上 |
+| **高亮窗口** | `scene_highlight_window` | 可配置的基于时间窗口的场景优先级 —— 偏向用户指定的高亮范围的场景选择 |
+
+这些参数通过 UnifiedParamSchema 添加到 `PARAM_WHITELIST`，并经由标准 `build_context` → `ctx.metadata` 路径传递。
 
 ## 关键设计决策
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,14 +27,21 @@ pytest -v
 movie-narrator/
 ├── src/movie_narrator/
 │   ├── pipeline/        # 15-step runner, preflight, tts/render/match/... step modules
+│   ├── pipeline/scene_filter.py  # WP6 scene filtering (intro skip, dark frame, highlight window)
+│   ├── pipeline/registry.py      # StepRegistry integration with runner
 │   ├── tts/             # TTS provider abstraction (edge, openai, mimo, factory, cache)
+│   ├── providers/       # ProviderRegistry (register_tts, register_vision, tts_registry, vision_registry)
+│   ├── vision/          # VisionCaptioner abstraction (stub + http_vlm)
+│   ├── presets/         # Narration presets (douyin-fast, mainstream-dry, bilibili-long)
 │   ├── utils/           # llm.py, errors.py, shared helpers
-│   ├── models.py        # Context, PipelineStatus, StepState, ...
+│   ├── plugin_loader.py # Plugin discovery via entry_points, StepRegistry, Plugin protocol
+│   ├── models.py        # Context, PipelineStatus, StepState, Services, ...
+│   ├── contract.py      # Stable API boundary (CONTRACT_VERSION = (0, 5, 0))
 │   ├── cli.py           # `mn` Typer entry points (create, version, ...)
 │   └── workflow.py      # job.yaml load/merge (JobConfig, merge_job)
 ├── tests/               # pytest suite (unit + smoke)
 ├── docs/                # ARCHITECTURE, ROADMAP, CONTRIBUTING, specs/
-└── examples/            # job.example.yaml
+└── examples/            # job.example.yaml, plugins/watermark/
 ```
 
 The Web UI is developed in a separate repository ([`movie-narrator-web`](https://github.com/zcbacxc/movie-narrator-web)); it consumes the core engine only through the contract surface defined in `contract.py`. There is no `web_api/` or `webui/` tree in this repo.
@@ -70,6 +77,23 @@ The Web UI (FastAPI + React 18 SPA, launched via the standalone `mn-web` command
 
 ## Adding a New Pipeline Step
 
+### Recommended: Plugin API (v0.5+)
+
+Use the `@register_step` decorator to add steps without modifying the runner:
+
+1. Create a Python package with your step function `def my_step(ctx: Context) -> Context`
+2. Use `@register_step("my_step", soft=True, after="render_video")` to register it
+3. Declare an entry point in your `pyproject.toml`:
+   ```toml
+   [project.entry-points."movie_narrator.plugins"]
+   my_plugin = "my_package:MyPlugin"
+   ```
+4. The step is auto-discovered when your package is installed
+
+See `examples/plugins/watermark/` for a complete reference implementation.
+
+### Legacy: Direct STEPS modification
+
 1. Add a module under `src/movie_narrator/pipeline/` exposing
    `def <step_name>(ctx: Context) -> Context`
 2. For soft steps, set `ctx.status.<field>`, `ctx.step_state` (with
@@ -82,3 +106,15 @@ The Web UI (FastAPI + React 18 SPA, launched via the standalone `mn-web` command
    `disabled`, except `translate` which defaults to `skipped`)
 5. Add tests under `tests/test_<step>.py` covering the decision matrix
    (disabled / skipped / success / failure) and CLI/YAML integration
+
+## Developing a Plugin
+
+Plugins extend the pipeline with custom steps and providers:
+
+1. **Implement the Plugin protocol**: create a class with a `name` property and a `register(ctx: PluginContext)` method
+2. **Register steps/providers**: inside `register()`, call `ctx.steps.register(...)`, `ctx.tts.register(...)`, or `ctx.vision.register(...)`
+3. **Declare entry point**: add `[project.entry-points."movie_narrator.plugins"]` to your `pyproject.toml`
+4. **Use services**: access `ctx.services.logger` for structured logging (M2)
+5. **Test**: verify your plugin loads via `discover_plugins()` and `list_available_plugins()`
+
+Reference implementation: `examples/plugins/watermark/`

--- a/docs/CONTRIBUTING.zh-CN.md
+++ b/docs/CONTRIBUTING.zh-CN.md
@@ -27,14 +27,21 @@ pytest -v
 movie-narrator/
 ├── src/movie_narrator/
 │   ├── pipeline/        # 15 步 pipeline、preflight、tts/render/match 等 step 模块
+│   ├── pipeline/scene_filter.py  # WP6 场景过滤（片头跳过、黑帧检测、高亮窗口）
+│   ├── pipeline/registry.py      # StepRegistry 与 runner 集成
 │   ├── tts/             # TTS provider 抽象层（edge、openai、mimo、factory、cache）
+│   ├── providers/       # ProviderRegistry（register_tts、register_vision、tts_registry、vision_registry）
+│   ├── vision/          # VisionCaptioner 抽象（stub + http_vlm）
+│   ├── presets/         # 解说预设（douyin-fast、mainstream-dry、bilibili-long）
 │   ├── utils/           # llm.py、errors.py、共享辅助
-│   ├── models.py        # Context、PipelineStatus、StepState 等
+│   ├── plugin_loader.py # 插件发现（entry_points）、StepRegistry、Plugin protocol
+│   ├── models.py        # Context、PipelineStatus、StepState、Services 等
+│   ├── contract.py      # 稳定 API 边界（CONTRACT_VERSION = (0, 5, 0)）
 │   ├── cli.py           # `mn` Typer 入口（create、version 等）
 │   └── workflow.py      # job.yaml 加载与合并（JobConfig、merge_job）
 ├── tests/               # pytest 套件（单元 + 烟雾测试）
 ├── docs/                # ARCHITECTURE、ROADMAP、CONTRIBUTING、specs/
-└── examples/            # job.example.yaml
+└── examples/            # job.example.yaml、plugins/watermark/
 ```
 
 Web UI 在独立仓库 [`movie-narrator-web`](https://github.com/zcbacxc/movie-narrator-web) 中开发；它只通过 `contract.py` 定义的契约面消费核心引擎。本 repo 不含 `web_api/` 或 `webui/` 目录树。
@@ -68,6 +75,23 @@ Web UI（FastAPI + React 18 SPA，安装 `pip install movie-narrator-web` 后通
 
 ## 新增一个 Pipeline 步骤
 
+### 推荐：插件 API（v0.5+）
+
+使用 `@register_step` 装饰器添加步骤，无需修改 runner：
+
+1. 创建一个 Python 包，包含步骤函数 `def my_step(ctx: Context) -> Context`
+2. 使用 `@register_step("my_step", soft=True, after="render_video")` 注册
+3. 在 `pyproject.toml` 中声明 entry point：
+   ```toml
+   [project.entry-points."movie_narrator.plugins"]
+   my_plugin = "my_package:MyPlugin"
+   ```
+4. 安装你的包后步骤会被自动发现
+
+完整参考实现见 `examples/plugins/watermark/`。
+
+### 旧方式：直接修改 STEPS
+
 1. 在 `src/movie_narrator/pipeline/` 下新增一个模块，导出
    `def <step_name>(ctx: Context) -> Context`
 2. 对 soft 步骤，请在 `ctx.status.<field>`、`ctx.step_state`（使用
@@ -79,3 +103,15 @@ Web UI（FastAPI + React 18 SPA，安装 `pip install movie-narrator-web` 后通
    但 `translate` 例外，默认 `skipped`）
 5. 在 `tests/test_<step>.py` 下写覆盖决策矩阵（disabled / skipped / success / failure）
    以及 CLI/YAML 集成的测试
+
+## 开发插件
+
+插件通过自定义步骤和 provider 扩展流水线：
+
+1. **实现 Plugin protocol**：创建一个具有 `name` 属性和 `register(ctx: PluginContext)` 方法的类
+2. **注册步骤/provider**：在 `register()` 中调用 `ctx.steps.register(...)`、`ctx.tts.register(...)` 或 `ctx.vision.register(...)`
+3. **声明 entry point**：在 `pyproject.toml` 中添加 `[project.entry-points."movie_narrator.plugins"]`
+4. **使用服务**：通过 `ctx.services.logger` 进行结构化日志（M2）
+5. **测试**：验证插件通过 `discover_plugins()` 和 `list_available_plugins()` 正确加载
+
+参考实现：`examples/plugins/watermark/`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,7 +54,7 @@
 > The Web UI work below has since been split into the independent repository [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web). The core repo no longer ships `web_api/` or `webui/`; install the Web UI separately via `pip install movie-narrator-web` and launch it with `mn-web`.
 
 - [x] Gradio → FastAPI + React SPA refactor (Vite + TypeScript + shadcn/ui)
-- [x] WebSocket real-time progress (`/ws/jobs/{id}`)
+- [x] WebSocket real-time progress (`/ws/task/{task_id}`)
 - [x] pip-installable WebUI packaging — now shipped from the separate `movie-narrator-web` repo (`pip install movie-narrator-web`, command `mn-web`)
 
 ### Core Engine Quality
@@ -101,11 +101,33 @@
 
 > **Goal**: Freeze the public API surface (Pipeline, Workflow, Plugin, SDK) before Cloud features depend on it.
 
-- [ ] Plugin API for custom pipeline steps (step registration, lifecycle hooks, dependency declaration)
-- [ ] Python SDK for programmatic usage (`from movie_narrator import ...`)
-- [ ] Custom pipeline step registration (`@register_step`)
-- [ ] Third-party provider extensions (TTS, LLM, research backends via Plugin API)
-- [ ] Community extension discovery and packaging conventions
+### M1 — Plugin registry infrastructure (#91)
+
+- [x] Plugin API for custom pipeline steps (step registration, lifecycle hooks, dependency declaration)
+- [x] StepRegistry + ProviderRegistry with `@register_step` / `@register_provider` decorators
+- [x] UnifiedParamSchema — `PARAM_WHITELIST` auto-derived from `JobParams` model fields
+- [x] SDK surface exports (`list_presets`, `get_preset`) in `contract.py` and `__init__.py`
+
+### M2 — SDK freeze (#92)
+
+- [x] Python SDK for programmatic usage (`from movie_narrator import ...`)
+- [x] Custom pipeline step registration (`@register_step`)
+- [x] Plugin discovery via `importlib.metadata` entry points (`movie_narrator.plugins` group)
+- [x] Third-party provider extensions (TTS, LLM, research backends via Plugin API)
+- [x] `Services.logger` optional field for structured logging in plugins
+- [x] Out-of-tree example plugin (`examples/plugins/watermark/`)
+
+### WP6 — Scene filtering (#93)
+
+- [x] Intro skip — auto-detect and skip intro/logo sequences via luminance + motion analysis
+- [x] Dark frame detection — filter near-black frames that waste narration budget
+- [x] Highlight window — configurable time-window-based scene prioritization
+
+### WebUI split — Dual repository separation (#94, #95)
+
+- [x] WebUI (FastAPI + React) extracted into standalone repo [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web)
+- [x] Core engine is now a pure CLI package with no web dependencies
+- [x] Contract versioning (`CONTRACT_VERSION = (0, 5, 0)`) for import-time compatibility checks
 
 > **Design note**: SDK and Plugin API are designed together — the SDK is the primary consumer of the Plugin API, so both must stabilize in the same release to avoid compatibility pressure.
 

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -54,7 +54,7 @@
 > 以下 Web UI 工作随后已拆分为独立 repo [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web)。核心 repo 不再包含 `web_api/` 或 `webui/`；以独立包形式安装 Web UI：`pip install movie-narrator-web`，通过 `mn-web` 启动。
 
 - [x] Gradio → FastAPI + React SPA 重构（Vite + TypeScript + shadcn/ui）
-- [x] WebSocket 实时进度推送（`/ws/jobs/{id}`）
+- [x] WebSocket 实时进度推送（`/ws/task/{task_id}`）
 - [x] pip 可安装的 WebUI 打包 —— 现由独立的 `movie-narrator-web` repo 发布（`pip install movie-narrator-web`，命令 `mn-web`）
 
 ### 核心引擎质量
@@ -101,11 +101,33 @@
 
 > **目标**：在 Cloud 功能依赖之前，先冻结公开 API 表面（Pipeline、Workflow、Plugin、SDK）。
 
-- [ ] 自定义流水线步骤的 Plugin API（步骤注册、生命周期钩子、依赖声明）
-- [ ] 编程式使用的 Python SDK（`from movie_narrator import ...`）
-- [ ] 自定义流水线步骤的注册（`@register_step`）
-- [ ] 第三方 provider 扩展（TTS、LLM、资料 backend，通过 Plugin API）
-- [ ] 社区扩展发现与打包约定
+### M1 — 插件注册基础设施 (#91)
+
+- [x] 自定义流水线步骤的 Plugin API（步骤注册、生命周期钩子、依赖声明）
+- [x] StepRegistry + ProviderRegistry，支持 `@register_step` / `@register_provider` 装饰器
+- [x] UnifiedParamSchema —— `PARAM_WHITELIST` 由 `JobParams` 模型字段自动派生
+- [x] SDK 公开导出（`list_presets`、`get_preset`）在 `contract.py` 和 `__init__.py` 中
+
+### M2 — SDK 冻结 (#92)
+
+- [x] 编程式使用的 Python SDK（`from movie_narrator import ...`）
+- [x] 自定义流水线步骤的注册（`@register_step`）
+- [x] 通过 `importlib.metadata` entry points 发现插件（`movie_narrator.plugins` 组）
+- [x] 第三方 provider 扩展（TTS、LLM、资料 backend，通过 Plugin API）
+- [x] `Services.logger` 可选字段，供插件结构化日志使用
+- [x] 树外示例插件（`examples/plugins/watermark/`）
+
+### WP6 — 场景过滤 (#93)
+
+- [x] 片头跳过 —— 通过亮度 + 运动分析自动检测并跳过 intro/logo 序列
+- [x] 黑帧检测 —— 过滤浪费解说预算的近黑帧
+- [x] 高亮窗口 —— 可配置的基于时间窗口的场景优先级
+
+### WebUI 拆分 —— 双仓库分离 (#94, #95)
+
+- [x] WebUI（FastAPI + React）拆分为独立 repo [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web)
+- [x] 核心引擎现为纯 CLI 包，无 web 依赖
+- [x] 契约版本号（`CONTRACT_VERSION = (0, 5, 0)`），支持导入时兼容性检查
 
 > **设计备注**：SDK 与 Plugin API 是一起设计的 —— SDK 是 Plugin API 的主要使用者，所以两者必须在同一次发布稳定下来，避免兼容性压力。
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -5,6 +5,8 @@ Verifies that:
 - Re-exported objects are identical to their source (same object)
 - PipelineResult protocol is satisfied by Context
 - The contract __all__ matches the actual exports
+- CONTRACT_VERSION is correct (v0.5+)
+- M1/M2 SDK symbols are re-exported correctly (v0.5+)
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ from movie_narrator import contract
 from movie_narrator.contract import (
     BaseConsole,
     Console,
+    CONTRACT_VERSION,
     PARAM_WHITELIST,
     PipelineCancelled,
     PipelineResult,
@@ -111,6 +114,16 @@ class TestAllCompleteness:
             "RunController", "StepAction", "check_cancelled",
             "PARAM_WHITELIST", "build_context", "run_pipeline",
             "sanitize_filename", "PipelineResult",
+            # M1/M2 symbols (v0.5+)
+            "CONTRACT_VERSION",
+            "StepRegistry", "step_registry",
+            "ProviderRegistry", "tts_registry", "vision_registry",
+            "register_step", "step",
+            "register_tts", "register_vision",
+            "Plugin", "PluginContext",
+            "load_plugin", "discover_plugins", "list_available_plugins",
+            "Step",
+            "list_presets", "get_preset",
         }
         assert expected.issubset(set(contract.__all__))
 
@@ -186,3 +199,93 @@ class TestContractIsolation:
             f"web package needs {web_needed - contract_provided} "
             f"which are not in contract.__all__"
         )
+
+
+# ── CONTRACT_VERSION (v0.5+) ──────────────────────────────
+
+
+class TestContractVersion:
+    """CONTRACT_VERSION is the stable API boundary for external consumers."""
+
+    def test_contract_version_value(self):
+        """CONTRACT_VERSION is (0, 5, 0)."""
+        assert CONTRACT_VERSION == (0, 5, 0)
+
+    def test_contract_version_is_tuple(self):
+        """CONTRACT_VERSION is a 3-tuple of ints (semver)."""
+        assert isinstance(CONTRACT_VERSION, tuple)
+        assert len(CONTRACT_VERSION) == 3
+        assert all(isinstance(v, int) for v in CONTRACT_VERSION)
+
+    def test_contract_version_in_all(self):
+        """CONTRACT_VERSION is in __all__."""
+        assert "CONTRACT_VERSION" in contract.__all__
+
+
+# ── M1/M2 SDK symbol re-exports (v0.5+) ───────────────────
+
+
+class TestSDKSymbolExports:
+    """M1/M2 SDK symbols are accessible from the contract module."""
+
+    @pytest.mark.parametrize("name", [
+        "StepRegistry", "step_registry",
+        "ProviderRegistry", "tts_registry", "vision_registry",
+        "register_step", "step",
+        "register_tts", "register_vision",
+        "Plugin", "PluginContext",
+        "load_plugin", "discover_plugins", "list_available_plugins",
+        "Step",
+        "list_presets", "get_preset",
+    ])
+    def test_symbol_accessible(self, name):
+        """Each M1/M2 symbol is accessible on the contract module."""
+        assert hasattr(contract, name), f"{name!r} not accessible from contract module"
+
+    def test_step_registry_is_global_instance(self):
+        """step_registry is the global StepRegistry instance."""
+        from movie_narrator.pipeline.registry import step_registry as _step_registry
+        assert contract.step_registry is _step_registry
+
+    def test_tts_registry_is_global_instance(self):
+        """tts_registry is the global ProviderRegistry instance for TTS."""
+        from movie_narrator.providers.registry import tts_registry as _tts_registry
+        assert contract.tts_registry is _tts_registry
+
+    def test_vision_registry_is_global_instance(self):
+        """vision_registry is the global ProviderRegistry instance for vision."""
+        from movie_narrator.providers.registry import vision_registry as _vision_registry
+        assert contract.vision_registry is _vision_registry
+
+    def test_register_step_identity(self):
+        """register_step is the same function as in pipeline.registry."""
+        from movie_narrator.pipeline.registry import register_step as _register_step
+        assert contract.register_step is _register_step
+
+    def test_register_tts_identity(self):
+        """register_tts is the same function as in providers.registry."""
+        from movie_narrator.providers.registry import register_tts as _register_tts
+        assert contract.register_tts is _register_tts
+
+    def test_register_vision_identity(self):
+        """register_vision is the same function as in providers.registry."""
+        from movie_narrator.providers.registry import register_vision as _register_vision
+        assert contract.register_vision is _register_vision
+
+    def test_load_plugin_identity(self):
+        """load_plugin is the same function as in plugin_loader."""
+        from movie_narrator.plugin_loader import load_plugin as _load_plugin
+        assert contract.load_plugin is _load_plugin
+
+    def test_discover_plugins_identity(self):
+        """discover_plugins is the same function as in plugin_loader."""
+        from movie_narrator.plugin_loader import discover_plugins as _discover_plugins
+        assert contract.discover_plugins is _discover_plugins
+
+    def test_list_presets_callable(self):
+        """list_presets is callable from contract."""
+        assert callable(contract.list_presets)
+
+    def test_get_preset_callable(self):
+        """get_preset is callable from contract."""
+        assert callable(contract.get_preset)


### PR DESCRIPTION
## Problem

After completing v0.5.0 (M1/M2/WP6/WebUI split), multiple documentation files were out of sync with the actual project state.

## Changes (11 files)

### CHANGELOG.md — 3 factual errors fixed
- Plugin path: `examples/example_plugin/` → `examples/plugins/watermark/`
- Entry point group: `movie_narrator.steps` + `movie_narrator.providers` → `movie_narrator.plugins` (single group)
- Non-existent `docs/sdk/` → updated to reference the example plugin README

### ROADMAP.md / ROADMAP.zh-CN.md
- Marked M1/M2 as complete (`[x]`)
- Added WP6 scene filtering section
- Added WebUI split section
- Fixed WebSocket path `/ws/jobs/{id}` → `/ws/task/{task_id}`

### ARCHITECTURE.md / ARCHITECTURE.zh-CN.md
- Added **Plugin System (v0.5+)** section with registry, discovery, and Plugin protocol docs
- Added **WP6 Scene Filtering** section
- Expanded contract.py symbol table with 8 M1/M2 symbols (StepRegistry, ProviderRegistry, register_step, Plugin, PluginContext, etc.)
- Updated Extension Points to recommend Plugin API over legacy STEPS modification
- Updated DAG reference: "no plugins in v0.3" → "custom steps via @register_step since v0.5"

### CONTRIBUTING.md / CONTRIBUTING.zh-CN.md
- Added plugin development workflow (Plugin protocol, entry_points, testing)
- Added "Recommended: Plugin API" vs "Legacy: Direct STEPS modification" sections
- Updated project structure with new modules (scene_filter.py, registry.py, providers/, vision/, presets/, plugin_loader.py, contract.py)

### AI_GUIDE.md
- Updated project structure with all v0.5 new modules
- Added "Recommended: Plugin API" step guide

### README.md / README.zh-CN.md
- Marked v0.5.x roadmap items as complete
- Added WP6 and WebUI split entries with PR references

### tests/test_contract.py — 16 new tests
- `TestContractVersion`: 3 tests (value, type, __all__ membership)
- `TestSDKSymbolExports`: 13 tests (parametrized symbol accessibility + identity checks for all M1/M2 exports)
- Updated `test_all_names_in_all` to include 16 M1/M2 symbols

## Testing

- 52 contract tests pass (was 36, +16 new)
- Full test suite will run in CI