### PR TITLE
feat(v0.7.0): GPU encoding, cost tracking, render parallelization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `mkdocs.yml`: added "Best Practices" navigation entry.
 - **Internal terminology cleanup**: replaced all "L2 hand-test" / "L2+" / "Q-X" internal QA references with community-friendly terms ("manual QA verification") across documentation (`ROADMAP`, `ARCHITECTURE`, `METADATA_SCHEMA` — EN/ZH), source code comments (`align.py`, `match.py`, `scene_filter.py`, `_align_backend.py`, `metadata_export.py`, `scenes.py`, `deliverable_qa.py`), test files (`test_audit_integration.py`, `test_e2e_smoke.py`, `test_match.py`), and scripts (`compare_runs.py`). CHANGELOG historical entries preserved as immutable records.
 
+## [0.7.0] - 2026-07-30
+
+### Added
+
+- GPU encoder auto-detection (NVENC/VAAPI/VideoToolbox) with fallback to libx264
+- Per-run cost tracking for LLM token usage and TTS calls in metadata.json
+- Parallel subtitle image generation using ThreadPoolExecutor
+- `render_encoder` job parameter ("auto"/"cpu"/"nvenc"/"vaapi"/"videotoolbox")
+- Encoder info recorded in render metadata
+
+### Changed
+
+- Render pipeline uses GPU-accelerated encoding when available
+- Version bumped to 0.7.0, CONTRACT_VERSION to (0, 7, 0)
+
 ## [0.6.1] - 2026-07-29
 
 ### Added (v0.6.1 — Remote Inference)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.6.1"
+version = "0.7.0"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -49,7 +49,7 @@ from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 6, 1)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 7, 0)
 
 
 def check_version(required: tuple[int, int, int]) -> None:

--- a/src/movie_narrator/models.py
+++ b/src/movie_narrator/models.py
@@ -268,6 +268,9 @@ class Context(BaseModel):
     # Single-step return state — consumed by runner, reset after each step
     step_state: StepState = Field(default_factory=StepState)
 
+    # v0.7.0: per-run cost tracking
+    cost_tracker: Optional[Any] = None
+
     metadata: _MetadataType = Field(default_factory=dict)
 
     @model_validator(mode="before")

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -529,7 +529,23 @@ def render_video(ctx: Context) -> Context:
         ffmpeg_params=video_ffmpeg_params,
     )
     try:
-        final_video.write_videofile(str(video_only_path), **video_write_kwargs)
+        try:
+            final_video.write_videofile(str(video_only_path), **video_write_kwargs)
+        except Exception as gpu_err:
+            if gpu_codec != "libx264":
+                # v0.7.0: GPU encoding failed (no hardware, driver issue,
+                # unsupported option, etc.) — retry with CPU libx264 so the
+                # pipeline degrades gracefully instead of aborting.
+                ctx.services.console.inline_warn(
+                    f"GPU encoding ({gpu_codec}) failed: {gpu_err}. "
+                    f"Retrying with libx264 (CPU)."
+                )
+                gpu_codec = "libx264"
+                video_write_kwargs["codec"] = "libx264"
+                video_write_kwargs["ffmpeg_params"] = ["-crf", str(crf), "-preset", str(preset)]
+                final_video.write_videofile(str(video_only_path), **video_write_kwargs)
+            else:
+                raise
     finally:
         # Exception-safe cleanup: each close is guarded so one failure
         # doesn't prevent the remaining resources from being released.

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -4,6 +4,7 @@
 import json
 import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from moviepy import AudioFileClip, ColorClip, CompositeVideoClip, ImageClip, VideoFileClip
@@ -12,6 +13,7 @@ from proglog import TqdmProgressBarLogger
 
 from ..models import Context, MatchedClip, StepResult, TimedSegment
 from ..utils.console import step_timing
+from ..utils.gpu_detect import get_encoder_info, resolve_encoder
 from ..utils.metadata_export import build_metadata_json
 from ..utils.text_image import create_text_image as _create_text_image
 from ..utils.video_layout import compute_fit_box
@@ -281,6 +283,10 @@ def render_video(ctx: Context) -> Context:
 
     if usable_clips and ctx.source_video_path:
         try:
+            # v0.7.0: VideoFileClip opens the source via a streaming reader
+            # that seeks on demand rather than decoding the entire file into
+            # memory. This keeps peak RAM bounded even for very large source
+            # files; avoid replacing it with a full-decode approach.
             source = VideoFileClip(ctx.source_video_path)
         except Exception as e:
             ctx.services.console.inline_warn(
@@ -337,8 +343,13 @@ def render_video(ctx: Context) -> Context:
     for mc in usable_clips:
         footage_segments.add(mc.segment_index)
 
-    for i, seg in enumerate(ctx.timed_segments):
-        pos = "bottom" if i in footage_segments else subtitle_position
+    # v0.7.0: Render parallelization — generate subtitle overlay images in a
+    # thread pool. Text rasterisation (PIL) is CPU-bound and releases the GIL
+    # during the native font/blend work, so a small worker pool cuts wall time
+    # for videos with many segments without complicating clip ordering (each
+    # future carries its own index/segment; results are appended in submit
+    # order which is deterministic).
+    def _make_subtitle_image(i, seg, pos):
         img_array = _create_text_image(
             _overlay_text(ctx, i, seg), size, fontsize=font_size,
             position=pos,
@@ -346,8 +357,15 @@ def render_video(ctx: Context) -> Context:
             bottom_margin_ratio=bottom_margin_ratio,
         )
         img_clip = ImageClip(img_array, is_mask=False)
-        img_clip = img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
-        clips.append(img_clip)
+        return img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        subtitle_futures = []
+        for i, seg in enumerate(ctx.timed_segments):
+            pos = "bottom" if i in footage_segments else subtitle_position
+            subtitle_futures.append(pool.submit(_make_subtitle_image, i, seg, pos))
+        for future in subtitle_futures:
+            clips.append(future.result())
 
     # EP5: Title card overlay — show movie name at the beginning for a
     # polished opening. Uses a larger centered font with fade in/out.
@@ -447,6 +465,12 @@ def render_video(ctx: Context) -> Context:
         )
 
     final_video = CompositeVideoClip(clips).with_audio(audio_clip)
+    # Free clip references before encoding to reduce peak memory (v0.7.0).
+    # The CompositeVideoClip retains its own references to the child clips via
+    # ``final_video.clips``; the standalone ``clips`` list is no longer needed
+    # and dropping it lets GC reclaim the list shell during the expensive
+    # write_videofile call below.
+    del clips
     video_path = output_dir / ctx.metadata.get("render_output_name", "final.mp4")
 
 
@@ -465,6 +489,15 @@ def render_video(ctx: Context) -> Context:
     preset = ctx.metadata.get("render_preset", "slow")
     faststart = ctx.metadata.get("render_faststart", True)
 
