### PR TITLE
feat(M4): Provider migration — LLM/Research registries + protocol validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] - 2026-07-26
+
+### Added (M4 — Provider Migration)
+
+- **LLM registry** (`llm_registry`): `utils/llm.py` migrated to the registry pattern. Built-in `openai` provider registered via `@register_llm("openai")`. External plugins can now register custom LLM providers through the Plugin API.
+- **Research registry** (`research_registry`): `pipeline/research.py` migrated to the registry pattern. Built-in `llm` provider registered via `@register_research("llm")`. External plugins can register custom research backends.
+- **Protocol validation**: `tts_registry` and `vision_registry` now enforce ABC conformance at `create()` time — factories returning non-`TTSProvider` / non-`VisionCaptioner` instances raise `TypeError`.
+- **`PluginContext` extension**: `PluginContext` now includes `llm` and `research` fields, giving plugins access to all four provider registries.
+- **SDK exports**: `register_llm`, `register_research`, `llm_registry`, `research_registry` added to `contract.py` and `__init__.py`.
+- **`CONTRACT_VERSION` bumped** to `(0, 5, 1)` — backward compatible (new exports only, no removals or signature changes).
+- **`llm_provider` setting** added to `config.py` — allows selecting LLM provider by name (default: `"openai"`).
+
+### Changed
+
+- `tts/factory.py`: removed legacy fallback code — provider dispatch is now registry-only.
+- `vision/factory.py`: removed legacy fallback code — provider dispatch is now registry-only.
+- `providers/registry.py`: added `set_protocol()` method for deferred protocol binding (avoids circular imports); added `contains()` method to `ProviderRegistry`.
+- `providers/__init__.py`: exports `llm_registry`, `research_registry`, `register_llm`, `register_research`.
+- `workflow/schema.py`: updated `vision_captioner` comment to reflect plugin-based providers.
+
+### Documentation
+
+- Updated `ROADMAP.md` / `ROADMAP.zh-CN.md`: added M4 section.
+- Updated `ARCHITECTURE.md` / `ARCHITECTURE.zh-CN.md`: provider registry table now includes LLM/Research; extension points updated.
+- Updated `CONTRIBUTING.md` / `CONTRIBUTING.zh-CN.md`: directory tree reflects new provider registrations.
+- Updated `AI_GUIDE.md`: directory tree and contract version updated.
+- Fixed `http_vlm` references across all docs — `http_vlm` was never merged; vision providers are now extensible via Plugin API.
+
 ## [0.5.0] - 2026-07-26
 
 ### Added (v0.5 Ecosystem — Plugin API, SDK, Scene Filter, WebUI Split)

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -103,7 +103,7 @@ src/movie_narrator/
 ├── cli.py               # Typer CLI 入口（mn 命令）
 ├── config.py            # Settings（pydantic-settings，MN_* 环境变量）
 ├── models.py            # Context、PipelineStatus、StepState、Services 等数据模型
-├── contract.py          # 稳定 API 边界（CONTRACT_VERSION = (0, 5, 0)，web 包通过它消费引擎）
+├── contract.py          # 稳定 API 边界（CONTRACT_VERSION = (0, 5, 1)，web 包通过它消费引擎）
 ├── plugin_loader.py     # 插件发现（entry_points）、StepRegistry、Plugin protocol、PluginContext
 ├── pipeline/
 │   ├── runner.py        # 15 步流水线编排（STEPS 列表 + build_context）
@@ -117,8 +117,8 @@ src/movie_narrator/
 │   ├── qa.py            # 成片质检（ffprobe）
 │   └── errors.py        # PipelineStrictError, PipelineCancelled, StepAction
 ├── tts/                 # TTS 抽象层（edge / openai / mimo）
-├── providers/           # ProviderRegistry（register_tts、register_vision）
-├── vision/              # VisionCaptioner 抽象（stub + http_vlm）
+├── providers/           # ProviderRegistry（register_tts、register_vision、register_llm、register_research）
+├── vision/              # VisionCaptioner 抽象（stub，通过 Plugin API 可扩展）
 ├── workflow/            # YAML 配置加载与合并
 ├── presets/             # 解说风格预设（douyin-fast / mainstream-dry / bilibili-long）
 └── utils/               # 工具函数（llm、font、json_parser 等）

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,7 @@ React SPA (in movie-narrator-web) — form / progress / artifacts view
     ▼   REST (POST /api/tasks)  +  WebSocket (/ws/task/{task_id})
 FastAPI app (in movie-narrator-web) — uvicorn on :8760
     ▼
-contract.py (core repo — stable API boundary, CONTRACT_VERSION = (0, 5, 0))
+contract.py (core repo — stable API boundary, CONTRACT_VERSION = (0, 5, 1))
     ▼
 build_context(..., services=Services(console=BufferedConsole))
     ▼
@@ -106,7 +106,7 @@ The React SPA is built by Vite into static assets that FastAPI serves directly, 
 
 ### Modules — `contract.py` (stable API boundary, the only import surface for `movie-narrator-web`)
 
