### PR TITLE
fix(docs): align CONTRIBUTING and README with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ mn create --movie "飞驰人生" --duration 60
 
 ### Full reference
 
-See [`.env.example`](.env.example) for the complete list of all 24 environment variables (LLM + TTS infrastructure only). All pipeline behavior is configured via [`examples/job.example.yaml`](examples/job.example.yaml) — 48 params keys covering scene detection, match, render, translate, BGM, WhisperX, async, and video sizes.
+See [`.env.example`](.env.example) for the complete list of all environment variables (LLM + TTS infrastructure only). All pipeline behavior is configured via [`examples/job.example.yaml`](examples/job.example.yaml) — params keys covering scene detection, match, render, translate, BGM, WhisperX, async, and video sizes.
 
 ### LLM Provider Guides
 
@@ -466,7 +466,7 @@ movie-narrator/
 - [x] Step-level retry mechanism (`--retry` flag, `StepAction` enum)
 - [x] Auto-create `~/.movie-narrator/.env` on first run
 - [x] `export_clips` direct ffmpeg subprocess (design choice, not workaround)
-- [x] Config system overhaul: strict env/yaml boundary — `.env` (Settings) contains 21 LLM + TTS infrastructure fields only; `job.yaml` (params) contains all 32 pipeline behavior keys; YAML auto-discovery (`--config` not passed → `cwd/job.yaml` → packaged example); `.env.example` and `job.example.yaml` are the single sources of truth; no code constants module — inline literals match example files
+- [x] Config system overhaul: strict env/yaml boundary — `.env` (Settings) contains LLM + TTS infrastructure fields only; `job.yaml` (params) contains all pipeline behavior keys; YAML auto-discovery (`--config` not passed → `cwd/job.yaml` → packaged example); `.env.example` and `job.example.yaml` are the single sources of truth; no code constants module — inline literals match example files
 
 ### v0.5.x — Ecosystem
 
@@ -479,6 +479,8 @@ movie-narrator/
 - [x] Out-of-tree example plugin (`examples/plugins/watermark/`) (#92)
 - [x] WP6 scene filtering — intro skip, dark frame detection, highlight window (#93)
 - [x] WebUI split — `movie-narrator-web` standalone repo, core engine is now pure CLI (#94, #95)
+- [x] M4 — Provider migration: LLM/Research registries, protocol validation for TTS/Vision (#98)
+- [x] M5 — Community & packaging: CLI plugin commands, plugin template, `check_version()`, packaging guide (#99)
 
 > SDK and Plugin API are designed together — both must stabilize in the same release.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,11 +37,11 @@ movie-narrator/
 │   ├── plugin_loader.py # Plugin discovery via entry_points, StepRegistry, Plugin protocol
 │   ├── models.py        # Context, PipelineStatus, StepState, Services, ...
 │   ├── contract.py      # Stable API boundary (CONTRACT_VERSION = (0, 5, 1))
-│   ├── cli.py           # `mn` Typer entry points (create, version, ...)
-│   └── workflow.py      # job.yaml load/merge (JobConfig, merge_job)
+│   ├── cli.py           # `mn` Typer entry points (create, version, plugin, ...)
+│   └── workflow/        # job.yaml load/merge (schema.py, load.py, merge.py, errors.py)
 ├── tests/               # pytest suite (unit + smoke)
-├── docs/                # ARCHITECTURE, ROADMAP, CONTRIBUTING, specs/
-└── examples/            # job.example.yaml, plugins/watermark/
+├── docs/                # ARCHITECTURE, ROADMAP, CONTRIBUTING, PACKAGING, specs/
+└── examples/            # job.example.yaml, plugins/watermark/, plugins/template/
 ```
 
 The Web UI is developed in a separate repository ([`movie-narrator-web`](https://github.com/zcbacxc/movie-narrator-web)); it consumes the core engine only through the contract surface defined in `contract.py`. There is no `web_api/` or `webui/` tree in this repo.
@@ -112,9 +112,11 @@ See `examples/plugins/watermark/` for a complete reference implementation.
 Plugins extend the pipeline with custom steps and providers:
 
 1. **Implement the Plugin protocol**: create a class with a `name` property and a `register(ctx: PluginContext)` method
-2. **Register steps/providers**: inside `register()`, call `ctx.steps.register(...)`, `ctx.tts.register(...)`, or `ctx.vision.register(...)`
+2. **Register steps/providers**: inside `register()`, call `ctx.steps.register(...)`, `ctx.tts.register(...)`, `ctx.vision.register(...)`, `ctx.llm.register(...)`, or `ctx.research.register(...)`
 3. **Declare entry point**: add `[project.entry-points."movie_narrator.plugins"]` to your `pyproject.toml`
 4. **Use services**: access `ctx.services.logger` for structured logging (M2)
 5. **Test**: verify your plugin loads via `discover_plugins()` and `list_available_plugins()`
 
 Reference implementation: `examples/plugins/watermark/`
+
+For plugin packaging, versioning, and PyPI publishing, see [PACKAGING.md](PACKAGING.md).


### PR DESCRIPTION
## Summary

Aligns `docs/CONTRIBUTING.md` and `README.md` with the current project structure after M4/M5.

## Changes

### CONTRIBUTING.md
- Fix `workflow.py` → `workflow/` directory reference (schema.py, load.py, merge.py, errors.py)
- Add `plugin` to CLI entry points list
- Add `plugins/template/` to examples listing
- Add `PACKAGING.md` to docs listing
- Add `ctx.llm.register(...)` and `ctx.research.register(...)` to plugin provider registration list
- Add PACKAGING.md reference at the end of plugin development section

### README.md
- Add M4 (Provider migration) and M5 (Community & packaging) to v0.5.x roadmap
- Remove hardcoded env/param counts (24/48/21/32) — replace with source-of-truth file references to avoid future drift

## No code changes
Documentation-only PR.