### PR TITLE
fix: flaky test_list_artifacts_no_output race condition

### DIFF
--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -375,10 +375,17 @@ class TestArtifactManagement:
         assert "subtitle.srt" in filenames
         assert "metadata.json" in filenames
 
-    def test_list_artifacts_no_output(self, api_server, remote_queue):
+    def test_list_artifacts_no_output(self, api_server):
         """GET /tasks/{id}/artifacts returns empty for tasks without output."""
-        task_id = remote_queue.submit(TaskRequest(movie_name="NoOutput", max_retries=0))
-        artifacts = list_artifacts(api_server.base_url, task_id)
+        from movie_narrator.cloud.models import Task
+
+        # Create a pending task directly in storage (bypassing worker execution)
+        task = Task(
+            request=TaskRequest(movie_name="NoOutput", max_retries=0),
+            status=TaskStatus.PENDING,
+        )
+        api_server.queue._storage.save(task)
+        artifacts = list_artifacts(api_server.base_url, task.id)
         assert artifacts == []
 
     def test_download_artifact(self, api_server, completed_task_with_files, tmp_path):


### PR DESCRIPTION
## Fix

	est_list_artifacts_no_output was flaky: it submitted a task via emote_queue.submit() then immediately asserted rtifacts == []. However, the mock pipeline executes synchronously and could complete before the assertion, producing inal.mp4 and 
arration.mp3 output files.

## Root Cause

The test relied on the task not completing before the list_artifacts call — a race condition that fails on faster CI runners (Python 3.11).

## Fix

Create a PENDING task directly in storage, bypassing the worker execution path entirely. This guarantees no output files exist when list_artifacts is called.

## Test

\\\
tests/test_v061_remote.py::TestArtifactManagement::test_list_artifacts_no_output PASSED
\\\
