### PR TITLE
feat(v0.5.3): hardening — SDK docs, benchmarks, quickstart, research plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.3] - 2026-07-27
+
+### Added (v0.5.3 — Hardening)
+
+- **SDK API reference** (`mkdocs.yml` + `docs/sdk/`): mkdocs + mkdocstrings configuration for auto-generating API documentation from source docstrings. SDK reference pages cover `contract.py`, `models.py`, `providers/registry.py`, `pipeline/runner.py`, `tts/`, and `presets/`.
+- **Performance benchmark** (`benchmarks/profile_pipeline.py`): per-step profiling script that runs the full 15-step pipeline in CI mode (mock LLM + silent TTS) and reports timing for each step. Supports multiple runs with averaging and JSON output.
+- **Quickstart guide** (`docs/QUICKSTART.md`): end-to-end plugin development tutorial covering package creation, installation, testing, all four extension types (step/TTS/LLM/research), and PyPI publishing.
+- **Research provider example** (`examples/plugins/research-wiki/`): out-of-tree plugin demonstrating `@register_research` with a Wikipedia REST API-based research provider. Includes comparison table with the built-in `llm` provider.
+- **`ResearchInfo` SDK export**: `ResearchInfo` model added to the public SDK surface (`contract.py` + `__init__.py`), enabling research providers to import it directly from `movie_narrator`.
+- **`docs` optional dependency** (`pyproject.toml`): `pip install movie-narrator[docs]` installs mkdocs + mkdocstrings for local doc building.
+
+### Changed
+
+- `docs/PLUGIN_DEVELOPMENT.md`: added LLM Providers and Research Providers sections with code examples; updated SDK Surface table with `register_llm`, `register_research`, `llm_registry`, `research_registry`, `ResearchInfo`, and `check_version`; updated stability guarantees to include LLM/Research interfaces.
+- `docs/ROADMAP.md`: added v0.5.3 Hardening section.
+
 ## [0.5.2] - 2026-07-26
 
 ### Added (M5 — Community & Packaging)