-The `contract.py` module is the **single import surface** that the external `movie-narrator-web` package (and any future consumer) depends on. It re-exports symbols from 4 internal modules and defines the `PipelineResult` protocol, without moving any code. The contract version is pinned via `CONTRACT_VERSION = (0, 5, 0)` — the web package checks this at import time to refuse mismatched engine versions.
+The `contract.py` module is the **single import surface** that the external `movie-narrator-web` package (and any future consumer) depends on. It re-exports symbols from 4 internal modules and defines the `PipelineResult` protocol, without moving any code. The contract version is pinned via `CONTRACT_VERSION = (0, 5, 1)` — the web package checks this at import time to refuse mismatched engine versions.
 
 ```text
 movie-narrator-web  →  contract.py  →  pipeline/runner.py (build_context, run_pipeline, PARAM_WHITELIST)
@@ -124,12 +124,12 @@ movie-narrator-web  →  contract.py  →  pipeline/runner.py (build_context, ru
 | `PipelineCancelled` / `PipelineStrictError` | pipeline/errors.py | Pipeline terminal exceptions |
 | `RunController` / `StepAction` / `check_cancelled` | pipeline/errors.py | Cooperative cancel + retry protocol |
 | `sanitize_filename` | utils/sanitize.py | Cross-platform filename sanitization |
-| `CONTRACT_VERSION` | contract.py | `(0, 5, 0)` — version the external `movie-narrator-web` package checks against at import time |
+| `CONTRACT_VERSION` | contract.py | `(0, 5, 1)` — version the external `movie-narrator-web` package checks against at import time |
 | `StepRegistry` / `step_registry` | plugin_loader.py | Central registry for pipeline step plugins; `step_registry` is the global instance |
-| `ProviderRegistry` / `tts_registry` / `vision_registry` | providers/registry.py | Provider registration system for TTS, vision, and future provider types |
+| `ProviderRegistry` / `tts_registry` / `vision_registry` / `llm_registry` / `research_registry` | providers/registry.py | Provider registration system for TTS, vision, LLM, and research providers |
 | `register_step` / `step` | plugin_loader.py | Decorator-based step registration (`@register_step("name", ...)` or `@step("name")`) |
-| `register_tts` / `register_vision` | providers/registry.py | Decorator-based provider registration for TTS and vision providers |
-| `Plugin` / `PluginContext` | plugin_loader.py | `Plugin` protocol (`name` + `register(ctx)`) and `PluginContext` (holds `steps`, `tts`, `vision`, `services`) |
+| `register_tts` / `register_vision` / `register_llm` / `register_research` | providers/registry.py | Decorator-based provider registration for TTS, vision, LLM, and research providers |
+| `Plugin` / `PluginContext` | plugin_loader.py | `Plugin` protocol (`name` + `register(ctx)`) and `PluginContext` (holds `steps`, `tts`, `vision`, `llm`, `research`) |
 | `load_plugin` / `discover_plugins` / `list_available_plugins` | plugin_loader.py | Manual plugin loading, entry_points auto-discovery, and plugin listing |
 | `Step` | plugin_loader.py | Dataclass describing a registered step (name, func, soft, before, after) |
 | `list_presets` / `get_preset` | presets/ | Public SDK exports for narration preset introspection |
@@ -410,7 +410,7 @@ segment's end. This is preferable to a 100ms flash on screen.
 - **New pipeline step (recommended)**: use `@register_step("name", ...)` decorator via the Plugin API. The step is auto-discovered if packaged as an entry_points plugin, or can be loaded manually via `load_plugin()`. See `examples/plugins/watermark/` for a reference implementation.
 - **New pipeline step (legacy)**: append directly to `STEPS` in `pipeline/runner.py`. Signature must be `(ctx: Context) -> Context`.
 - **Swap TTS/renderer/LLM**: replace `pipeline/tts.py`, `pipeline/render.py`, or `utils/llm.py` while keeping the step function signature.
-- **New TTS/Vision provider (recommended)**: use `@register_tts("name")` or `@register_vision("name")` decorator via the Provider Registry. The provider is auto-discovered if packaged as an entry_points plugin.
+- **New TTS/Vision/LLM/Research provider (recommended)**: use `@register_tts("name")`, `@register_vision("name")`, `@register_llm("name")`, or `@register_research("name")` decorator via the Provider Registry. The provider is auto-discovered if packaged as an entry_points plugin.
 - **New VisionCaptioner provider (legacy)**: implement `VisionCaptioner` ABC in `vision/`, register in `vision/factory.py`. See `vision/stub.py` for reference. Match logic auto-detects fake vs real captions via `is_stub` flag.
 - **Pipeline pause/resume**: `--pause-at script|match` pauses after the step; `mn resume <output_dir>` continues. State serialized to `pipeline_state.json`.
 - **New CLI command**: add `@app.command()` in `cli.py`.
@@ -425,7 +425,7 @@ Third-party package (pyproject.toml entry_points)
     ▼
 discover_plugins() — importlib.metadata entry_points("movie_narrator.plugins")
     ▼
-Plugin.register(ctx: PluginContext) — calls @register_step / @register_tts / @register_vision
+Plugin.register(ctx: PluginContext) — calls @register_step / @register_tts / @register_vision / @register_llm / @register_research
     ▼
 StepRegistry / ProviderRegistry — central registries
     ▼
@@ -437,7 +437,7 @@ runner.py — inserts registered steps into STEPS at before/after positions
 | Module | Responsibility |
 |--------|---------------|
 | `plugin_loader.py` | `StepRegistry`, `Plugin` protocol, `PluginContext`, `load_plugin()`, `discover_plugins()`, `list_available_plugins()` |
-| `providers/registry.py` | `ProviderRegistry`, `register_tts`, `register_vision`, `tts_registry`, `vision_registry` |
+| `providers/registry.py` | `ProviderRegistry`, `register_tts`, `register_vision`, `register_llm`, `register_research`, `tts_registry`, `vision_registry`, `llm_registry`, `research_registry` |
 | `presets/` | Narration preset system (`list_presets()`, `get_preset()`) |
 
 ### Plugin protocol

--- a/docs/ARCHITECTURE.zh-CN.md
+++ b/docs/ARCHITECTURE.zh-CN.md
@@ -81,7 +81,7 @@ React SPA（位于 movie-narrator-web）— 表单 / 进度 / 产物视图
     ▼   REST (POST /api/tasks)  +  WebSocket (/ws/task/{task_id})
 FastAPI app（位于 movie-narrator-web）— uvicorn 监听 :8760
     ▼
-contract.py（核心 repo — 稳定 API 边界，CONTRACT_VERSION = (0, 5, 0)）
+contract.py（核心 repo — 稳定 API 边界，CONTRACT_VERSION = (0, 5, 1)）
     ▼
 build_context(..., services=Services(console=BufferedConsole))
     ▼
@@ -102,7 +102,7 @@ React SPA 由 Vite 打包产出静态资源，FastAPI 直接托管；因此单�
 
 ### 模块 —— `contract.py`（稳定 API 边界，`movie-narrator-web` 唯一的导入面）
 
-`contract.py` 模块是外部 `movie-narrator-web` 包（以及任何未来消费者）依赖的 **唯一导入面**。它从 4 个内部模块 re-export 符号，并定义 `PipelineResult` protocol，不移动任何代码。契约版本通过 `CONTRACT_VERSION = (0, 5, 0)` 固定 —— web 包在 import 时校验，拒绝不匹配的引擎版本。
+`contract.py` 模块是外部 `movie-narrator-web` 包（以及任何未来消费者）依赖的 **唯一导入面**。它从 4 个内部模块 re-export 符号，并定义 `PipelineResult` protocol，不移动任何代码。契约版本通过 `CONTRACT_VERSION = (0, 5, 1)` 固定 —— web 包在 import 时校验，拒绝不匹配的引擎版本。
 
 ```text
 movie-narrator-web  →  contract.py  →  pipeline/runner.py (build_context, run_pipeline, PARAM_WHITELIST)