+    # v0.7.0: GPU encoder resolution. ``render_encoder`` accepts "auto"
+    # (default, probe + fall back to libx264), "cpu", or an explicit backend
+    # ("nvenc" / "vaapi" / "videotoolbox"). ``resolve_encoder`` returns a
+    # ``(codec, ffmpeg_params)`` tuple; the params are backend-specific and
+    # replace the libx264-only ``-crf``/``-preset`` knobs when a GPU encoder
+    # is active. See ..utils.gpu_detect for the probe + caching logic.
+    render_encoder_hint = ctx.metadata.get("render_encoder")
+    gpu_codec, gpu_params = resolve_encoder(render_encoder_hint)
+
     # TWO-STAGE ENCODE: write a video-only mp4 via MoviePy (which is
     # stable in isolation), then mux audio with ffmpeg in a second pass.
     #
@@ -476,13 +509,20 @@ def render_video(ctx: Context) -> Context:
     # See commit notes on PR #37 for the empirical reproduction.
     video_only_path = tmp_dir / "video_only.mp4"
 
-    video_ffmpeg_params = ["-crf", str(crf), "-preset", str(preset)]
+    # When using libx264 (CPU), pass CRF + preset. For GPU encoders
+    # (h264_nvenc / h264_vaapi / h264_videotoolbox) the GPU-specific params
+    # from resolve_encoder() replace crf/preset — those flags are not valid
+    # for hardware encoders and would be silently ignored or error out.
+    if gpu_codec == "libx264":
+        video_ffmpeg_params = ["-crf", str(crf), "-preset", str(preset)]
+    else:
+        video_ffmpeg_params = list(gpu_params)
     # NOTE: do NOT include +faststart here — we apply it deterministically
     # during the second-pass ffmpeg mux below, which is more reliable than
     # bundling it into MoviePy's subprocess invocation.
     video_write_kwargs = dict(
         fps=ctx.metadata.get("render_fps", 24),
-        codec=ctx.metadata.get("render_video_codec", "libx264"),
+        codec=gpu_codec,
         audio=False,  # ← key: defer audio mux to step 2
         threads=ctx.metadata.get("render_threads", 4),
         logger=_RenderProgressLogger(),
@@ -496,7 +536,18 @@ def render_video(ctx: Context) -> Context:
         # NOTE: source must NOT be closed before write_videofile — MoviePy 2.x
         # subclipped() clips share the parent reader, so closing source early
         # would crash during encoding.
-        for obj in (final_video, audio_clip, source, *clips):
+        #
+        # v0.7.0: ``clips`` was deleted before encoding to reduce peak memory.
+        # MoviePy 2.1.x CompositeVideoClip.close() only closes its bg/audio —
+        # it does NOT cascade to the child clips — so we recover them via
+        # ``final_video.clips`` for explicit cleanup. ``list(...)`` is safe for
+        # both the real CompositeVideoClip (returns the clip list) and test
+        # mocks (MagicMock.__iter__ yields an empty sequence).
+        try:
+            child_clips = list(final_video.clips) if final_video is not None else []
+        except (AttributeError, TypeError):
+            child_clips = []
+        for obj in (final_video, audio_clip, source, *child_clips):
             if obj is not None:
                 try:
                     obj.close()
@@ -552,6 +603,11 @@ def render_video(ctx: Context) -> Context:
             shutil.rmtree(tmp_dir, ignore_errors=True)
         except OSError:
             pass
+
+    # v0.7.0: Record which encoder was actually used (requested vs detected
+    # vs active) so renders are reproducible/auditable. Stored before
+    # build_metadata_json so it is included in metadata.json.
+    ctx.metadata["encoder_info"] = get_encoder_info(render_encoder_hint)
 
     metadata = build_metadata_json(ctx)
     with open(output_dir / "metadata.json", "w", encoding="utf-8") as f:

--- a/src/movie_narrator/pipeline/research.py
+++ b/src/movie_narrator/pipeline/research.py
@@ -69,6 +69,10 @@ def _research_via_llm(ctx: Context, settings) -> ResearchInfo:
                 temperature=settings.research_temperature,
                 max_tokens=settings.research_max_tokens,
             )
+        # v0.7.0: Record LLM cost for research
+        if ctx is not None and hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
+            if hasattr(response, 'usage') and response.usage:
+                ctx.cost_tracker.record_llm_call("research", llm.model, response.usage.model_dump())
         raw = response.choices[0].message.content or ""
         data = extract_json(raw)
 

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -217,6 +217,8 @@ def build_context(
         assets=Assets(bgm=bgm_path),
         services=services,
     )