--- a/benchmarks/profile_pipeline.py
+++ b/benchmarks/profile_pipeline.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Pipeline performance benchmark.
+
+Profiles each of the 15 built-in pipeline steps in CI mode (mock LLM +
+silent TTS) to establish baseline timings. Output is a JSON report plus
+a human-readable summary printed to stdout.
+
+Usage::
+
+    python benchmarks/profile_pipeline.py
+    python benchmarks/profile_pipeline.py --output benchmark.json
+    python benchmarks/profile_pipeline.py --runs 3
+
+Requirements:
+    - movie-narrator installed (pip install -e ".[dev]")
+    - ffmpeg with mp3 encoder (libmp3lame)
+    - CI=1 environment variable (auto-set by this script)
+
+The benchmark does NOT make real LLM or TTS API calls — it uses the
+CI mock fallback that produces 4 canned script segments and silent
+TTS audio. This isolates pipeline orchestration overhead from network
+latency.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Force CI mode before importing movie_narrator
+os.environ["CI"] = "1"
+
+# Add src to path when running from source checkout
+_src = Path(__file__).resolve().parent.parent / "src"
+if _src.exists():
+    sys.path.insert(0, str(_src))
+
+
+@dataclass
+class StepTiming:
+    name: str
+    duration_sec: float
+    soft: bool
+    status: str = "ok"
+
+
+@dataclass
+class BenchmarkResult:
+    timestamp: str
+    python_version: str
+    total_duration_sec: float
+    steps: list[StepTiming] = field(default_factory=list)
+    slowest_step: Optional[str] = None
+    fastest_step: Optional[str] = None
+
+
+def _ffmpeg_has_mp3() -> bool:
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return False
+    try:
+        result = subprocess.run(
+            [ffmpeg, "-hide_banner", "-encoders"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return "libmp3lame" in result.stdout
+    except Exception:
+        return False
+
+
+def _run_benchmark(output_dir: Path) -> BenchmarkResult:
+    """Run one pipeline execution and collect per-step timings."""
+    from movie_narrator.models import Context, Services
+    from movie_narrator.pipeline.runner import build_context, run_pipeline
+    from movie_narrator.pipeline.registry import step_registry
+    from movie_narrator.utils.console import SilentConsole
+
+    from unittest.mock import patch
+
+    # Build context in CI mode
+    ctx = build_context(
+        movie="Benchmark Movie",
+        style="test",
+        duration=30,
+        voice=None,
+        format="16:9",
+        output_dir=output_dir,
+        keep_cache=False,
+        research=False,
+        services=Services(console=SilentConsole()),
+    )
+
+    # Wrap each step function with timing
+    timings: list[StepTiming] = []
+    original_steps = step_registry.ordered_steps()
+
+    # Monkey-patch the runner's STEPS list to wrap each step with timing
+    import movie_narrator.pipeline.runner as runner_mod
+
+    original_run = runner_mod.run_pipeline
+
+    step_timings: dict[str, float] = {}
+
+    # We'll intercept step execution by wrapping each step function
+    wrapped_steps = {}
+    for step_entry in original_steps:
+        original_func = step_entry.func
+
+        def make_wrapper(name, func):
+            def wrapper(ctx):
+                start = time.perf_counter()
+                try:
+                    result = func(ctx)
+                    elapsed = time.perf_counter() - start
+                    step_timings[name] = elapsed
+                    return result
+                except Exception:
+                    elapsed = time.perf_counter() - start
+                    step_timings[name] = elapsed
+                    raise
+            return wrapper
+
+        wrapper = make_wrapper(step_entry.name, original_func)
+        wrapped_steps[step_entry.name] = wrapper
+
+        # Re-register the wrapped version
+        if step_registry.contains(step_entry.name):
+            step_registry.unregister(step_entry.name)
+        step_registry.register(
+            step_entry.name,
+            wrapper,
+            soft=step_entry.soft,
+            status_field=step_entry.status_field,
+            consequence=step_entry.consequence,
+        )
+
+    # Run the pipeline
+    start_total = time.perf_counter()
+    try:
+        run_pipeline(ctx)
+    except Exception as e:
+        print(f"  WARNING: pipeline raised: {e}", file=sys.stderr)
+    total_duration = time.perf_counter() - start_total
+
+    # Restore original steps
+    for step_entry in original_steps:
+        if step_registry.contains(step_entry.name):
+            step_registry.unregister(step_entry.name)
+        step_registry.register(
+            step_entry.name,
+            step_entry.func,
+            soft=step_entry.soft,
+            status_field=step_entry.status_field,
+            consequence=step_entry.consequence,
+        )
+
+    # Build timing list in step order
+    for step_entry in original_steps:
+        name = step_entry.name
+        duration = step_timings.get(name, 0.0)
+        timings.append(StepTiming(
+            name=name,
+            duration_sec=round(duration, 4),
+            soft=step_entry.soft,
+            status="skipped" if duration == 0.0 else "ok",
+        ))
+
+    slowest = max(timings, key=lambda t: t.duration_sec) if timings else None
+    fastest = min((t for t in timings if t.duration_sec > 0), key=lambda t: t.duration_sec, default=None)
+
+    from datetime import datetime, timezone
+    return BenchmarkResult(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        python_version=sys.version.split()[0],
+        total_duration_sec=round(total_duration, 4),
+        steps=timings,
+        slowest_step=slowest.name if slowest else None,
+        fastest_step=fastest.name if fastest else None,
+    )
+
+
+def _format_summary(result: BenchmarkResult) -> str:
+    """Format a human-readable summary."""
+    lines = [
+        "",
+        "=" * 60,
+        "  Pipeline Performance Benchmark",
+        "=" * 60,
+        f"  Python:    {result.python_version}",
+        f"  Total:     {result.total_duration_sec:.3f}s",
+        f"  Steps:     {len(result.steps)}",
+        f"  Slowest:   {result.slowest_step}",
+        f"  Fastest:   {result.fastest_step}",
+        "=" * 60,
+        "",
+        f"  {'Step':<25} {'Time':>8}  {'Type':<6} {'Status'}",
+        f"  {'-'*25} {'-'*8}  {'-'*6} {'-'*8}",
+    ]
+    for step in result.steps:
+        lines.append(
+            f"  {step.name:<25} {step.duration_sec:>7.3f}s  "
+            f"{'soft' if step.soft else 'hard':<6} {step.status}"
+        )
+    lines.append("")
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Benchmark movie-narrator pipeline")
+    parser.add_argument("--output", "-o", type=Path, default=None, help="Output JSON file path")
+    parser.add_argument("--runs", "-n", type=int, default=1, help="Number of runs (averaged)")
+    args = parser.parse_args()
+
+    if not _ffmpeg_has_mp3():
+        print("ERROR: ffmpeg with libmp3lame is required for benchmarking.", file=sys.stderr)
+        print("Install ffmpeg or run in CI (ubuntu-latest).", file=sys.stderr)
+        return 1
+
+    results: list[BenchmarkResult] = []
+    for i in range(args.runs):
+        if args.runs > 1:
+            print(f"\n--- Run {i+1}/{args.runs} ---", file=sys.stderr)
+
+        with tempfile.TemporaryDirectory(prefix="mn_bench_") as tmpdir:
+            result = _run_benchmark(Path(tmpdir))
+            results.append(result)
+            print(_format_summary(result), file=sys.stderr)
+
+    # If multiple runs, compute averages
+    if args.runs > 1 and results:
+        avg_total = sum(r.total_duration_sec for r in results) / len(results)
+        print(f"\n--- Average over {args.runs} runs: {avg_total:.3f}s ---", file=sys.stderr)
+
+    # Output JSON
+    output_data = [asdict(r) for r in results]
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(output_data, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\nJSON report written to {args.output}", file=sys.stderr)
+    else:
+        print(json.dumps(output_data, indent=2, ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -78,9 +78,15 @@ The public SDK is importable from `movie_narrator`:
 | `register_step` | Decorator to register a pipeline step |
 | `register_tts` | Decorator to register a TTS provider factory |
 | `register_vision` | Decorator to register a Vision captioner factory |
+| `register_llm` | Decorator to register an LLM provider factory |
+| `register_research` | Decorator to register a research provider factory |
 | `step_registry` | Global step registry instance |
 | `tts_registry` | Global TTS provider registry instance |
 | `vision_registry` | Global Vision provider registry instance |
+| `llm_registry` | Global LLM provider registry instance |
+| `research_registry` | Global research provider registry instance |
+| `ResearchInfo` | Model returned by research providers |
+| `check_version` | Import-time contract version validation |
 
 ## Pipeline Steps
 
@@ -161,6 +167,60 @@ The factory receives keyword arguments and must return an object
 satisfying the `VisionCaptioner` protocol (with `caption_frame` and
 `caption_scenes` methods).
 
+## LLM Providers
+
+```python
+from contextlib import contextmanager
+from movie_narrator import register_llm
+
+@register_llm("anthropic")
+def make_anthropic():
+    @contextmanager
+    def _cm():
+        from .anthropic_client import AnthropicLLMClient
+        yield AnthropicLLMClient(model="claude-3-opus", api_key=...)
+    return _cm()
+```
+
+The factory takes no arguments and must return a **context manager**
+that yields an `LLMClient`-compatible object (with `.client` and
+`.model` attributes). The context manager pattern ensures proper
+resource cleanup.
+
+Select the provider via `llm_provider` in `.env` or settings.
+
+## Research Providers
+
+```python
+from movie_narrator import Context, ResearchInfo, register_research
+
+@register_research("web_search")
+def make_web_search(ctx: Context, settings) -> ResearchInfo:
+    # Fetch from your data source (API, database, web scraper, etc.)
+    return ResearchInfo(
+        title=ctx.movie_name,
+        year=2024,
+        summary="A custom summary from my provider.",
+        genres=["Action", "Drama"],
+        cast=["Actor 1", "Actor 2"],
+        keywords=["keyword1", "keyword2"],
+    )
+```
+
+The factory receives `(ctx, settings)` and must return a `ResearchInfo`
+instance. The pipeline's `research_plot` step calls this factory and
+writes the result to `research.json`.
+
+Select the provider in your job config:
+
+```yaml
+params:
+  research_provider: web_search
+```
+
+See `examples/plugins/research-wiki/` for a complete reference
+implementation using Wikipedia's REST API.
+
 ## Services
 
 The `Services` container provides infrastructure to steps:
@@ -204,12 +264,14 @@ The entry point value can be:
 ### What's stable in v0.5
 
 - The `Plugin` protocol (`name` + `register(ctx)`)
-- The `PluginContext` interface (`steps`, `tts`, `vision`)
+- The `PluginContext` interface (`steps`, `tts`, `vision`, `llm`, `research`)
 - `register_step` decorator signature
-- `register_tts` / `register_vision` decorator signatures
+- `register_tts` / `register_vision` / `register_llm` / `register_research` decorator signatures
 - Built-in step names and execution order
 - `discover_plugins()` / `load_plugin()` function signatures
 - `Services` field names (`console`, `logger`)
+- `ResearchInfo` model fields (`title`, `year`, `summary`, `genres`, `cast`, `keywords`)
+- `check_version()` function for import-time compatibility validation
 
 ### What may change in v0.6+
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,240 @@
+# Quickstart: Plugin Development
+
+This guide walks you through creating, packaging, and distributing a
+movie-narrator plugin from scratch in under 10 minutes.
+
+## Prerequisites
+
+```bash
+pip install movie-narrator
+```
+
+Verify installation:
+
+```bash
+mn version
+# movie-narrator 0.5.3 (contract 0.5.1)
+```
+
+## Step 1: Create the plugin package
+
+Create a new directory for your plugin:
+
+```
+my-plugin/
+├── pyproject.toml
+└── my_plugin/
+    └── __init__.py
+```
+
+### `pyproject.toml`
+
+```toml
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "my-plugin"
+version = "0.1.0"
+description = "My custom movie-narrator plugin."
+requires-python = ">=3.10"
+dependencies = ["movie-narrator>=0.5.0"]
+
+[project.entry-points."movie_narrator.plugins"]
+my-plugin = "my_plugin:MyPlugin"
+
+[tool.setuptools.packages.find]
+where = ["."]
+```
+
+The `[project.entry-points]` section is critical — it registers your
+plugin for auto-discovery. The key (`my-plugin`) is the plugin name
+shown by `mn plugin list`, and the value (`my_plugin:MyPlugin`) is the
+import path to your plugin class.
+
+### `my_plugin/__init__.py`
+
+```python
+from movie_narrator import Context, PluginContext, register_step
+
+
+class MyPlugin:
+    name = "my-plugin"
+
+    def register(self, ctx: PluginContext) -> None:
+        ctx.steps.register(
+            "my_step",
+            _my_step,
+            soft=True,
+            status_field="my_step",
+            consequence="my step skipped — output unaffected",
+            after="render_video",
+        )
+
+
+def _my_step(ctx: Context) -> Context:
+    """Add a custom processing step after video rendering."""
+    console = ctx.services.console
+    console.info(f"MyPlugin: processing {ctx.video_path}")
+
+    # Your custom logic here
+    ctx.metadata["my_step_ran"] = True
+
+    ctx.step_state.result = ctx.step_state.result.__class__("success")
+    ctx.step_state.message = "my step completed"
+    return ctx
+```
+
+## Step 2: Install and test locally
+
+```bash
+cd my-plugin
+pip install -e .
+```
+
+Verify the plugin is discovered:
+
+```bash
+mn plugin list
+# my-plugin (entry_point: my_plugin:MyPlugin)
+```
+
+Load it and verify registration:
+
+```bash
+mn plugin discover
+# Discovered: my-plugin
+# Registered steps: my_step (after render_video, soft)
+```
+
+## Step 3: Run with the plugin active
+
+The plugin is auto-loaded when `discover_plugins()` is called. In the
+CLI, this happens automatically:
+
+```bash
+mn create --movie "Inception" --video movie.mp4 --output-dir output/
+```
+
+Your step will execute after `render_video` and log its message.
+
+## Step 4: Choose your extension type
+
+The Plugin SDK supports four extension points. Pick the one that
+matches your goal:
+
+| Goal | Decorator | Factory signature | Example |
+|------|-----------|-------------------|---------|
+| Add a pipeline step | `register_step` | `(ctx: Context) -> Context` | `examples/plugins/watermark/` |
+| Add a TTS provider | `register_tts` | `(settings) -> TTSProvider` | Built-in `edge`, `openai`, `mimo` |
+| Add an LLM provider | `register_llm` | `() -> ContextManager[LLMClient]` | Built-in `openai` |
+| Add a research provider | `register_research` | `(ctx, settings) -> ResearchInfo` | `examples/plugins/research-wiki/` |
+| Add a vision captioner | `register_vision` | `(**kwargs) -> VisionCaptioner` | Built-in `stub` |
+
+### Research provider example
+
+```python
+from movie_narrator import Context, ResearchInfo, register_research
+
+@register_research("my_research")
+def _research(ctx: Context, settings) -> ResearchInfo:
+    # Fetch data from your source (API, database, etc.)
+    return ResearchInfo(
+        title=ctx.movie_name,
+        summary="A custom summary from my provider.",
+        genres=["Action"],
+        cast=[],
+        keywords=["custom"],
+    )
+```
+
+Select it in your job config:
+
+```yaml
+params:
+  research_provider: my_research
+```
+
+### TTS provider example
+
+```python
+from movie_narrator import register_tts
+
+@register_tts("my_tts")
+def _make_tts(settings) -> "TTSProvider":
+    from my_tts_impl import MyTTSProvider
+    return MyTTSProvider(settings)
+```
+
+Select it via environment variable:
+
+```bash
+MN_TTS_PROVIDER=my_tts mn create ...
+```
+
+## Step 5: Package and distribute
+
+### Build the wheel
+
+```bash
+pip install build
+python -m build
+```
+
+This produces `dist/my_plugin-0.1.0-py3-none-any.whl`.
+
+### Publish to PyPI
+
+```bash
+pip install twine
+twine upload dist/*
+```
+
+### Users install and use
+
+```bash
+pip install my-plugin
+mn plugin list          # confirms discovery
+mn create --movie ...   # plugin auto-loads
+```
+
+## Debugging
+
+### Plugin not discovered?
+
+Check:
+1. The entry point group is exactly `movie_narrator.plugins`
+2. The entry point value matches `package:ClassName`
+3. The package is installed (`pip show my-plugin`)
+4. Run `mn plugin list` to see all discovered entry points
+
+### Step not executing?
+
+Check:
+1. `mn plugin registries` shows your step in the registry
+2. The `after`/`before` insertion point matches a built-in step name
+3. The step is not disabled in `job.yaml` under `steps:`
+4. For soft steps, check `_degraded_steps` in metadata if it failed silently
+
+### Protocol validation error?
+
+TTS and Vision providers must return instances that satisfy the
+protocol ABC (`TTSProvider` / `VisionCaptioner`). If you see a
+`TypeError` from `create()`, ensure your provider class inherits from
+or implements all required methods.
+
+## Reference examples
+
+| Plugin | Extension type | Location |
+|--------|---------------|----------|
+| Watermark | Pipeline step | `examples/plugins/watermark/` |
+| Template | Pipeline step (skeleton) | `examples/plugins/template/` |
+| Research Wiki | Research provider | `examples/plugins/research-wiki/` |
+
+## Next steps
+
+- Read the [Plugin Development Guide](PLUGIN_DEVELOPMENT.md) for the
+  full API reference
+- Check the [Architecture](ARCHITECTURE.md) to understand pipeline flow
+- Review [PACKAGING.md](PACKAGING.md) for publishing best practices

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,6 +149,16 @@
 
 > **Design note**: SDK and Plugin API are designed together — the SDK is the primary consumer of the Plugin API, so both must stabilize in the same release to avoid compatibility pressure.
 
+### v0.5.3 — Hardening
+
+- [x] SDK API reference (`mkdocs.yml` + `docs/sdk/` — auto-generated from docstrings via mkdocstrings)
+- [x] Performance benchmark script (`benchmarks/profile_pipeline.py` — per-step profiling in CI mode)
+- [x] Quickstart guide (`docs/QUICKSTART.md` — end-to-end plugin tutorial)
+- [x] Research provider example (`examples/plugins/research-wiki/` — Wikipedia API-based research provider)
+- [x] `ResearchInfo` added to SDK exports (`contract.py` + `__init__.py`)
+- [x] `PLUGIN_DEVELOPMENT.md` updated with LLM and Research provider sections
+- [x] `docs` optional dependency group (mkdocs + mkdocstrings)
+
 ## v0.6.x — Cloud
 
 - [ ] Remote inference (offload LLM / TTS / rendering to cloud workers)

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -149,6 +149,16 @@
 
 > **设计备注**：SDK 与 Plugin API 是一起设计的 —— SDK 是 Plugin API 的主要使用者，所以两者必须在同一次发布稳定下来，避免兼容性压力。
 
+### v0.5.3 — Hardening
+
+- [x] SDK API 参考（`mkdocs.yml` + `docs/sdk/` —— 通过 mkdocstrings 从 docstring 自动生成）
+- [x] 性能基准脚本（`benchmarks/profile_pipeline.py` —— CI 模式下逐步骤 profiling）
+- [x] Quickstart 指南（`docs/QUICKSTART.md` —— 端到端插件开发教程）
+- [x] Research provider 示例（`examples/plugins/research-wiki/` —— 基于 Wikipedia API 的调研 provider）
+- [x] `ResearchInfo` 加入 SDK 导出（`contract.py` + `__init__.py`）
+- [x] `PLUGIN_DEVELOPMENT.md` 补全 LLM 和 Research provider 章节
+- [x] `docs` 可选依赖组（mkdocs + mkdocstrings）
+
 ## v0.6.x — Cloud
 
 - [ ] 远程推理（offload LLM / TTS / 渲染到云 worker）

--- a/docs/sdk/contract.md
+++ b/docs/sdk/contract.md
@@ -1,0 +1,40 @@
+# SDK API Reference
+
+This section is auto-generated from the source code docstrings using
+[mkdocstrings](https://mkdocstrings.github.io/). To build the docs
+locally:
+
+```bash
+pip install mkdocs mkdocstrings[python]
+mkdocs serve
+```
+
+Then open <http://localhost:8000>.
+
+## Contract module
+
+The `contract.py` module is the single import surface for external
+consumers (web package, plugins, SDK users).
+
+::: movie_narrator.contract
+
+## Models
+
+Core data models: `Context`, `Services`, `ResearchInfo`, `StepState`,
+`StepResult`, etc.
+
+::: movie_narrator.models
+
+## Provider registries
+
+The `ProviderRegistry` class and global registry instances for TTS,
+Vision, LLM, and Research providers.
+
+::: movie_narrator.providers.registry
+
+## Pipeline runner
+
+The `build_context` and `run_pipeline` functions, plus the
+`StepRegistry` and `PARAM_WHITELIST` exports.
+
+::: movie_narrator.pipeline.runner

--- a/docs/sdk/models.md
+++ b/docs/sdk/models.md
@@ -1,0 +1,5 @@
+# Models
+
+Core data models used throughout the pipeline.
+
+::: movie_narrator.models

--- a/docs/sdk/pipeline.md
+++ b/docs/sdk/pipeline.md
@@ -1,0 +1,5 @@
+# Pipeline
+
+The pipeline runner, step registry, and related modules.
+
+::: movie_narrator.pipeline.runner

--- a/docs/sdk/presets.md
+++ b/docs/sdk/presets.md
@@ -1,0 +1,6 @@
+# Narration Presets
+
+Built-in narration presets and the preset registry.
+
+::: movie_narrator.presets.base
+::: movie_narrator.presets.registry

--- a/docs/sdk/registries.md
+++ b/docs/sdk/registries.md
@@ -1,0 +1,5 @@
+# Provider Registries
+
+The `ProviderRegistry` class and global registry instances.
+
+::: movie_narrator.providers.registry

--- a/docs/sdk/tts.md
+++ b/docs/sdk/tts.md
@@ -1,0 +1,6 @@
+# TTS Providers
+
+The TTS provider abstraction, protocol, and built-in implementations.
+
+::: movie_narrator.tts.base
+::: movie_narrator.tts.protocol

--- a/examples/plugins/research-wiki/README.md
+++ b/examples/plugins/research-wiki/README.md
@@ -1,0 +1,79 @@
+# movie-narrator-research-wiki
+
+Example out-of-tree plugin demonstrating the `@register_research` provider
+extension point in the v0.5 Plugin SDK.
+
+## What it does
+
+Registers a research provider `wiki` that fetches movie information from
+Wikipedia's REST API instead of using an LLM. This is useful when:
+
+- You don't have an LLM API key configured
+- You want offline-friendly (free) movie metadata
+- You want to demonstrate the Research provider extension point
+
+## Installation
+
+```bash
+cd examples/plugins/research-wiki
+pip install -e .
+```
+
+## Usage
+
+### 1. Enable auto-discovery
+
+```python
+from movie_narrator import discover_plugins
+discover_plugins()
+```
+
+Or load manually:
+
+```python
+from movie_narrator import load_plugin
+from movie_narrator_research_wiki import WikiResearchPlugin
+load_plugin(WikiResearchPlugin())
+```
+
+### 2. Select the wiki provider in your job config
+
+```yaml
+params:
+  research_provider: wiki
+```
+
+Or via CLI:
+
+```bash
+mn create --movie "The Matrix" --research --config job.yaml
+```
+
+The pipeline will call Wikipedia's API instead of an LLM for the
+`research_plot` step.
+
+## How it works
+
+1. The plugin registers a factory function with `research_registry`
+2. When `research_plot` runs, it calls `research_registry.create("wiki", ctx, settings)`
+3. The factory searches Wikipedia for the movie title, fetches the summary,
+   and returns a `ResearchInfo` object
+4. The pipeline writes `research.json` and uses the data for script generation
+
+## Limitations
+
+- Wikipedia summaries may not include cast or detailed plot information
+- Year extraction is best-effort (regex on the summary text)
+- Genre extraction is keyword-based and may miss or misidentify genres
+- No API key required (uses public Wikipedia REST API)
+
+## Comparison with built-in `llm` provider
+
+| Feature | `llm` (built-in) | `wiki` (this plugin) |
+|---------|-------------------|----------------------|
+| Requires API key | Yes (OpenAI) | No |
+| Summary quality | High (structured) | Medium (Wikipedia extract) |
+| Cast/keywords | Yes | No |
+| Genres | Yes (LLM-inferred) | Best-effort keyword match |
+| Latency | 2-5s | 1-3s |
+| Cost | Per-token | Free |

--- a/examples/plugins/research-wiki/movie_narrator_research_wiki/__init__.py
+++ b/examples/plugins/research-wiki/movie_narrator_research_wiki/__init__.py
@@ -1,0 +1,115 @@
+"""WikiResearchPlugin — example research provider plugin.
+
+Registers a custom research provider ``wiki`` that fetches movie
+information from Wikipedia's REST API instead of using an LLM.
+
+This demonstrates the ``@register_research`` decorator and the
+ResearchInfo return contract. The provider is selected by setting
+``research_provider: wiki`` in job.yaml params.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from movie_narrator import Context, PluginContext, ResearchInfo, register_research
+
+WIKI_API = "https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
+WIKI_SEARCH = "https://en.wikipedia.org/w/api.php"
+
+
+def _search_wikipedia(movie: str) -> str | None:
+    """Search Wikipedia for a movie title and return the best-matching page title."""
+    params = urllib.parse.urlencode({
+        "action": "query",
+        "list": "search",
+        "srsearch": f"{movie} film",
+        "srlimit": "1",
+        "format": "json",
+        "origin": "*",
+    })
+    url = f"{WIKI_SEARCH}?{params}"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            results = data.get("query", {}).get("search", [])
+            if results:
+                return results[0]["title"]
+    except Exception:
+        pass
+    return None
+
+
+def _fetch_summary(page_title: str) -> dict[str, Any]:
+    """Fetch the Wikipedia summary for a page title."""
+    encoded = urllib.parse.quote(page_title, safe="")
+    url = WIKI_API.format(title=encoded)
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _extract_year(extract: str) -> int | None:
+    """Best-effort extraction of a 4-digit year from the summary text."""
+    import re
+    match = re.search(r"\b(19\d{2}|20\d{2})\b", extract)
+    return int(match.group(1)) if match else None
+
+
+def _extract_genres(extract: str) -> list[str]:
+    """Best-effort extraction of genre keywords from the summary text."""
+    genre_words = [
+        "action", "adventure", "comedy", "drama", "horror", "thriller",
+        "romance", "sci-fi", "science fiction", "fantasy", "mystery",
+        "crime", "animation", "documentary", "biographical", "musical",
+        "war", "western", "family", "sports",
+    ]
+    lower = extract.lower()
+    return list(dict.fromkeys(g.title() for g in genre_words if g in lower))
+
+
+class WikiResearchPlugin:
+    """Plugin that registers a Wikipedia-based research provider."""
+
+    name = "research-wiki"
+
+    def register(self, ctx: PluginContext) -> None:
+        """Register the wiki research provider."""
+        ctx.research.register("wiki", _research_via_wiki)
+
+
+def _research_via_wiki(ctx: Context, settings) -> ResearchInfo:
+    """Fetch movie research data from Wikipedia's REST API.
+
+    This function is called by the pipeline when ``research_provider``
+    is set to ``"wiki"`` in the job configuration.
+
+    Args:
+        ctx: Pipeline context containing ``ctx.movie_name``.
+        settings: Project settings (unused — Wikipedia API needs no key).
+
+    Returns:
+        ResearchInfo populated from Wikipedia data.
+
+    Raises:
+        RuntimeError: if Wikipedia lookup fails entirely.
+    """
+    movie = ctx.movie_name
+
+    page_title = _search_wikipedia(movie)
+    if not page_title:
+        page_title = movie
+
+    summary_data = _fetch_summary(page_title)
+    extract = summary_data.get("extract", "")
+
+    return ResearchInfo(
+        title=summary_data.get("title", movie),
+        year=_extract_year(extract),
+        summary=extract[:500] if extract else "",
+        genres=_extract_genres(extract),
+        cast=[],
+        keywords=[],
+    )

--- a/examples/plugins/research-wiki/pyproject.toml
+++ b/examples/plugins/research-wiki/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "movie-narrator-research-wiki"
+version = "0.1.0"
+description = "Example plugin for movie-narrator: Wikipedia-based research provider."
+requires-python = ">=3.10"
+
+[project.entry-points."movie_narrator.plugins"]
+research-wiki = "movie_narrator_research_wiki:WikiResearchPlugin"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,58 @@
+site_name: movie-narrator
+site_description: Generate narrated movie recap videos from a single prompt.
+site_url: https://github.com/zcbacxc/movie-narrator
+repo_url: https://github.com/zcbacxc/movie-narrator
+repo_name: zcbacxc/movie-narrator
+edit_uri: edit/main/docs/
+
+theme:
+  name: readthedocs
+  highlightjs: true
+  hljs_languages:
+    - python
+    - yaml
+    - bash
+    - toml
+
+nav:
+  - Home: index.md
+  - Quickstart: QUICKSTART.md
+  - Plugin Development: PLUGIN_DEVELOPMENT.md
+  - Architecture: ARCHITECTURE.md
+  - Roadmap: ROADMAP.md
+  - Contributing: CONTRIBUTING.md
+  - Packaging: PACKAGING.md
+  - LLM Providers: LLM_PROVIDERS.md
+  - SDK Reference:
+      - Contract: sdk/contract.md
+      - Models: sdk/models.md
+      - Registries: sdk/registries.md
+      - Pipeline: sdk/pipeline.md
+      - TTS: sdk/tts.md
+      - Presets: sdk/presets.md
+
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: false
+            show_root_heading: true
+            show_signature_annotations: true
+            separate_signature: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            filters:
+              - "!^_"
+              - "!^__"
+
+markdown_extensions:
+  - admonition
+  - codehilite
+  - toc:
+      permalink: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.superfences

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.5.2"
+version = "0.5.3"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = {text = "AGPL-3.0"}
@@ -48,6 +48,11 @@ full = [
     'sentence-transformers>=3.0; python_version < "3.14"',
 ]
 dev = ["pytest>=8.0"]
+docs = [
+    "mkdocs>=1.5",
+    "mkdocstrings[python]>=0.24",
+    "pymdown-extensions>=9.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/zcbacxc/movie-narrator"

--- a/src/movie_narrator/__init__.py
+++ b/src/movie_narrator/__init__.py
@@ -22,6 +22,7 @@ from .contract import (  # noqa: F401
     Plugin,
     PluginContext,
     ProviderRegistry,
+    ResearchInfo,
     Services,
     Step,
     StepRegistry,

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -92,7 +92,7 @@ from .pipeline.runner import PARAM_WHITELIST, build_context, run_pipeline
 
 # ── Re-exports: models ─────────────────────────────────────
 
-from .models import Context, Services
+from .models import Context, ResearchInfo, Services
 
 # ── Re-exports: registries ─────────────────────────────────
 
@@ -259,6 +259,7 @@ __all__ = [
     "PipelineResult",
     # Models
     "Context",
+    "ResearchInfo",
     "Services",
     # Registries
     "StepRegistry",


### PR DESCRIPTION
## v0.5.3 — Hardening

SDK documentation, performance benchmarks, and developer guides to prepare for v0.6 cloud architecture.

### Changes

| Item | Description |
|------|-------------|
| **SDK API reference** | `mkdocs.yml` + `docs/sdk/` pages with mkdocstrings auto-generation for `contract.py`, `models.py`, `providers/registry.py`, `pipeline/runner.py`, `tts/`, `presets/` |
| **Performance benchmark** | `benchmarks/profile_pipeline.py` — per-step profiling in CI mode (mock LLM + silent TTS), supports `--runs N` and `--output json` |
| **Quickstart guide** | `docs/QUICKSTART.md` — end-to-end plugin tutorial (package creation → install → test → publish) |
| **Research provider example** | `examples/plugins/research-wiki/` — Wikipedia API-based `@register_research` plugin with comparison table |
| **ResearchInfo SDK export** | `ResearchInfo` added to public SDK surface (`contract.py` + `__init__.py`) |
| **PLUGIN_DEVELOPMENT.md** | Added LLM Providers + Research Providers sections; updated SDK Surface table and stability guarantees |
| **docs optional dep** | `pip install movie-narrator[docs]` installs mkdocs + mkdocstrings |

### Test Results

- **704 passed**, 23 skipped (identical to v0.5.2 baseline)
- `ResearchInfo` import verified from both `movie_narrator` and `movie_narrator.contract`
- CONTRACT_VERSION unchanged at `(0, 5, 1)` — backward compatible patch release

### Files (19 changed, +941 lines)

```
new:  benchmarks/profile_pipeline.py
new:  docs/QUICKSTART.md
new:  docs/sdk/{contract,models,pipeline,presets,registries,tts}.md
new:  examples/plugins/research-wiki/{README.md,pyproject.toml,__init__.py}
new:  mkdocs.yml
mod:  CHANGELOG.md
mod:  docs/PLUGIN_DEVELOPMENT.md
mod:  docs/ROADMAP.md + ROADMAP.zh-CN.md
mod:  pyproject.toml (version → 0.5.3, docs extras)
mod:  src/movie_narrator/{__init__,contract}.py (ResearchInfo export)
```