@@ -120,12 +120,12 @@ movie-narrator-web  →  contract.py  →  pipeline/runner.py (build_context, ru
 | `PipelineCancelled` / `PipelineStrictError` | pipeline/errors.py | 流水线终态异常 |
 | `RunController` / `StepAction` / `check_cancelled` | pipeline/errors.py | 协作式取消 + 重试 protocol |
 | `sanitize_filename` | utils/sanitize.py | 跨平台文件名清洗 |
-| `CONTRACT_VERSION` | contract.py | `(0, 5, 0)` —— 外部 `movie-narrator-web` 包在 import 时校验的版本号 |
+| `CONTRACT_VERSION` | contract.py | `(0, 5, 1)` —— 外部 `movie-narrator-web` 包在 import 时校验的版本号 |
 | `StepRegistry` / `step_registry` | plugin_loader.py | 流水线步骤插件中央注册表；`step_registry` 是全局实例 |
-| `ProviderRegistry` / `tts_registry` / `vision_registry` | providers/registry.py | TTS、vision 及未来 provider 类型的注册系统 |
+| `ProviderRegistry` / `tts_registry` / `vision_registry` / `llm_registry` / `research_registry` | providers/registry.py | TTS、vision、LLM、research provider 的注册系统 |
 | `register_step` / `step` | plugin_loader.py | 装饰器式步骤注册（`@register_step("name", ...)` 或 `@step("name")`） |
-| `register_tts` / `register_vision` | providers/registry.py | 装饰器式 TTS 和 vision provider 注册 |
-| `Plugin` / `PluginContext` | plugin_loader.py | `Plugin` protocol（`name` + `register(ctx)`）和 `PluginContext`（持有 `steps`、`tts`、`vision`、`services`） |
+| `register_tts` / `register_vision` / `register_llm` / `register_research` | providers/registry.py | 装饰器式 TTS、vision、LLM、research provider 注册 |
+| `Plugin` / `PluginContext` | plugin_loader.py | `Plugin` protocol（`name` + `register(ctx)`）和 `PluginContext`（持有 `steps`、`tts`、`vision`、`llm`、`research`） |
 | `load_plugin` / `discover_plugins` / `list_available_plugins` | plugin_loader.py | 手动插件加载、entry_points 自动发现、插件列表 |
 | `Step` | plugin_loader.py | 描述已注册步骤的 dataclass（name, func, soft, before, after） |
 | `list_presets` / `get_preset` | presets/ | SDK 公开导出，用于解说预设内省 |
@@ -253,7 +253,7 @@ output/<movie>/
 - **新增流水线步骤（推荐）**：通过插件 API 使用 `@register_step("name", ...)` 装饰器注册。若打包为 entry_points 插件则自动发现，也可通过 `load_plugin()` 手动加载。参考实现见 `examples/plugins/watermark/`。
 - **新增流水线步骤（旧方式）**：直接在 `pipeline/runner.py` 的 `STEPS` 末尾追加。函数签名必须是 `(ctx: Context) -> Context`。
 - **替换 TTS / 渲染器 / LLM**：直接替换 `pipeline/tts.py`、`pipeline/render.py` 或 `utils/llm.py`，保留步骤函数签名即可
-- **新增 TTS / Vision provider（推荐）**：通过 Provider Registry 使用 `@register_tts("name")` 或 `@register_vision("name")` 装饰器注册。若打包为 entry_points 插件则自动发现。
+- **新增 TTS / Vision / LLM / Research provider（推荐）**：通过 Provider Registry 使用 `@register_tts("name")`、`@register_vision("name")`、`@register_llm("name")` 或 `@register_research("name")` 装饰器注册。若打包为 entry_points 插件则自动发现。
 - **新增 VisionCaptioner provider（旧方式）**：在 `vision/` 中实现 `VisionCaptioner` ABC，在 `vision/factory.py` 注册。参考 `vision/stub.py`。匹配逻辑通过 `is_stub` 标志自动区分 fake 与真实字幕。
 - **流水线暂停 / 恢复**：`--pause-at script|match` 在指定步骤后暂停；`mn resume <output_dir>` 继续。状态序列化到 `pipeline_state.json`。
 - **新增 CLI 命令**：在 `cli.py` 加 `@app.command()`
@@ -268,7 +268,7 @@ output/<movie>/
     ▼
 discover_plugins() — importlib.metadata entry_points("movie_narrator.plugins")
     ▼
-Plugin.register(ctx: PluginContext) — 调用 @register_step / @register_tts / @register_vision
+Plugin.register(ctx: PluginContext) — 调用 @register_step / @register_tts / @register_vision / @register_llm / @register_research
     ▼
 StepRegistry / ProviderRegistry — 中央注册表
     ▼
@@ -280,7 +280,7 @@ runner.py — 将已注册步骤插入 STEPS 的 before/after 位置
 | 模块 | 职责 |
 |------|------|
 | `plugin_loader.py` | `StepRegistry`、`Plugin` protocol、`PluginContext`、`load_plugin()`、`discover_plugins()`、`list_available_plugins()` |
-| `providers/registry.py` | `ProviderRegistry`、`register_tts`、`register_vision`、`tts_registry`、`vision_registry` |
+| `providers/registry.py` | `ProviderRegistry`、`register_tts`、`register_vision`、`register_llm`、`register_research`、`tts_registry`、`vision_registry`、`llm_registry`、`research_registry` |
 | `presets/` | 解说预设系统（`list_presets()`、`get_preset()`） |
 
 ### Plugin protocol

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,13 +30,13 @@ movie-narrator/
 │   ├── pipeline/scene_filter.py  # WP6 scene filtering (intro skip, dark frame, highlight window)
 │   ├── pipeline/registry.py      # StepRegistry integration with runner
 │   ├── tts/             # TTS provider abstraction (edge, openai, mimo, factory, cache)
-│   ├── providers/       # ProviderRegistry (register_tts, register_vision, tts_registry, vision_registry)
-│   ├── vision/          # VisionCaptioner abstraction (stub + http_vlm)
+│   ├── providers/       # ProviderRegistry (register_tts, register_vision, register_llm, register_research)
+│   ├── vision/          # VisionCaptioner abstraction (stub, extensible via Plugin API)
 │   ├── presets/         # Narration presets (douyin-fast, mainstream-dry, bilibili-long)
 │   ├── utils/           # llm.py, errors.py, shared helpers
 │   ├── plugin_loader.py # Plugin discovery via entry_points, StepRegistry, Plugin protocol
 │   ├── models.py        # Context, PipelineStatus, StepState, Services, ...
-│   ├── contract.py      # Stable API boundary (CONTRACT_VERSION = (0, 5, 0))
+│   ├── contract.py      # Stable API boundary (CONTRACT_VERSION = (0, 5, 1))
 │   ├── cli.py           # `mn` Typer entry points (create, version, ...)
 │   └── workflow.py      # job.yaml load/merge (JobConfig, merge_job)
 ├── tests/               # pytest suite (unit + smoke)

--- a/docs/CONTRIBUTING.zh-CN.md
+++ b/docs/CONTRIBUTING.zh-CN.md
@@ -30,13 +30,13 @@ movie-narrator/
 │   ├── pipeline/scene_filter.py  # WP6 场景过滤（片头跳过、黑帧检测、高亮窗口）
 │   ├── pipeline/registry.py      # StepRegistry 与 runner 集成
 │   ├── tts/             # TTS provider 抽象层（edge、openai、mimo、factory、cache）
-│   ├── providers/       # ProviderRegistry（register_tts、register_vision、tts_registry、vision_registry）
-│   ├── vision/          # VisionCaptioner 抽象（stub + http_vlm）
+│   ├── providers/       # ProviderRegistry（register_tts、register_vision、register_llm、register_research）
+│   ├── vision/          # VisionCaptioner 抽象（stub，通过 Plugin API 可扩展）
 │   ├── presets/         # 解说预设（douyin-fast、mainstream-dry、bilibili-long）
 │   ├── utils/           # llm.py、errors.py、共享辅助
 │   ├── plugin_loader.py # 插件发现（entry_points）、StepRegistry、Plugin protocol
 │   ├── models.py        # Context、PipelineStatus、StepState、Services 等
-│   ├── contract.py      # 稳定 API 边界（CONTRACT_VERSION = (0, 5, 0)）
+│   ├── contract.py      # 稳定 API 边界（CONTRACT_VERSION = (0, 5, 1)）
 │   ├── cli.py           # `mn` Typer 入口（create、version 等）
 │   └── workflow.py      # job.yaml 加载与合并（JobConfig、merge_job）
 ├── tests/               # pytest 套件（单元 + 烟雾测试）

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,9 +92,9 @@
 
 ### Extensibility & Pipeline
 
-- [x] EP8 VisionCaptioner abstraction (`vision/` package; stub + `http_vlm` OpenAI-compatible provider)
+- [x] EP8 VisionCaptioner abstraction (`vision/` package; stub provider, extensible via Plugin API)
 - [x] EP9 pause/resume (`--pause-at` + `mn resume` + `pipeline_state.json`)
-- [x] Contract layer (`contract.py` — stable API boundary; now the surface consumed by the external [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web) package, `CONTRACT_VERSION = (0, 5, 0)`)
+- [x] Contract layer (`contract.py` — stable API boundary; now the surface consumed by the external [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web) package, `CONTRACT_VERSION = (0, 5, 1)`)
 - [x] Stage E productization (CLI match summary + RS-07/08/09 render fixes)
 
 ## v0.5.x — Ecosystem
@@ -128,6 +128,16 @@
 - [x] WebUI (FastAPI + React) extracted into standalone repo [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web)
 - [x] Core engine is now a pure CLI package with no web dependencies
 - [x] Contract versioning (`CONTRACT_VERSION = (0, 5, 0)`) for import-time compatibility checks
+
+### M4 — Provider migration
+
+- [x] LLM registry (`llm_registry`) — `utils/llm.py` migrated to registry pattern with built-in `openai` provider
+- [x] Research registry (`research_registry`) — `pipeline/research.py` migrated to registry pattern with built-in `llm` provider
+- [x] TTS/Vision factory legacy fallback cleanup — removed dead code, registry-only dispatch
+- [x] Protocol validation — `tts_registry` and `vision_registry` enforce ABC conformance at `create()` time
+- [x] `PluginContext` extended with `llm` and `research` fields
+- [x] `CONTRACT_VERSION` bumped to `(0, 5, 1)` — backward compatible (new exports only)
+- [x] SDK exports: `register_llm`, `register_research`, `llm_registry`, `research_registry` added to `contract.py` and `__init__.py`
 
 > **Design note**: SDK and Plugin API are designed together — the SDK is the primary consumer of the Plugin API, so both must stabilize in the same release to avoid compatibility pressure.
 

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -92,9 +92,9 @@
 
 ### 可扩展性与流水线
 
-- [x] EP8 VisionCaptioner 抽象（`vision/` 包；stub + `http_vlm` OpenAI 兼容 provider）
+- [x] EP8 VisionCaptioner 抽象（`vision/` 包；stub provider，通过 Plugin API 可扩展）
 - [x] EP9 暂停/恢复（`--pause-at` + `mn resume` + `pipeline_state.json`）
-- [x] 契约层（`contract.py` —— 稳定 API 边界；现由外部 [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web) 包消费，`CONTRACT_VERSION = (0, 5, 0)`）
+- [x] 契约层（`contract.py` —— 稳定 API 边界；现由外部 [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web) 包消费，`CONTRACT_VERSION = (0, 5, 1)`）
 - [x] Stage E 产品化（CLI 匹配摘要 + RS-07/08/09 渲染修复）
 
 ## v0.5.x — 生态
@@ -128,6 +128,16 @@
 - [x] WebUI（FastAPI + React）拆分为独立 repo [movie-narrator-web](https://github.com/zcbacxc/movie-narrator-web)
 - [x] 核心引擎现为纯 CLI 包，无 web 依赖
 - [x] 契约版本号（`CONTRACT_VERSION = (0, 5, 0)`），支持导入时兼容性检查
+
+### M4 — Provider 迁移
+
+- [x] LLM 注册表（`llm_registry`）—— `utils/llm.py` 迁移到注册表模式，内置 `openai` provider
+- [x] Research 注册表（`research_registry`）—— `pipeline/research.py` 迁移到注册表模式，内置 `llm` provider
+- [x] TTS/Vision 工厂清理 legacy fallback —— 移除死代码，仅通过注册表分发
+- [x] Protocol 校验 —— `tts_registry` 和 `vision_registry` 在 `create()` 时强制 ABC 一致性
+- [x] `PluginContext` 扩展 `llm` 和 `research` 字段
+- [x] `CONTRACT_VERSION` 升至 `(0, 5, 1)` —— 向后兼容（仅新增导出）
+- [x] SDK 导出：`register_llm`、`register_research`、`llm_registry`、`research_registry` 加入 `contract.py` 和 `__init__.py`
 
 > **设计备注**：SDK 与 Plugin API 是一起设计的 —— SDK 是 Plugin API 的主要使用者，所以两者必须在同一次发布稳定下来，避免兼容性压力。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.5.0"
+version = "0.5.1"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = {text = "AGPL-3.0"}

--- a/src/movie_narrator/__init__.py
+++ b/src/movie_narrator/__init__.py
@@ -7,6 +7,7 @@ __version__ = version("movie-narrator")
 #
 #   from movie_narrator import register_step, Context
 #   from movie_narrator import register_tts, register_vision
+#   from movie_narrator import register_llm, register_research
 #   from movie_narrator import Plugin, PluginContext, load_plugin
 #   from movie_narrator import discover_plugins  # entry_points discovery
 #
@@ -32,9 +33,13 @@ from .contract import (  # noqa: F401
     register_step,
     register_tts,
     register_vision,
+    register_llm,
+    register_research,
     run_pipeline,
     step,
     step_registry,
     tts_registry,
     vision_registry,
+    llm_registry,
+    research_registry,
 )

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -107,6 +107,7 @@ class Settings(BaseSettings):
     is configured via job.yaml params — see ``examples/job.example.yaml`` for defaults.
     """
     # ── LLM ──
+    llm_provider: str = "openai"  # registered LLM provider name (see llm_registry)
     llm_base_url: str = "http://localhost:11434/v1"
     llm_api_key: str = "ollama"
     llm_model: str = "qwen2.5:7b"

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -13,7 +13,8 @@ By centralizing the contract here:
 - ``PARAM_WHITELIST`` is accessible without importing the full runner
   module, eliminating the highest drift-risk coupling point.
 - External plugins import ``from movie_narrator import register_step,
-  register_tts, register_vision, Context`` to extend the engine.
+  register_tts, register_vision, register_llm, register_research, Context``
+  to extend the engine.
 - This module is the natural package boundary between the core engine
   repo (``movie-narrator``) and the web UI repo (``movie-narrator-web``).
 
@@ -45,7 +46,7 @@ from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 5, 0)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 5, 1)
 
 # ── Re-exports: console abstraction ────────────────────────
 
@@ -75,8 +76,12 @@ from .models import Context, Services
 from .pipeline.registry import StepRegistry, register_step, step, step_registry
 from .providers import (
     ProviderRegistry,
+    llm_registry,
+    register_llm,
+    register_research,
     register_tts,
     register_vision,
+    research_registry,
     tts_registry,
     vision_registry,
 )
@@ -136,6 +141,8 @@ class PluginContext:
     steps: StepRegistry
     tts: ProviderRegistry
     vision: ProviderRegistry
+    llm: ProviderRegistry
+    research: ProviderRegistry
 
     @classmethod
     def default(cls) -> "PluginContext":
@@ -144,6 +151,8 @@ class PluginContext:
             steps=step_registry,
             tts=tts_registry,
             vision=vision_registry,
+            llm=llm_registry,
+            research=research_registry,
         )
 
 
@@ -177,8 +186,8 @@ def load_plugin(plugin: Plugin) -> None:
     """Register a plugin with the global registries.
 
     Calls ``plugin.register(PluginContext.default())``, giving the
-    plugin access to ``step_registry``, ``tts_registry``, and
-    ``vision_registry``.
+    plugin access to ``step_registry``, ``tts_registry``,
+    ``vision_registry``, ``llm_registry``, and ``research_registry``.
 
     Args:
         plugin: An object implementing the :class:`Plugin` protocol.
@@ -233,10 +242,14 @@ __all__ = [
     "step_registry",
     "tts_registry",
     "vision_registry",
+    "llm_registry",
+    "research_registry",
     # Registration decorators
     "register_step",
     "register_tts",
     "register_vision",
+    "register_llm",
+    "register_research",
     "step",  # alias for register_step
     # Plugin system
     "Step",

--- a/src/movie_narrator/pipeline/research.py
+++ b/src/movie_narrator/pipeline/research.py
@@ -4,6 +4,7 @@ from time import sleep
 
 from ..config import get_settings
 from ..models import Context, ResearchInfo, StepResult
+from ..providers import research_registry, register_research
 from ..utils.json_parser import extract_json
 from ..utils.llm import get_llm_client
 
@@ -35,6 +36,36 @@ def _write_envelope(output_dir: Path, status: str, error: str | None, research: 
     return path
 
 
+# ── Built-in "llm" research provider ─────────────────────
+
+
+@register_research("llm")
+def _research_via_llm(ctx: Context, settings) -> ResearchInfo:
+    """Fetch movie research data via LLM chat completion."""
+    with get_llm_client() as llm:
+        prompt = RESEARCH_PROMPT.format(movie=ctx.movie_name)
+        response = llm.client.chat.completions.create(
+            model=llm.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=settings.research_temperature,
+            max_tokens=settings.research_max_tokens,
+        )
+        raw = response.choices[0].message.content or ""
+        data = extract_json(raw)
+
+        return ResearchInfo(
+            title=data.get("title", ctx.movie_name),
+            year=data.get("year"),
+            summary=data.get("summary", ""),
+            genres=data.get("genres", []),
+            cast=data.get("cast", []),
+            keywords=data.get("keywords", []),
+        )
+
+
+# ── Pipeline step ────────────────────────────────────────
+
+
 def research_plot(ctx: Context) -> Context:
     if not ctx.metadata.get("research_enabled"):
         ctx.status.research = "skipped"
@@ -45,7 +76,7 @@ def research_plot(ctx: Context) -> Context:
     provider = ctx.metadata.get("research_provider", "llm")
     output_dir = Path(ctx.output_dir)
 
-    if provider != "llm":
+    if not research_registry.contains(provider):
         err = f"unknown provider: {provider}"
         ctx.step_state.result = StepResult.WARNING
         ctx.step_state.message = err
@@ -59,28 +90,11 @@ def research_plot(ctx: Context) -> Context:
 
     for attempt in range(settings.research_retries):
         try:
-            with get_llm_client() as llm:
-                prompt = RESEARCH_PROMPT.format(movie=ctx.movie_name)
-                response = llm.client.chat.completions.create(
-                    model=llm.model,
-                    messages=[{"role": "user", "content": prompt}],
-                    temperature=settings.research_temperature,
-                    max_tokens=settings.research_max_tokens,
-                )
-                raw = response.choices[0].message.content or ""
-                data = extract_json(raw)
-
-                ctx.research = ResearchInfo(
-                    title=data.get("title", ctx.movie_name),
-                    year=data.get("year"),
-                    summary=data.get("summary", ""),
-                    genres=data.get("genres", []),
-                    cast=data.get("cast", []),
-                    keywords=data.get("keywords", []),
-                )
-                _write_envelope(output_dir, "success", None, ctx.research.model_dump())
-                ctx.status.research = "success"
-                return ctx
+            info = research_registry.create(provider, ctx, settings)
+            ctx.research = info
+            _write_envelope(output_dir, "success", None, ctx.research.model_dump())
+            ctx.status.research = "success"
+            return ctx
         except Exception as e:
             last_err = e
             if attempt < settings.research_retries - 1:

--- a/src/movie_narrator/providers/__init__.py
+++ b/src/movie_narrator/providers/__init__.py
@@ -1,14 +1,19 @@
-"""Provider package: unified registry for TTS, Vision, and future providers.
+"""Provider package: unified registry for TTS, Vision, LLM, Research providers.
 
 This package hosts the :class:`ProviderRegistry` and global registry
 instances for each provider category. External plugins register their
-factories here via :func:`register_tts` / :func:`register_vision`.
+factories here via :func:`register_tts` / :func:`register_vision` /
+:func:`register_llm` / :func:`register_research`.
 """
 
 from .registry import (
     ProviderRegistry,
+    llm_registry,
+    register_llm,
+    register_research,
     register_tts,
     register_vision,
+    research_registry,
     tts_registry,
     vision_registry,
 )
@@ -17,6 +22,10 @@ __all__ = [
     "ProviderRegistry",
     "register_tts",
     "register_vision",
+    "register_llm",
+    "register_research",
     "tts_registry",
     "vision_registry",
+    "llm_registry",
+    "research_registry",
 ]

--- a/src/movie_narrator/providers/registry.py
+++ b/src/movie_narrator/providers/registry.py
@@ -1,6 +1,6 @@
-"""Provider registry for TTS, Vision, and other pluggable providers.
+"""Provider registry for TTS, Vision, LLM, Research, and other pluggable providers.
 
-Each provider category (TTS, Vision, etc.) has a global
+Each provider category (TTS, Vision, LLM, Research, etc.) has a global
 :class:`ProviderRegistry` instance. Providers register a factory
 callable that takes configuration (settings/kwargs) and returns an
 instance of the provider protocol.
@@ -22,11 +22,28 @@ Example (Vision)::
     def make_blip(**kwargs):
         from .blip import BlipCaptioner
         return BlipCaptioner(**kwargs)
+
+Example (LLM)::
+
+    from movie_narrator import register_llm
+
+    @register_llm("anthropic")
+    def make_anthropic():
+        ...
+        return context_manager
+
+Example (Research)::
+
+    from movie_narrator import register_research
+
+    @register_research("web_search")
+    def make_web_search(ctx, settings):
+        return ResearchInfo(...)
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Type
 
 
 class ProviderRegistry:
@@ -35,11 +52,23 @@ class ProviderRegistry:
     A factory is a callable ``(config) -> provider_instance``. The
     config type varies by category (Settings for TTS, kwargs for Vision)
     but the registration interface is identical.
+
+    Args:
+        category: Human-readable category name for error messages.
+        protocol: Optional ABC/Protocol for ``create()`` return-value
+            validation. When set, ``create()`` raises ``TypeError`` if
+            the factory returns an object that is not an instance of
+            *protocol*. Defaults to ``None`` (no validation).
     """
 
-    def __init__(self, category: str = "provider") -> None:
+    def __init__(
+        self,
+        category: str = "provider",
+        protocol: Optional[Type[Any]] = None,
+    ) -> None:
         self._category = category
         self._factories: Dict[str, Callable[..., Any]] = {}
+        self._protocol = protocol
 
     def register(
         self,
@@ -83,6 +112,8 @@ class ProviderRegistry:
 
         Raises:
             ValueError: if *name* is not registered.
+            TypeError: if the factory returns an object that is not an
+                instance of the registry's *protocol* (when configured).
         """
         factory = self._factories.get(name)
         if factory is None:
@@ -91,7 +122,14 @@ class ProviderRegistry:
                 f"Unknown {self._category} provider: {name!r}. "
                 f"Registered: {available}"
             )
-        return factory(*args, **kwargs)
+        instance = factory(*args, **kwargs)
+        if self._protocol is not None and not isinstance(instance, self._protocol):
+            raise TypeError(
+                f"{self._category} provider '{name}' factory returned "
+                f"{type(instance).__name__} which is not a "
+                f"{self._protocol.__name__} instance."
+            )
+        return instance
 
     def names(self) -> List[str]:
         """Return all registered provider names."""
@@ -105,11 +143,30 @@ class ProviderRegistry:
         """Remove all registered factories. For testing only."""
         self._factories.clear()
 
+    def set_protocol(self, protocol: Optional[Type[Any]]) -> None:
+        """Set or clear the protocol for ``create()`` return-value validation.
+
+        This is intended for use by factory modules that import the
+        provider ABC (e.g. ``tts/protocol.py``) — setting the protocol
+        at import time in ``providers/registry.py`` would cause circular
+        imports.
+
+        Args:
+            protocol: ABC/Protocol class, or ``None`` to disable validation.
+        """
+        self._protocol = protocol
+
 
 # ── Global registry instances ────────────────────────────
 
+# TTS and Vision registries validate protocol conformance at create() time.
+# LLM and Research registries do not (LLM factories return context managers,
+# Research factories return ResearchInfo — neither has a shared ABC).
+
 tts_registry = ProviderRegistry(category="tts")
 vision_registry = ProviderRegistry(category="vision")
+llm_registry = ProviderRegistry(category="llm")
+research_registry = ProviderRegistry(category="research")
 
 
 # ── Decorators ────────────────────────────────────────────
@@ -143,5 +200,47 @@ def register_vision(name: str) -> Callable[[Callable[..., Any]], Callable[..., A
 
     def decorator(factory: Callable[..., Any]) -> Callable[..., Any]:
         return vision_registry.register(name, factory)
+
+    return decorator
+
+
+def register_llm(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register an LLM provider factory.
+
+    The factory should return a context manager that yields an
+    :class:`~movie_narrator.utils.llm.LLMClient`.
+
+    Usage::
+
+        @register_llm("anthropic")
+        def make_anthropic():
+            @contextmanager
+            def _cm():
+                ...
+                yield LLMClient(client=..., model=...)
+            return _cm()
+    """
+
+    def decorator(factory: Callable[..., Any]) -> Callable[..., Any]:
+        return llm_registry.register(name, factory)
+
+    return decorator
+
+
+def register_research(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a research provider factory.
+
+    The factory receives ``(ctx, settings)`` and should return a
+    :class:`~movie_narrator.models.ResearchInfo` instance.
+
+    Usage::
+
+        @register_research("web_search")
+        def make_web_search(ctx, settings):
+            return ResearchInfo(...)
+    """
+
+    def decorator(factory: Callable[..., Any]) -> Callable[..., Any]:
+        return research_registry.register(name, factory)
 
     return decorator

--- a/src/movie_narrator/tts/factory.py
+++ b/src/movie_narrator/tts/factory.py
@@ -4,11 +4,6 @@ Uses the :data:`tts_registry` to dispatch provider creation.
 Built-in providers (edge, openai, mimo) are registered at import
 time below. External plugins can register additional providers
 via :func:`register_tts`.
-
-Backward compatibility: if a provider name is not in the registry,
-the old if/elif chain is tried as a fallback. This ensures existing
-code that depends on ``TTSProviderType`` continues to work during
-the transition period.
 """
 
 from ..config import Settings, TTSProviderType
@@ -44,6 +39,10 @@ for _name, _factory in [
     if not tts_registry.contains(_name):
         tts_registry.register(_name, _factory)
 
+# Enable protocol validation: create() will TypeError if a factory
+# returns something that is not a TTSProvider instance.
+tts_registry.set_protocol(TTSProvider)
+
 
 # ── Public factory function ───────────────────────────────
 
@@ -51,10 +50,7 @@ for _name, _factory in [
 def get_tts_provider(settings: Settings) -> TTSProvider:
     """Return a TTSProvider instance for the configured provider.
 
-    Looks up the provider name in :data:`tts_registry` first.
-    Falls back to the enum-based if/elif chain for backward
-    compatibility with any code that might register custom
-    TTSProviderType values without updating the registry.
+    Looks up the provider name in :data:`tts_registry`.
 
     Raises:
         ConfigError: when the provider is unsupported.
@@ -65,17 +61,8 @@ def get_tts_provider(settings: Settings) -> TTSProvider:
         else str(settings.tts_provider)
     )
 
-    # Registry path (preferred)
     if tts_registry.contains(provider_name):
         return tts_registry.create(provider_name, settings)
-
-    # Legacy fallback (should not be reached for built-in providers)
-    if settings.tts_provider is TTSProviderType.EDGE:
-        return _make_edge(settings)
-    elif settings.tts_provider is TTSProviderType.OPENAI:
-        return _make_openai(settings)
-    elif settings.tts_provider is TTSProviderType.MIMO:
-        return _make_mimo(settings)
 
     raise ConfigError(
         f"Unsupported TTS provider: {settings.tts_provider!r}. "

--- a/src/movie_narrator/utils/llm.py
+++ b/src/movie_narrator/utils/llm.py
@@ -1,3 +1,14 @@
+"""LLM client factory backed by the provider registry.
+
+The built-in ``"openai"`` provider is registered at import time.
+External plugins can register additional LLM providers via
+:func:`register_llm`.
+
+``get_llm_client()`` remains a zero-argument callable that returns a
+context manager yielding :class:`LLMClient`. This preserves backward
+compatibility with all existing call sites and test patches.
+"""
+
 from dataclasses import dataclass
 from contextlib import contextmanager
 
@@ -5,6 +16,7 @@ import httpx
 from openai import OpenAI
 
 from ..config import get_settings
+from ..providers import llm_registry, register_llm
 
 
 @dataclass
@@ -13,17 +25,47 @@ class LLMClient:
     model: str
 
 
-@contextmanager
+# ── Built-in "openai" provider ───────────────────────────
+
+
+@register_llm("openai")
+def _make_openai_llm():
+    """Factory for the OpenAI-compatible LLM provider.
+
+    Returns a context manager that yields an :class:`LLMClient`
+    backed by a managed ``httpx.Client`` (closed on exit).
+    """
+
+    @contextmanager
+    def _cm():
+        settings = get_settings()
+        http_client = httpx.Client(timeout=settings.llm_timeout)
+        try:
+            client = OpenAI(
+                base_url=settings.llm_base_url,
+                api_key=settings.llm_api_key,
+                http_client=http_client,
+            )
+            yield LLMClient(client=client, model=settings.llm_model)
+        finally:
+            http_client.close()
+
+    return _cm()
+
+
+# ── Public factory function ──────────────────────────────
+
+
 def get_llm_client():
-    """Yield an LLMClient backed by a managed httpx.Client (closed on exit)."""
+    """Yield an LLMClient via the llm_registry.
+
+    Dispatches to the provider configured by ``settings.llm_provider``
+    (default: ``"openai"``). The returned object is a context manager
+    that must be used in a ``with`` statement.
+
+    This function's module path (``movie_narrator.utils.llm``) and
+    zero-argument signature are preserved for backward compatibility
+    with existing call sites and test patches.
+    """
     settings = get_settings()
-    http_client = httpx.Client(timeout=settings.llm_timeout)
-    try:
-        client = OpenAI(
-            base_url=settings.llm_base_url,
-            api_key=settings.llm_api_key,
-            http_client=http_client,
-        )
-        yield LLMClient(client=client, model=settings.llm_model)
-    finally:
-        http_client.close()
+    return llm_registry.create(settings.llm_provider)

--- a/src/movie_narrator/vision/factory.py
+++ b/src/movie_narrator/vision/factory.py
@@ -2,8 +2,7 @@
 
 Uses the :data:`vision_registry` to dispatch provider creation.
 Built-in provider (stub) is registered at import time. External
-plugins can register additional providers (blip, llava, http_vlm,
-etc.) via :func:`register_vision`.
+plugins can register additional providers via :func:`register_vision`.
 """
 
 from ..providers import vision_registry
@@ -22,6 +21,10 @@ def _make_stub(**kwargs) -> VisionCaptioner:
 if not vision_registry.contains("stub"):
     vision_registry.register("stub", _make_stub)
 
+# Enable protocol validation: create() will TypeError if a factory
+# returns something that is not a VisionCaptioner instance.
+vision_registry.set_protocol(VisionCaptioner)
+
 
 # ── Public factory function ───────────────────────────────
 
@@ -32,11 +35,10 @@ def get_vision_captioner(
 ) -> VisionCaptioner:
     """Return a VisionCaptioner instance.
 
-    Looks up the provider name in :data:`vision_registry` first.
-    Falls back to the old if/elif chain for backward compatibility.
+    Looks up the provider name in :data:`vision_registry`.
 
     Args:
-        provider: Provider name (e.g. "stub", "http_vlm").
+        provider: Provider name (e.g. "stub", or plugin-registered names).
         **kwargs: Provider-specific configuration.
 
     Returns:
@@ -45,13 +47,8 @@ def get_vision_captioner(
     Raises:
         ValueError: when the provider is unknown.
     """
-    # Registry path (preferred)
     if vision_registry.contains(provider):
         return vision_registry.create(provider, **kwargs)
-
-    # Legacy fallback
-    if provider == "stub":
-        return _make_stub(**kwargs)
 
     raise ValueError(
         f"Unsupported vision captioner provider: {provider!r}. "

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -39,7 +39,7 @@ class JobParams(BaseModel):
     match_topk_reuse_penalty: Optional[float] = None  # EP3: score deduction for recently used scenes (default 0.15)
     embedding_model_name: Optional[str] = None
     # ── Vision (EP8) ──
-    # "none" (default) | "stub" | future providers (http_vlm, blip, etc.)
+    # "none" (default) | "stub" | plugin-registered providers (via register_vision)
     vision_captioner: Optional[str] = None
     # ── WP6: scene filtering ──
     # intro skip, dark frame drop, highlight window (all opt-in, default off)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -118,8 +118,10 @@ class TestAllCompleteness:
             "CONTRACT_VERSION",
             "StepRegistry", "step_registry",
             "ProviderRegistry", "tts_registry", "vision_registry",
+            "llm_registry", "research_registry",
             "register_step", "step",
             "register_tts", "register_vision",
+            "register_llm", "register_research",
             "Plugin", "PluginContext",
             "load_plugin", "discover_plugins", "list_available_plugins",
             "Step",
@@ -208,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 5, 0)."""
-        assert CONTRACT_VERSION == (0, 5, 0)
+        """CONTRACT_VERSION is (0, 5, 1) — bumped for M4 LLM/Research registry additions."""
+        assert CONTRACT_VERSION == (0, 5, 1)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""
@@ -231,8 +233,10 @@ class TestSDKSymbolExports:
     @pytest.mark.parametrize("name", [
         "StepRegistry", "step_registry",
         "ProviderRegistry", "tts_registry", "vision_registry",
+        "llm_registry", "research_registry",
         "register_step", "step",
         "register_tts", "register_vision",
+        "register_llm", "register_research",
         "Plugin", "PluginContext",
         "load_plugin", "discover_plugins", "list_available_plugins",
         "Step",
@@ -271,6 +275,26 @@ class TestSDKSymbolExports:
         """register_vision is the same function as in providers.registry."""
         from movie_narrator.providers.registry import register_vision as _register_vision
         assert contract.register_vision is _register_vision
+
+    def test_llm_registry_is_global_instance(self):
+        """llm_registry is the global ProviderRegistry instance for LLM."""
+        from movie_narrator.providers.registry import llm_registry as _llm_registry
+        assert contract.llm_registry is _llm_registry
+
+    def test_research_registry_is_global_instance(self):
+        """research_registry is the global ProviderRegistry instance for research."""
+        from movie_narrator.providers.registry import research_registry as _research_registry
+        assert contract.research_registry is _research_registry
+
+    def test_register_llm_identity(self):
+        """register_llm is the same function as in providers.registry."""
+        from movie_narrator.providers.registry import register_llm as _register_llm
+        assert contract.register_llm is _register_llm
+
+    def test_register_research_identity(self):
+        """register_research is the same function as in providers.registry."""
+        from movie_narrator.providers.registry import register_research as _register_research
+        assert contract.register_research is _register_research
 
     def test_load_plugin_identity(self):
         """load_plugin is the same function as in plugin_loader."""

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -24,8 +24,12 @@ from movie_narrator.providers import (
     ProviderRegistry,
     tts_registry,
     vision_registry,
+    llm_registry,
+    research_registry,
     register_tts,
     register_vision,
+    register_llm,
+    register_research,
 )
 from movie_narrator.contract import (
     Plugin,
@@ -437,6 +441,38 @@ class TestGlobalVisionRegistry:
         assert isinstance(provider, VisionCaptioner)
 
 
+class TestGlobalLlmRegistry:
+    """The global llm_registry (M4)."""
+
+    def test_openai_registered_after_import(self):
+        # Import the module to trigger registration
+        import movie_narrator.utils.llm  # noqa: F401
+        assert "openai" in llm_registry.names()
+
+    def test_registry_category(self):
+        assert llm_registry._category == "llm"
+
+    def test_registry_no_protocol(self):
+        """LLM registry does not set a protocol (factories return context managers)."""
+        assert llm_registry._protocol is None
+
+
+class TestGlobalResearchRegistry:
+    """The global research_registry (M4)."""
+
+    def test_llm_registered_after_import(self):
+        # Import the module to trigger registration
+        import movie_narrator.pipeline.research  # noqa: F401
+        assert "llm" in research_registry.names()
+
+    def test_registry_category(self):
+        assert research_registry._category == "research"
+
+    def test_registry_no_protocol(self):
+        """Research registry does not set a protocol (factories return ResearchInfo)."""
+        assert research_registry._protocol is None
+
+
 # ── Plugin system tests ───────────────────────────────────
 
 
@@ -479,6 +515,8 @@ class TestPluginProtocol:
         assert ctx.steps is step_registry
         assert ctx.tts is tts_registry
         assert ctx.vision is vision_registry
+        assert ctx.llm is llm_registry
+        assert ctx.research is research_registry
 
 
 class TestPluginStepInsertion:
@@ -602,6 +640,24 @@ class TestSDKSurface:
     def test_register_vision_exported(self):
         from movie_narrator import register_vision
         assert callable(register_vision)
+
+    def test_register_llm_exported(self):
+        from movie_narrator import register_llm
+        assert callable(register_llm)
+
+    def test_register_research_exported(self):
+        from movie_narrator import register_research
+        assert callable(register_research)
+
+    def test_llm_registry_exported(self):
+        from movie_narrator import llm_registry as exported
+        from movie_narrator.providers import llm_registry
+        assert exported is llm_registry
+
+    def test_research_registry_exported(self):
+        from movie_narrator import research_registry as exported
+        from movie_narrator.providers import research_registry
+        assert exported is research_registry
 
     def test_context_exported(self):
         from movie_narrator import Context as ExportedContext


### PR DESCRIPTION
## M4 — Provider Migration

Migrates built-in LLM and Research providers to the registry pattern established in M1/M2, completing the v0.5 provider ecosystem.

### Changes

#### New Registries
- **`llm_registry`** — `utils/llm.py` migrated to registry pattern with built-in `openai` provider (`@register_llm("openai")`)
- **`research_registry`** — `pipeline/research.py` migrated to registry pattern with built-in `llm` provider (`@register_research("llm")`)

#### Protocol Validation
- `tts_registry` and `vision_registry` now enforce ABC conformance at `create()` time
- Factories returning non-`TTSProvider` / non-`VisionCaptioner` instances raise `TypeError`
- `set_protocol()` method added for deferred protocol binding (avoids circular imports)

#### Legacy Cleanup
- Removed dead fallback code from `tts/factory.py` and `vision/factory.py`
- Provider dispatch is now registry-only

#### SDK Surface
- `register_llm`, `register_research`, `llm_registry`, `research_registry` added to `contract.py` and `__init__.py`
- `PluginContext` extended with `llm` and `research` fields
- `llm_provider` setting added to `config.py`

#### Version
- `CONTRACT_VERSION` bumped to `(0, 5, 1)` — backward compatible (new exports only)
- Package version bumped to `0.5.1`

### Documentation
- ROADMAP (EN/ZH): added M4 section
- ARCHITECTURE (EN/ZH): updated provider registry table, extension points, plugin system
- CONTRIBUTING (EN/ZH): updated directory tree
- AI_GUIDE: updated directory tree and contract version
- Fixed `http_vlm` references across all docs and source code (was never merged)
- CHANGELOG: added 0.5.1 entry

### Testing
- 676 tests passed, 23 skipped
- New tests: LLM/Research registry identity, SDK exports, PluginContext fields
- Updated tests: CONTRACT_VERSION assertion, `__all__` completeness, parametrize lists