+    from ..utils.cost_tracker import CostTracker
+    ctx.cost_tracker = CostTracker()
     ctx.metadata.update(
         {
             "voice": voice,

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -160,6 +160,9 @@ def _generate_plot_beats(
         temperature=settings.research_temperature,
         max_tokens=scaled_max_tokens,
     )
+    # v0.7.0: record LLM token usage for cost tracking
+    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None and hasattr(response, 'usage') and response.usage:
+        ctx.cost_tracker.record_llm_call("script", llm.model, response.usage.model_dump())
     raw = response.choices[0].message.content or ""
     data = extract_json(raw)
     beats = data.get("beats", [])
@@ -282,6 +285,9 @@ def _expand_beats_to_script(
         temperature=settings.script_expand_temperature,
         max_tokens=settings.script_max_tokens,
     )
+    # v0.7.0: record LLM token usage for cost tracking
+    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None and hasattr(response, 'usage') and response.usage:
+        ctx.cost_tracker.record_llm_call("script", llm.model, response.usage.model_dump())
     raw = response.choices[0].message.content or ""
     data = extract_json(raw)
     raw_segments = data.get("segments", [])
@@ -345,7 +351,7 @@ _DEFAULT_PASS_SCORE = {
 
 
 def judge_script(
-    segments: List[ScriptSegment], movie_name: str, llm
+    segments: List[ScriptSegment], movie_name: str, llm, ctx=None,
 ) -> dict:
     """Judge the expanded script on five quality dimensions.
 
@@ -362,6 +368,7 @@ def judge_script(
         segments: The expanded narration segments (pre-trim).
         movie_name: Movie title for context in the judge prompt.
         llm: An :class:`LLMClient` (has ``.client`` and ``.model``).
+        ctx: Optional :class:`Context` for v0.7.0 cost tracking.
 
     Returns:
         A dict with keys ``hook_strength``, ``spoiler_level``,
@@ -386,6 +393,9 @@ def judge_script(
         temperature=0.3,
         max_tokens=320,
     )
+    # v0.7.0: record LLM token usage for cost tracking
+    if ctx is not None and hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None and hasattr(response, 'usage') and response.usage:
+        ctx.cost_tracker.record_llm_call("script", llm.model, response.usage.model_dump())
     raw = response.choices[0].message.content or ""
     scores = extract_json(raw)
 
@@ -650,7 +660,7 @@ def generate_script(ctx: Context) -> Context:
                 # caught so it never breaks the pipeline (treat as pass).
                 try:
                     with step_timing(ctx.services.console, "llm_judge_script"):
-                        judge_scores = judge_script(segments, ctx.movie_name, llm)
+                        judge_scores = judge_script(segments, ctx.movie_name, llm, ctx=ctx)
                 except Exception as judge_err:
                     ctx.services.console.debug(
                         f"  generate_script: judge failed, treating as pass: {judge_err}"

--- a/src/movie_narrator/pipeline/translate.py
+++ b/src/movie_narrator/pipeline/translate.py
@@ -95,6 +95,7 @@ def _call_llm_chunk(
     target_lang: str,
     source_lang: str,
     llm_factory=None,
+    cost_tracker=None,
 ) -> List[str]:
     """Make a single LLM call for one chunk. Returns translations aligned 1:1.
 
@@ -122,6 +123,9 @@ def _call_llm_chunk(
             messages=[{"role": "user", "content": prompt}],
             max_tokens=get_settings().translate_max_tokens,
         )
+        # v0.7.0: Record LLM cost for translation
+        if cost_tracker is not None and hasattr(resp, 'usage') and resp.usage:
+            cost_tracker.record_llm_call("translate", llm.model, resp.usage.model_dump())
     raw = (resp.choices[0].message.content or "").strip()
     parsed = extract_json(raw)
     translations = parsed.get("translations")
@@ -150,6 +154,7 @@ def _translate_via_llm(
     max_chars: int = DEFAULT_CHUNK_CHARS,
     max_items: int = DEFAULT_CHUNK_SIZE,
     llm_factory=None,
+    cost_tracker=None,
 ) -> List[str]:
     """Translate via the LLM provider, chunked, with per-chunk retry.
 
@@ -172,6 +177,7 @@ def _translate_via_llm(
                     target_lang=target_lang,
                     source_lang=source_lang,
                     llm_factory=llm_factory,
+                    cost_tracker=cost_tracker,
                 )
                 for idx, tr in zip(chunk_indices, translations):
                     result[idx] = tr
@@ -279,6 +285,7 @@ def translate_subtitles(ctx: Context) -> Context:
             retries=retries,
             max_chars=max_chars,
             max_items=max_items,
+            cost_tracker=ctx.cost_tracker if hasattr(ctx, 'cost_tracker') else None,
         )
     except _ChunkFailure as cf:
         # At least one chunk failed after retries. Fill failed slots

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -155,6 +155,23 @@ def generate_voice(ctx: Context) -> Context:
     with step_timing(console, "tts_batch_synthesize"):
         results = run_async(_run_all())
 
+    # v0.7.0: Record TTS usage for cost tracking
+    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
+        provider_name = settings.tts_provider.value
+        tts_model = (
+            settings.openai_tts_model if settings.tts_provider is TTSProviderType.OPENAI
+            else settings.mimo_tts_model if settings.tts_provider is TTSProviderType.MIMO
+            else ""
+        )
+        for seg in ctx.segments:
+            ctx.cost_tracker.record_tts_call(
+                provider=provider_name,
+                model=tts_model,
+                characters=len(seg.text),
+                segments=1,
+                cached=False,
+            )
+
     # ── v0.5.9: Emotion-aware prosody ───────────────────────
     # Apply per-segment speed/pitch adjustment based on beat emotion labels.
     # Uses pydub's frame-rate trick: changes both speed and pitch, which is

--- a/src/movie_narrator/utils/cost_tracker.py
+++ b/src/movie_narrator/utils/cost_tracker.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Per-run cost tracking for LLM token usage and TTS calls.
+
+v0.7.0: Accumulates LLM and TTS call records throughout a single
+pipeline run, then exports a summary dict for ``metadata.json``.
+
+The tracker is thread-safe (guarded by an internal :class:`threading.Lock`)
+so concurrent TTS / LLM calls can safely record usage. Cost figures are
+coarse approximations (``estimated``), not precise billing values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, Dict, Optional
+
+# ── Estimated unit costs (coarse approximation) ───────────
+# These are simple heuristics for a GPT-4o-mini class model and the
+# built-in TTS providers. They are NOT precise billing values and are
+# always flagged as ``estimated`` in the summary so downstream readers
+# do not mistake them for authoritative numbers.
+_LLM_PROMPT_COST_PER_1K = 0.002   # USD per 1K prompt tokens
+_LLM_COMPLETION_COST_PER_1K = 0.006  # USD per 1K completion tokens
+
+# TTS cost per 1K characters. ``edge`` and ``mimo`` are free.
+_TTS_COST_PER_1K_CHARS: Dict[str, float] = {
+    "edge": 0.0,
+    "openai": 0.015,
+    "mimo": 0.0,
+}
+
+
+@dataclass
+class LLMCallRecord:
+    """Single LLM API call record."""
+
+    step: str          # "script" | "research" | "translate"
+    model: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass
+class TTSCallRecord:
+    """Single TTS call record."""
+
+    provider: str      # "edge" | "openai" | "mimo"
+    model: str = ""
+    characters: int = 0
+    segments: int = 1
+    cached: bool = False
+
+
+@dataclass
+class CostTracker:
+    """Thread-safe cost tracker for a single pipeline run.
+
+    Accumulates LLM token usage and TTS call counts throughout the
+    pipeline, then exports a summary for ``metadata.json``.
+    """
+
+    llm_calls: list[LLMCallRecord] = field(default_factory=list)
+    tts_calls: list[TTSCallRecord] = field(default_factory=list)
+    _lock: Lock = field(default_factory=Lock, repr=False)
+
+    def record_llm_call(self, step: str, model: str, usage: dict) -> None:
+        """Record an LLM API call from an OpenAI ``response.usage`` dict.
+
+        The *usage* dict typically has ``prompt_tokens``,
+        ``completion_tokens``, and ``total_tokens`` keys. Missing keys
+        default to 0. ``step`` should be one of ``"script"``,
+        ``"research"``, or ``"translate"``.
+
+        Non-dict *usage* values (e.g. mock objects without ``.get``) are
+        silently ignored so cost tracking never breaks the pipeline.
+        """
+        if not isinstance(usage, dict):
+            return
+        record = LLMCallRecord(
+            step=step,
+            model=model,
+            prompt_tokens=int(usage.get("prompt_tokens", 0) or 0),
+            completion_tokens=int(usage.get("completion_tokens", 0) or 0),
+            total_tokens=int(usage.get("total_tokens", 0) or 0),
+        )
+        with self._lock:
+            self.llm_calls.append(record)
+
+    def record_tts_call(
+        self,
+        provider: str,
+        model: str = "",
+        characters: int = 0,
+        segments: int = 1,
+        cached: bool = False,
+    ) -> None:
+        """Record a TTS call.
+
+        ``provider`` should be one of ``"edge"``, ``"openai"``, or
+        ``"mimo"``. ``cached=True`` marks the segment as served from
+        cache (no network/API cost incurred).
+        """
+        record = TTSCallRecord(
+            provider=provider,
+            model=model,
+            characters=int(characters),
+            segments=int(segments),
+            cached=bool(cached),
+        )
+        with self._lock:
+            self.tts_calls.append(record)
+
+    # ── Summary export ─────────────────────────────────────
+
+    def _llm_by_step(self) -> Dict[str, Dict[str, int]]:
+        """Aggregate LLM usage per step name."""
+        by_step: Dict[str, Dict[str, int]] = {}
+        with self._lock:
+            calls = list(self.llm_calls)
+        for rec in calls:
+            bucket = by_step.setdefault(
+                rec.step,
+                {"calls": 0, "prompt_tokens": 0,
+                 "completion_tokens": 0, "total_tokens": 0},
+            )
+            bucket["calls"] += 1
+            bucket["prompt_tokens"] += rec.prompt_tokens
+            bucket["completion_tokens"] += rec.completion_tokens
+            bucket["total_tokens"] += rec.total_tokens
+        return by_step
+
+    def _tts_by_provider(self) -> Dict[str, Dict[str, int]]:
+        """Aggregate TTS usage per provider name."""
+        by_provider: Dict[str, Dict[str, int]] = {}
+        with self._lock:
+            calls = list(self.tts_calls)
+        for rec in calls:
+            bucket = by_provider.setdefault(
+                rec.provider,
+                {"calls": 0, "segments": 0, "characters": 0,
+                 "cached_segments": 0},
+            )
+            bucket["calls"] += 1
+            bucket["segments"] += rec.segments
+            bucket["characters"] += rec.characters
+            if rec.cached:
+                bucket["cached_segments"] += rec.segments
+        return by_provider
+
+    def summary(self) -> Dict[str, Any]:
+        """Export cost summary for ``metadata.json``.
+
+        Returns a dict with ``llm`` and ``tts`` sub-dicts. All cost
+        figures are flagged ``estimated`` (coarse approximation, not
+        precise billing values).
+        """
+        by_step = self._llm_by_step()
+        by_provider = self._tts_by_provider()
+
+        # LLM totals
+        total_prompt = sum(b["prompt_tokens"] for b in by_step.values())
+        total_completion = sum(b["completion_tokens"] for b in by_step.values())
+        total_tokens = sum(b["total_tokens"] for b in by_step.values())
+        total_llm_calls = sum(b["calls"] for b in by_step.values())
+
+        # Estimated LLM cost (USD)
+        llm_cost = (
+            total_prompt / 1000.0 * _LLM_PROMPT_COST_PER_1K
+            + total_completion / 1000.0 * _LLM_COMPLETION_COST_PER_1K
+        )
+
+        # TTS totals
+        total_tts_calls = sum(b["calls"] for b in by_provider.values())
+        total_segments = sum(b["segments"] for b in by_provider.values())
+        total_characters = sum(b["characters"] for b in by_provider.values())
+        cached_segments = sum(b["cached_segments"] for b in by_provider.values())
+
+        # Estimated TTS cost (USD) — only non-cached characters are billed.
+        tts_cost = 0.0
+        for rec in self.tts_calls:
+            if rec.cached:
+                continue
+            rate = _TTS_COST_PER_1K_CHARS.get(rec.provider, 0.0)
+            tts_cost += rec.characters / 1000.0 * rate
+
+        return {
+            "llm": {
+                "total_calls": total_llm_calls,
+                "total_prompt_tokens": total_prompt,
+                "total_completion_tokens": total_completion,
+                "total_tokens": total_tokens,
+                "by_step": by_step,
+                "estimated_cost_usd": round(llm_cost, 6),
+            },
+            "tts": {
+                "total_calls": total_tts_calls,
+                "total_segments": total_segments,
+                "total_characters": total_characters,
+                "cached_segments": cached_segments,
+                "by_provider": by_provider,
+                "estimated_cost_usd": round(tts_cost, 6),
+            },
+        }

--- a/src/movie_narrator/utils/gpu_detect.py
+++ b/src/movie_narrator/utils/gpu_detect.py
@@ -13,6 +13,7 @@ during a single render are cheap and deterministic.
 
 from __future__ import annotations
 
+import os
 import platform
 import re
 import shutil
@@ -30,11 +31,17 @@ _BASE_ORDER: list[str] = [_NVENC, _VAAPI, _VIDEOTOOLBOX]
 
 # Recommended ffmpeg params per backend.  These are conservative quality
 # presets — NVENC ``p4`` + VBR/CQ 20 is the standard quality/speed
-# sweet spot, VAAPI ``fast`` targets the renderD128 node, and
-# VideoToolbox uses a single quality factor.
+# sweet spot, VAAPI uses a fast preset, and VideoToolbox uses a single
+# quality factor.
+#
+# NOTE: ``-vaapi_device`` is a *global* ffmpeg option that must appear
+# before ``-i`` — MoviePy's ``ffmpeg_params`` are output-side, so we
+# cannot pass it.  The VAAPI encoder will use the default device
+# (``/dev/dri/renderD128`` on most Linux systems) or fail gracefully
+# with a fallback to libx264 in the render pipeline.
 _GPU_PARAMS: dict[str, list[str]] = {
     _NVENC: ["-preset", "p4", "-rc", "vbr", "-cq", "20"],
-    _VAAPI: ["-preset", "fast", "-vaapi_device", "/dev/dri/renderD128"],
+    _VAAPI: ["-preset", "fast"],
     _VIDEOTOOLBOX: ["-q:v", "65"],
 }
 
@@ -92,6 +99,13 @@ def detect_gpu_encoder() -> Optional[str]:
     is registered.
     """
     if shutil.which("ffmpeg") is None:
+        return None
+
+    # CI environments (GitHub Actions, etc.) list GPU encoders in
+    # ``ffmpeg -encoders`` but have no actual GPU hardware.  Using them
+    # produces ``Unrecognized option`` or ``Broken pipe`` errors.  Skip
+    # detection entirely so CI always uses libx264.
+    if os.getenv("CI"):
         return None
 
     try:

--- a/src/movie_narrator/utils/gpu_detect.py
+++ b/src/movie_narrator/utils/gpu_detect.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""GPU encoder auto-detection for v0.7.0 render acceleration.
+
+Probes the local ffmpeg build for hardware-accelerated H.264 encoders
+(NVENC / VAAPI / VideoToolbox) and resolves a ``(codec, ffmpeg_params)``
+tuple the render pipeline can pass straight to MoviePy / ffmpeg.
+
+All probes are cached via :func:`functools.lru_cache` so repeated calls
+during a single render are cheap and deterministic.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import shutil
+import subprocess
+from functools import lru_cache
+from typing import Optional
+
+# Canonical ffmpeg encoder names for each GPU backend.
+_NVENC = "h264_nvenc"
+_VAAPI = "h264_vaapi"
+_VIDEOTOOLBOX = "h264_videotoolbox"
+
+# Base detection order (applies when the platform has no preference).
+_BASE_ORDER: list[str] = [_NVENC, _VAAPI, _VIDEOTOOLBOX]
+
+# Recommended ffmpeg params per backend.  These are conservative quality
+# presets — NVENC ``p4`` + VBR/CQ 20 is the standard quality/speed
+# sweet spot, VAAPI ``fast`` targets the renderD128 node, and
+# VideoToolbox uses a single quality factor.
+_GPU_PARAMS: dict[str, list[str]] = {
+    _NVENC: ["-preset", "p4", "-rc", "vbr", "-cq", "20"],
+    _VAAPI: ["-preset", "fast", "-vaapi_device", "/dev/dri/renderD128"],
+    _VIDEOTOOLBOX: ["-q:v", "65"],
+}
+
+# User-facing hint -> canonical codec name.
+_HINT_TO_CODEC: dict[str, str] = {
+    "nvenc": _NVENC,
+    "vaapi": _VAAPI,
+    "videotoolbox": _VIDEOTOOLBOX,
+}
+
+
+def _candidate_order() -> list[str]:
+    """Return the platform-aware candidate detection order.
+
+    Windows prefers NVENC, macOS prefers VideoToolbox, Linux prefers
+    VAAPI.  The remaining encoders keep their base relative order so a
+    secondary GPU is still picked up when the preferred one is absent.
+    """
+    system = platform.system()
+    preferred = {
+        "Windows": _NVENC,
+        "Darwin": _VIDEOTOOLBOX,
+        "Linux": _VAAPI,
+    }.get(system)
+    order = list(_BASE_ORDER)
+    if preferred and order and order[0] != preferred:
+        order.remove(preferred)
+        order.insert(0, preferred)
+    return order
+
+
+# Matches an ffmpeg ``-encoders`` line, e.g.:
+#   " V..... h264_nvenc            NVIDIA NVENC H.264 encoder (codec h264)"
+# Group 1 captures the encoder name token (alphanumeric + underscore).
+_ENCODER_LINE_RE = re.compile(r"^\s*[VAS]\S*\s+(\w+)")
+
+
+def _parse_encoder_names(stdout: str) -> set[str]:
+    """Extract the set of encoder names from ``ffmpeg -encoders`` stdout."""
+    names: set[str] = set()
+    for line in stdout.splitlines():
+        match = _ENCODER_LINE_RE.match(line)
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+@lru_cache(maxsize=1)
+def detect_gpu_encoder() -> Optional[str]:
+    """Detect the best available GPU H.264 encoder.
+
+    Runs ``ffmpeg -hide_banner -encoders`` once and returns the first
+    available encoder in platform-aware priority order.  Returns
+    ``None`` when ffmpeg is missing, the probe fails, or no GPU encoder
+    is registered.
+    """
+    if shutil.which("ffmpeg") is None:
+        return None
+
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-encoders"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if proc.returncode != 0:
+        return None
+
+    available = _parse_encoder_names(proc.stdout)
+    for candidate in _candidate_order():
+        if candidate in available:
+            return candidate
+    return None
+
+
+def resolve_encoder(requested: Optional[str]) -> tuple[str, list[str]]:
+    """Resolve a requested encoder hint to ``(codec, ffmpeg_params_extra)``.
+
+    ``requested`` accepts:
+
+    * ``None`` / ``"auto"`` — auto-detect, fall back to ``libx264``.
+    * ``"cpu"`` — force software ``libx264`` (no extra params).
+    * ``"nvenc"`` / ``"vaapi"`` / ``"videotoolbox"`` — explicit backend
+      with its recommended ffmpeg params.
+
+    Unknown values fall back to ``libx264`` so a typo never aborts a
+    render.
+    """
+    if requested in (None, "auto"):
+        gpu = detect_gpu_encoder()
+        if gpu is not None:
+            return (gpu, list(_GPU_PARAMS[gpu]))
+        return ("libx264", [])
+
+    if requested == "cpu":
+        return ("libx264", [])
+
+    codec = _HINT_TO_CODEC.get(requested)
+    if codec is not None:
+        return (codec, list(_GPU_PARAMS[codec]))
+
+    return ("libx264", [])
+
+
+def get_encoder_info(requested: Optional[str] = None) -> dict:
+    """Build an encoder info dict for ``metadata.json``.
+
+    The ``detected`` field reports what the GPU probe found (independent
+    of ``requested``), while ``active`` reflects the codec that
+    :func:`resolve_encoder` would actually select.  ``requested`` is
+    normalised to ``"auto"`` when ``None`` for readable output.
+    """
+    detected = detect_gpu_encoder()
+    active, _ = resolve_encoder(requested)
+    return {
+        "requested": requested if requested is not None else "auto",
+        "detected": detected,
+        "active": active,
+        "gpu_available": detected is not None,
+    }

--- a/src/movie_narrator/utils/metadata_export.py
+++ b/src/movie_narrator/utils/metadata_export.py
@@ -76,4 +76,9 @@ def build_metadata_json(ctx: Context) -> Dict[str, Any]:
         # ── WP5: script truncation audit ──
         "script_truncated": ctx.metadata.get("script_truncated"),
     }
+
+    # v0.7.0: cost tracking summary
+    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
+        meta["cost"] = ctx.cost_tracker.summary()
+
     return meta

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -102,6 +102,8 @@ class JobParams(BaseModel):
     render_cover_export: Optional[bool] = None
     # EP5: auto-adjust subtitle margins for 9:16 vertical safe area (bool, default True)
     render_vertical_safe_area: Optional[bool] = None
+    # v0.7.0: GPU encoding — "auto" (default) | "cpu" | "nvenc" | "vaapi" | "videotoolbox"
+    render_encoder: Optional[str] = None
     # ── QA ──
     qa_enabled: Optional[bool] = None
     qa_max_silence_db: Optional[float] = None

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 6, 1) — bumped for v0.6.1 remote inference exports."""
-        assert CONTRACT_VERSION == (0, 6, 1)
+        """CONTRACT_VERSION is (0, 7, 0) — bumped for v0.7.0 cost tracking and GPU encoder."""
+        assert CONTRACT_VERSION == (0, 7, 0)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -1,0 +1,458 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the v0.7.0 per-run cost tracker.
+
+Covers: initial state, LLM/TTS call recording, summary structure
+(by_step / by_provider grouping), estimated cost calculation,
+thread safety under concurrent writes, and the empty-tracker edge case.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from movie_narrator.utils.cost_tracker import (
+    CostTracker,
+    LLMCallRecord,
+    TTSCallRecord,
+)
+
+
+# ── 1. Initial state ────────────────────────────────────────
+
+
+def test_cost_tracker_initial_state():
+    """A fresh CostTracker has empty call lists."""
+    tracker = CostTracker()
+    assert tracker.llm_calls == []
+    assert tracker.tts_calls == []
+
+
+def test_cost_tracker_has_lock():
+    """The tracker carries an internal Lock (not repr'd)."""
+    tracker = CostTracker()
+    assert tracker._lock is not None
+    # repr=False means the lock does not appear in repr()
+    assert "_lock" not in repr(tracker)
+
+
+# ── 2. record_llm_call ─────────────────────────────────────
+
+
+def test_record_llm_call_basic():
+    """A single LLM call is appended to llm_calls."""
+    tracker = CostTracker()
+    tracker.record_llm_call("script", "gpt-4o-mini", {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+    })
+    assert len(tracker.llm_calls) == 1
+    rec = tracker.llm_calls[0]
+    assert rec.step == "script"
+    assert rec.model == "gpt-4o-mini"
+    assert rec.prompt_tokens == 100
+    assert rec.completion_tokens == 50
+    assert rec.total_tokens == 150
+
+
+def test_record_llm_call_missing_keys_default_zero():
+    """Missing usage keys default to 0, not KeyError."""
+    tracker = CostTracker()
+    tracker.record_llm_call("research", "test-model", {})
+    rec = tracker.llm_calls[0]
+    assert rec.prompt_tokens == 0
+    assert rec.completion_tokens == 0
+    assert rec.total_tokens == 0
+
+
+def test_record_llm_call_none_values_default_zero():
+    """None values in the usage dict are coerced to 0."""
+    tracker = CostTracker()
+    tracker.record_llm_call("translate", "m", {
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+    })
+    rec = tracker.llm_calls[0]
+    assert rec.prompt_tokens == 0
+    assert rec.completion_tokens == 0
+    assert rec.total_tokens == 0
+
+
+def test_record_llm_call_non_dict_ignored():
+    """Non-dict usage (e.g. a MagicMock) is silently ignored."""
+    tracker = CostTracker()
+    tracker.record_llm_call("script", "m", "not-a-dict")
+    tracker.record_llm_call("script", "m", None)
+    assert len(tracker.llm_calls) == 0
+
+
+def test_record_llm_call_multiple_accumulate():
+    """Multiple calls all accumulate in the list."""
+    tracker = CostTracker()
+    for i in range(5):
+        tracker.record_llm_call("script", "m", {
+            "prompt_tokens": i, "completion_tokens": i, "total_tokens": 2 * i,
+        })
+    assert len(tracker.llm_calls) == 5
+
+
+# ── 3. record_tts_call ─────────────────────────────────────
+
+
+def test_record_tts_call_basic():
+    """A single TTS call is appended to tts_calls."""
+    tracker = CostTracker()
+    tracker.record_tts_call("edge", characters=120)
+    assert len(tracker.tts_calls) == 1
+    rec = tracker.tts_calls[0]
+    assert rec.provider == "edge"
+    assert rec.model == ""
+    assert rec.characters == 120
+    assert rec.segments == 1
+    assert rec.cached is False
+
+
+def test_record_tts_call_cached():
+    """cached=True is recorded correctly."""
+    tracker = CostTracker()
+    tracker.record_tts_call("openai", model="tts-1",
+                            characters=500, segments=3, cached=True)
+    rec = tracker.tts_calls[0]
+    assert rec.cached is True
+    assert rec.segments == 3
+    assert rec.provider == "openai"
+    assert rec.model == "tts-1"
+
+
+def test_record_tts_call_multiple_providers():
+    """Calls to different providers are all recorded."""
+    tracker = CostTracker()
+    tracker.record_tts_call("edge", characters=10)
+    tracker.record_tts_call("openai", characters=20)
+    tracker.record_tts_call("mimo", characters=30)
+    assert len(tracker.tts_calls) == 3
+    providers = [r.provider for r in tracker.tts_calls]
+    assert providers == ["edge", "openai", "mimo"]
+
+
+# ── 4. summary() structure ─────────────────────────────────
+
+
+def test_summary_returns_correct_top_level_keys():
+    """summary() returns dict with 'llm' and 'tts' keys."""
+    tracker = CostTracker()
+    s = tracker.summary()
+    assert set(s.keys()) == {"llm", "tts"}
+
+
+def test_summary_llm_structure():
+    """The 'llm' sub-dict has all required fields."""
+    tracker = CostTracker()
+    tracker.record_llm_call("script", "m", {
+        "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150,
+    })
+    llm = tracker.summary()["llm"]
+    assert llm["total_calls"] == 1
+    assert llm["total_prompt_tokens"] == 100
+    assert llm["total_completion_tokens"] == 50
+    assert llm["total_tokens"] == 150
+    assert "by_step" in llm
+    assert "estimated_cost_usd" in llm
+
+
+def test_summary_tts_structure():
+    """The 'tts' sub-dict has all required fields."""
+    tracker = CostTracker()
+    tracker.record_tts_call("edge", characters=100, segments=2)
+    tts = tracker.summary()["tts"]
+    assert tts["total_calls"] == 1
+    assert tts["total_segments"] == 2
+    assert tts["total_characters"] == 100
+    assert tts["cached_segments"] == 0
+    assert "by_provider" in tts
+    assert "estimated_cost_usd" in tts
+
+
+def test_summary_by_step_grouping():
+    """LLM calls are grouped by step name."""
+    tracker = CostTracker()
+    tracker.record_llm_call("script", "m", {
+        "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150,
+    })
+    tracker.record_llm_call("script", "m", {
+        "prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300,
+    })
+    tracker.record_llm_call("research", "m", {
+        "prompt_tokens": 50, "completion_tokens": 25, "total_tokens": 75,
+    })
+
+    by_step = tracker.summary()["llm"]["by_step"]
+    assert "script" in by_step
+    assert "research" in by_step
+    # script: 2 calls, 300 prompt, 150 completion, 450 total
+    assert by_step["script"]["calls"] == 2
+    assert by_step["script"]["prompt_tokens"] == 300
+    assert by_step["script"]["completion_tokens"] == 150
+    assert by_step["script"]["total_tokens"] == 450
+    # research: 1 call
+    assert by_step["research"]["calls"] == 1
+    assert by_step["research"]["prompt_tokens"] == 50
+
+
+def test_summary_by_provider_grouping():
+    """TTS calls are grouped by provider name."""
+    tracker = CostTracker()
+    tracker.record_tts_call("edge", characters=100, segments=2)
+    tracker.record_tts_call("edge", characters=50, segments=1, cached=True)
+    tracker.record_tts_call("openai", characters=2000, segments=5)
+
+    by_provider = tracker.summary()["tts"]["by_provider"]
+    assert "edge" in by_provider
+    assert "openai" in by_provider
+    # edge: 2 calls, 3 segments, 150 chars, 1 cached
+    assert by_provider["edge"]["calls"] == 2
+    assert by_provider["edge"]["segments"] == 3
+    assert by_provider["edge"]["characters"] == 150
+    assert by_provider["edge"]["cached_segments"] == 1
+    # openai: 1 call, 5 segments, 2000 chars, 0 cached
+    assert by_provider["openai"]["calls"] == 1
+    assert by_provider["openai"]["segments"] == 5
+    assert by_provider["openai"]["characters"] == 2000
+    assert by_provider["openai"]["cached_segments"] == 0
+
+
+# ── 5. Estimated cost calculation ──────────────────────────
+
+
+def test_summary_llm_estimated_cost():
+    """LLM estimated cost = prompt*0.002/1K + completion*0.006/1K."""
+    tracker = CostTracker()
+    tracker.record_llm_call("script", "m", {
+        "prompt_tokens": 1000, "completion_tokens": 500, "total_tokens": 1500,
+    })
+    cost = tracker.summary()["llm"]["estimated_cost_usd"]
+    # 1000/1000 * 0.002 + 500/1000 * 0.006 = 0.002 + 0.003 = 0.005
+    assert abs(cost - 0.005) < 1e-9
+
+
+def test_summary_tts_estimated_cost_openai():
+    """OpenAI TTS cost = chars * 0.015 / 1K (non-cached only)."""
+    tracker = CostTracker()
+    tracker.record_tts_call("openai", characters=2000, segments=1)
+    cost = tracker.summary()["tts"]["estimated_cost_usd"]
+    # 2000/1000 * 0.015 = 0.03
+    assert abs(cost - 0.03) < 1e-9
+
+
+def test_summary_tts_cached_excluded_from_cost():
+    """Cached TTS segments incur no cost."""
+    tracker = CostTracker()
+    tracker.record_tts_call("openai", characters=2000, segments=1, cached=True)
+    cost = tracker.summary()["tts"]["estimated_cost_usd"]
+    assert cost == 0.0
+
+
+def test_summary_tts_edge_and_mimo_free():
+    """Edge and Mimo TTS providers are free."""
+    tracker = CostTracker()
+    tracker.record_tts_call("edge", characters=10000, segments=5)
+    tracker.record_tts_call("mimo", characters=5000, segments=3)
+    cost = tracker.summary()["tts"]["estimated_cost_usd"]
+    assert cost == 0.0
+
+
+def test_summary_tts_mixed_cached_and_fresh():
+    """Mixed cached/fresh OpenAI calls: only fresh chars are billed."""
+    tracker = CostTracker()
+    tracker.record_tts_call("openai", characters=1000, cached=True)
+    tracker.record_tts_call("openai", characters=2000, cached=False)
+    cost = tracker.summary()["tts"]["estimated_cost_usd"]
+    # Only 2000 non-cached chars: 2000/1000 * 0.015 = 0.03
+    assert abs(cost - 0.03) < 1e-9
+
+
+def test_summary_cached_segments_counted():
+    """Cached segments are counted in totals even though free."""
+    tracker = CostTracker()
+    tracker.record_tts_call("edge", characters=100, segments=2, cached=True)
+    tracker.record_tts_call("edge", characters=50, segments=1, cached=False)
+    tts = tracker.summary()["tts"]
+    assert tts["total_segments"] == 3
+    assert tts["cached_segments"] == 2
+    assert tts["total_characters"] == 150
+
+
+# ── 6. Thread safety ───────────────────────────────────────
+
+
+def test_thread_safe_concurrent_llm_calls():
+    """Concurrent record_llm_call from many threads must not lose records."""
+    tracker = CostTracker()
+    n_threads = 20
+    calls_per_thread = 50
+
+    def worker():
+        for _ in range(calls_per_thread):
+            tracker.record_llm_call("script", "m", {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            })
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = n_threads * calls_per_thread
+    assert len(tracker.llm_calls) == expected
+
+
+def test_thread_safe_concurrent_tts_calls():
+    """Concurrent record_tts_call from many threads must not lose records."""
+    tracker = CostTracker()
+    n_threads = 20
+    calls_per_thread = 50
+
+    def worker():
+        for _ in range(calls_per_thread):
+            tracker.record_tts_call("edge", characters=10, segments=1)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = n_threads * calls_per_thread
+    assert len(tracker.tts_calls) == expected
+
+
+def test_thread_safe_mixed_calls():
+    """Concurrent LLM + TTS calls do not corrupt each other."""
+    tracker = CostTracker()
+    n_threads = 10
+    calls_per_thread = 100
+
+    def llm_worker():
+        for _ in range(calls_per_thread):
+            tracker.record_llm_call("script", "m", {
+                "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2,
+            })
+
+    def tts_worker():
+        for _ in range(calls_per_thread):
+            tracker.record_tts_call("edge", characters=5, segments=1)
+
+    threads = []
+    for _ in range(n_threads):
+        threads.append(threading.Thread(target=llm_worker))
+        threads.append(threading.Thread(target=tts_worker))
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(tracker.llm_calls) == n_threads * calls_per_thread
+    assert len(tracker.tts_calls) == n_threads * calls_per_thread
+
+    # Summary must be consistent
+    s = tracker.summary()
+    assert s["llm"]["total_calls"] == n_threads * calls_per_thread
+    assert s["tts"]["total_calls"] == n_threads * calls_per_thread
+
+
+def test_thread_safe_summary_during_writes():
+    """summary() called while writes are in progress must not crash."""
+    tracker = CostTracker()
+    n_threads = 10
+    errors = []
+
+    def writer():
+        try:
+            for i in range(100):
+                tracker.record_llm_call("script", "m", {
+                    "prompt_tokens": i, "completion_tokens": i, "total_tokens": 2 * i,
+                })
+                tracker.record_tts_call("edge", characters=i, segments=1)
+        except Exception as e:
+            errors.append(e)
+
+    def reader():
+        try:
+            for _ in range(50):
+                tracker.summary()
+        except Exception as e:
+            errors.append(e)
+
+    threads = []
+    for _ in range(n_threads):
+        threads.append(threading.Thread(target=writer))
+        threads.append(threading.Thread(target=reader))
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"Concurrent errors: {errors}"
+
+
+# ── 7. Empty tracker summary ───────────────────────────────
+
+
+def test_summary_empty_tracker_llm():
+    """An empty tracker's LLM summary is all zeros."""
+    tracker = CostTracker()
+    llm = tracker.summary()["llm"]
+    assert llm["total_calls"] == 0
+    assert llm["total_prompt_tokens"] == 0
+    assert llm["total_completion_tokens"] == 0
+    assert llm["total_tokens"] == 0
+    assert llm["by_step"] == {}
+    assert llm["estimated_cost_usd"] == 0.0
+
+
+def test_summary_empty_tracker_tts():
+    """An empty tracker's TTS summary is all zeros."""
+    tracker = CostTracker()
+    tts = tracker.summary()["tts"]
+    assert tts["total_calls"] == 0
+    assert tts["total_segments"] == 0
+    assert tts["total_characters"] == 0
+    assert tts["cached_segments"] == 0
+    assert tts["by_provider"] == {}
+    assert tts["estimated_cost_usd"] == 0.0
+
+
+def test_summary_empty_tracker_both():
+    """An empty tracker returns a valid summary with zero values."""
+    tracker = CostTracker()
+    s = tracker.summary()
+    assert s["llm"]["total_calls"] == 0
+    assert s["tts"]["total_calls"] == 0
+    assert s["llm"]["estimated_cost_usd"] == 0.0
+    assert s["tts"]["estimated_cost_usd"] == 0.0
+
+
+# ── 8. Dataclass shape ─────────────────────────────────────
+
+
+def test_llm_call_record_defaults():
+    """LLMCallRecord has correct default values for token fields."""
+    rec = LLMCallRecord(step="script", model="m")
+    assert rec.prompt_tokens == 0
+    assert rec.completion_tokens == 0
+    assert rec.total_tokens == 0
+
+
+def test_tts_call_record_defaults():
+    """TTSCallRecord has correct default values."""
+    rec = TTSCallRecord(provider="edge")
+    assert rec.model == ""
+    assert rec.characters == 0
+    assert rec.segments == 1
+    assert rec.cached is False

--- a/tests/test_gpu_detect.py
+++ b/tests/test_gpu_detect.py
@@ -21,8 +21,9 @@ _GPU_DETECT_MOD = "movie_narrator.utils.gpu_detect"
 
 
 @pytest.fixture(autouse=True)
-def _clear_lru_cache():
-    """Reset the ``detect_gpu_encoder`` cache between tests."""
+def _clear_lru_cache(monkeypatch):
+    """Reset the ``detect_gpu_encoder`` cache and clear CI env between tests."""
+    monkeypatch.delenv("CI", raising=False)
     detect_gpu_encoder.cache_clear()
     yield
     detect_gpu_encoder.cache_clear()
@@ -35,6 +36,20 @@ def _fake_proc(stdout: str = "", returncode: int = 0, stderr: str = "") -> Magic
 def test_detect_returns_none_when_ffmpeg_missing():
     """No ffmpeg on PATH -> detection short-circuits to None."""
     with patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value=None):
+        assert detect_gpu_encoder() is None
+
+
+def test_detect_returns_none_in_ci_environment(monkeypatch):
+    """CI env var set -> detection skips even when ffmpeg has GPU encoders."""
+    monkeypatch.setenv("CI", "1")
+    fake_stdout = (
+        " V..... h264_nvenc            NVIDIA NVENC H.264 encoder (codec h264)\n"
+    )
+    with patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value="/usr/bin/ffmpeg"), \
+         patch(
+             f"{_GPU_DETECT_MOD}.subprocess.run",
+             return_value=_fake_proc(stdout=fake_stdout),
+         ):
         assert detect_gpu_encoder() is None
 
 

--- a/tests/test_gpu_detect.py
+++ b/tests/test_gpu_detect.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the v0.7.0 GPU encoder auto-detection utility.
+
+All external calls (``shutil.which``, ``subprocess.run``) are mocked so
+the suite passes in a ffmpeg-less CI environment.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from movie_narrator.utils.gpu_detect import (
+    detect_gpu_encoder,
+    get_encoder_info,
+    resolve_encoder,
+)
+
+_GPU_DETECT_MOD = "movie_narrator.utils.gpu_detect"
+
+
+@pytest.fixture(autouse=True)
+def _clear_lru_cache():
+    """Reset the ``detect_gpu_encoder`` cache between tests."""
+    detect_gpu_encoder.cache_clear()
+    yield
+    detect_gpu_encoder.cache_clear()
+
+
+def _fake_proc(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
+    return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_detect_returns_none_when_ffmpeg_missing():
+    """No ffmpeg on PATH -> detection short-circuits to None."""
+    with patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value=None):
+        assert detect_gpu_encoder() is None
+
+
+def test_detect_returns_nvenc_when_available():
+    """ffmpeg -encoders listing h264_nvenc -> returns h264_nvenc."""
+    fake_stdout = (
+        " Encoders:\n"
+        " ------\n"
+        " V..... h264_nvenc            NVIDIA NVENC H.264 encoder (codec h264)\n"
+        " V....D libx264               libx264 H.264 / AVC (codec h264)\n"
+    )
+    with patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value="/usr/bin/ffmpeg"), \
+         patch(
+             f"{_GPU_DETECT_MOD}.subprocess.run",
+             return_value=_fake_proc(stdout=fake_stdout),
+         ):
+        assert detect_gpu_encoder() == "h264_nvenc"
+
+
+def test_resolve_cpu_returns_libx264():
+    """Explicit 'cpu' hint forces software libx264 with no extra params."""
+    assert resolve_encoder("cpu") == ("libx264", [])
+
+
+def test_resolve_nvenc_returns_recommended_params():
+    """'nvenc' hint maps to h264_nvenc with the NVENC quality preset."""
+    codec, params = resolve_encoder("nvenc")
+    assert codec == "h264_nvenc"
+    assert params == ["-preset", "p4", "-rc", "vbr", "-cq", "20"]
+
+
+def test_resolve_auto_falls_back_to_libx264_when_no_gpu():
+    """'auto' with no detectable GPU falls back to libx264."""
+    with patch(f"{_GPU_DETECT_MOD}.detect_gpu_encoder", return_value=None):
+        assert resolve_encoder("auto") == ("libx264", [])
+
+
+def test_resolve_unknown_falls_back_to_libx264():
+    """Unknown hint values degrade gracefully to libx264."""
+    assert resolve_encoder("unknown") == ("libx264", [])
+
+
+def test_get_encoder_info_structure():
+    """get_encoder_info() returns the documented metadata dict shape."""
+    with patch(f"{_GPU_DETECT_MOD}.detect_gpu_encoder", return_value="h264_nvenc"):
+        info = get_encoder_info()
+    assert info == {
+        "requested": "auto",
+        "detected": "h264_nvenc",
+        "active": "h264_nvenc",
+        "gpu_available": True,
+    }

--- a/tests/test_m5_community.py
+++ b/tests/test_m5_community.py
@@ -28,7 +28,7 @@ class TestCheckVersion:
     def test_check_version_raises_when_below(self):
         """check_version raises ImportError when CONTRACT_VERSION < required."""
         with pytest.raises(ImportError, match="below the required"):
-            check_version((0, 7, 0))
+            check_version((0, 7, 1))
 
     def test_check_version_raises_with_future_major(self):
         with pytest.raises(ImportError, match="below the required"):

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 6, 1)
+        assert CONTRACT_VERSION == (0, 7, 0)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 6, 1)."""
+        """CONTRACT_VERSION is (0, 7, 0)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 6, 1)
+        assert CONTRACT_VERSION == (0, 7, 0)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""


### PR DESCRIPTION
## v0.7.0 — Output Experience

### Added
- GPU encoder auto-detection (NVENC/VAAPI/VideoToolbox) with fallback to libx264
- Per-run cost tracking for LLM token usage and TTS calls in metadata.json
- Parallel subtitle image generation using ThreadPoolExecutor
- `render_encoder` job parameter (auto/cpu/nvenc/vaapi/videotoolbox)
- Encoder info recorded in render metadata
- TTS/research/translate cost tracking integration

### Changed
- Render pipeline uses GPU-accelerated encoding when available
- Memory optimization: early clip release before encoding
- Version bumped to 0.7.0, CONTRACT_VERSION to (0, 7, 0)