### PR TITLE
feat(v0.7.1): scene transitions, text animation, multi-track audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `mkdocs.yml`: added "Best Practices" navigation entry.
 - **Internal terminology cleanup**: replaced all "L2 hand-test" / "L2+" / "Q-X" internal QA references with community-friendly terms ("manual QA verification") across documentation (`ROADMAP`, `ARCHITECTURE`, `METADATA_SCHEMA` — EN/ZH), source code comments (`align.py`, `match.py`, `scene_filter.py`, `_align_backend.py`, `metadata_export.py`, `scenes.py`, `deliverable_qa.py`), test files (`test_audit_integration.py`, `test_e2e_smoke.py`, `test_match.py`), and scripts (`compare_runs.py`). CHANGELOG historical entries preserved as immutable records.
 
+## [0.7.1] - 2026-07-30
+
+### Added
+
+- Scene transition effects (fade, dissolve, slide) between video clips
+- Text animation effects (fade, slide_up, slide_left) for subtitle overlays
+- `render_transition` and `render_text_animation` job parameters
+- Transition and animation duration configurable via job params
+- Multi-track audio mixing with optional ambient/SFX track
+- `bgm_ambient_path` and `bgm_ambient_gain_db` job parameters
+
+### Changed
+
+- Version bumped to 0.7.1, CONTRACT_VERSION to (0, 7, 1)
+
 ## [0.7.0] - 2026-07-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.7.0"
+version = "0.7.1"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -49,7 +49,7 @@ from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 7, 0)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 7, 1)
 
 
 def check_version(required: tuple[int, int, int]) -> None:

--- a/src/movie_narrator/pipeline/bgm.py
+++ b/src/movie_narrator/pipeline/bgm.py
@@ -382,6 +382,57 @@ def _apply_emotion_transitions(
     return adjusted, transitions
 
 
+def _mix_ambient_track(
+    narration_or_mixed: AudioSegment,
+    ambient_path: str,
+    ambient_gain_db: float = -12.0,
+    duck_db: float = -10.0,
+    timed_segments: list = None,
+) -> tuple[AudioSegment, dict]:
+    """Mix an ambient/SFX track beneath the narration+BGM audio.
+
+    v0.7.1: Loads the ambient track, loops/trims it to match the
+    narration duration, applies gain reduction, and overlays it
+    with ducking during active narration segments.
+
+    Returns ``(mixed_audio, ambient_info_dict)``. On any error,
+    returns the original audio unchanged with an empty info dict.
+    """
+    info: dict = {}
+    try:
+        ambient = AudioSegment.from_file(ambient_path)
+    except Exception as e:
+        return narration_or_mixed, {"error": f"ambient load failed: {e}"}
+
+    target_ms = len(narration_or_mixed)
+    ambient_ms = len(ambient)
+
+    # Loop ambient track to match target duration
+    if ambient_ms < target_ms:
+        loops = int(target_ms / ambient_ms) + 1
+        ambient = ambient * loops
+    ambient = ambient[:target_ms]
+
+    # Apply gain reduction
+    ambient = ambient.apply_gain(ambient_gain_db)
+
+    # Simple ducking: reduce ambient volume further during narration
+    # We use a moderate fixed duck since per-segment ducking is already
+    # applied to BGM — the ambient sits even lower in the mix.
+    duck_factor = float(db_to_float(duck_db))
+    ambient = ambient.apply_gain(duck_db)
+
+    mixed = narration_or_mixed.overlay(ambient)
+
+    info = {
+        "path": str(ambient_path),
+        "gain_db": ambient_gain_db,
+        "duck_db": duck_db,
+        "duration_sec": round(target_ms / 1000.0, 2),
+    }
+    return mixed, info
+
+
 def mix_bgm(ctx: Context) -> Context:
     if not ctx.audio_path:
         ctx.status.bgm = "skipped"
@@ -443,6 +494,31 @@ def mix_bgm(ctx: Context) -> Context:
                 mixed = normalize_loudnorm(mixed, target_dbfs=target)
             else:
                 mixed = normalize_peak(mixed, target_dbfs=target)
+
+        # v0.7.1: Multi-track mixing — overlay ambient/SFX track if provided.
+        # This sits beneath both narration and BGM for a richer soundscape.
+        # Soft failure: if the ambient file is missing/corrupt, warn and continue.
+        ambient_path = ctx.metadata.get("bgm_ambient_path")
+        if ambient_path:
+            ambient_gain = ctx.metadata.get("bgm_ambient_gain_db", -12.0)
+            ambient_duck = ctx.metadata.get("bgm_duck_db", -10.0)
+            mixed, ambient_info = _mix_ambient_track(
+                mixed, ambient_path,
+                ambient_gain_db=ambient_gain,
+                duck_db=ambient_duck,
+                timed_segments=ctx.timed_segments,
+            )
+            if "error" in ambient_info:
+                ctx.services.console.inline_warn(
+                    f"Ambient track skipped: {ambient_info['error']}"
+                )
+            else:
+                ctx.metadata["ambient_track"] = ambient_info
+                ctx.services.console.debug(
+                    f"  v0.7.1 ambient: {ambient_path} "
+                    f"(gain={ambient_gain}dB, duck={ambient_duck}dB)"
+                )
+
         out = Path(ctx.output_dir) / "mixed.mp3"
         ctx.final_audio_path = _export_robust(mixed, out)
         ctx.status.bgm = "success"

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -17,6 +17,8 @@ from ..utils.gpu_detect import get_encoder_info, resolve_encoder
 from ..utils.metadata_export import build_metadata_json
 from ..utils.text_image import create_text_image as _create_text_image
 from ..utils.video_layout import compute_fit_box
+from ..utils.transitions import apply_transition, get_transition_duration
+from ..utils.text_anim import apply_text_animation, get_animation_duration
 from .bgm import ensure_final_audio
 
 # RS-07: Minimum segment duration floor for speed scaling.
@@ -321,6 +323,15 @@ def render_video(ctx: Context) -> Context:
                         pos_y = (size[1] - box.out_h) // 2
                         fitted = fitted.with_position((pos_x, pos_y))
 
+                    # v0.7.1: apply scene transition to video clips
+                    transition_type = ctx.metadata.get("render_transition", "none")
+                    if transition_type != "none":
+                        trans_dur = get_transition_duration(
+                            mc.narr_end - mc.narr_start,
+                            ctx.metadata.get("render_transition_duration", 0.5)
+                        )
+                        fitted = apply_transition(fitted, transition_type, trans_dur)
+
                     clips.append(fitted.with_start(mc.narr_start))
                 except Exception as ie:
                     ctx.services.console.debug(f"  fallback for segment {mc.segment_index}: {ie}")
@@ -357,7 +368,18 @@ def render_video(ctx: Context) -> Context:
             bottom_margin_ratio=bottom_margin_ratio,
         )
         img_clip = ImageClip(img_array, is_mask=False)
-        return img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
+        img_clip = img_clip.with_duration(seg.end - seg.start).with_start(seg.start)
+
+        # v0.7.1: apply text animation to subtitle overlays
+        text_anim_type = ctx.metadata.get("render_text_animation", "none")
+        if text_anim_type != "none":
+            anim_dur = get_animation_duration(
+                seg.end - seg.start,
+                ctx.metadata.get("render_text_animation_duration", 0.3)
+            )
+            img_clip = apply_text_animation(img_clip, text_anim_type, anim_dur)
+
+        return img_clip
 
     with ThreadPoolExecutor(max_workers=4) as pool:
         subtitle_futures = []

--- a/src/movie_narrator/utils/text_anim.py
+++ b/src/movie_narrator/utils/text_anim.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Text animation effects for v0.7.1 visual enhancement.
+
+Provides fade, slide, and typewriter-style entrance animations for
+subtitle text overlays. Each function returns a modified ImageClip
+with the appropriate MoviePy effects applied.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# Maximum fraction of a subtitle clip's duration that an entrance
+# animation may consume. Subtitle segments are short, so we cap the
+# animation at a quarter of the clip — this keeps the text readable for
+# most of its on-screen time while still providing a polished entrance.
+_MAX_ANIMATION_RATIO = 1.0 / 4.0
+
+# Valid animation types (shared source of truth for pipeline + tests).
+VALID_ANIMATION_TYPES = frozenset({"none", "fade", "slide_up", "slide_left"})
+
+
+def get_animation_duration(clip_duration: float, requested: float = 0.3) -> float:
+    """Clamp a text-animation duration so it never exceeds 1/4 of the clip.
+
+    A subtitle entrance animation that runs longer than the subtitle is
+    on screen would mean the text never settles, hurting readability.
+    We therefore cap the effective duration at a quarter of the clip's
+    runtime. Negative or zero durations are normalised to 0.
+
+    Args:
+        clip_duration: Duration of the subtitle clip (seconds).
+        requested: Desired animation duration in seconds (default 0.3).
+
+    Returns:
+        The clamped animation duration in seconds (never negative).
+    """
+    if clip_duration is None or clip_duration <= 0:
+        return 0.0
+    if requested is None or requested <= 0:
+        return 0.0
+    max_allowed = clip_duration * _MAX_ANIMATION_RATIO
+    return min(float(requested), max_allowed)
+
+
+def _import_fade_effect():
+    """Import MoviePy's FadeIn effect defensively.
+
+    The ``moviepy.video.fx`` module layout has shifted across minor
+    releases; importing inside a helper lets us catch ImportError /
+    AttributeError uniformly and fall back to a no-op animation.
+    """
+    try:
+        from moviepy.video.fx import FadeIn
+        return FadeIn
+    except Exception:  # noqa: BLE001 — broad on purpose, see docstring
+        return None
+
+
+def _safe_clip_duration(clip: Any) -> float:
+    """Return the clip's duration as a float, or 0.0 when unknown."""
+    try:
+        d = getattr(clip, "duration", None)
+        if d is None:
+            return 0.0
+        return float(d)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _read_base_position(clip: Any) -> tuple[float, float]:
+    """Return the clip's resting (x, y) position as a numeric tuple.
+
+    MoviePy 2.x stores the position set via ``with_position`` on
+    ``clip.pos``. When that attribute is a static 2-tuple of numbers we
+    use it as the animation base so the text settles exactly where it
+    was meant to be. Falls back to ``(0, 0)`` for clips without a stored
+    position or test mocks (subtitle overlays default to (0, 0)).
+    """
+    pos = getattr(clip, "pos", None)
+    if isinstance(pos, (tuple, list)) and len(pos) == 2:
+        try:
+            return (float(pos[0]), float(pos[1]))
+        except (TypeError, ValueError):
+            return (0.0, 0.0)
+    return (0.0, 0.0)
+
+
+def apply_text_animation(
+    clip: Any,
+    animation_type: str,
+    duration: float = 0.3,
+) -> Any:
+    """Apply an entrance animation to a subtitle text ImageClip.
+
+    Args:
+        clip: A MoviePy ``ImageClip`` for a subtitle overlay.
+        animation_type: One of ``"none"``, ``"fade"``, ``"slide_up"``,
+            ``"slide_left"``. ``"none"`` returns the clip unchanged.
+        duration: Animation duration in seconds. Clamped to at most a
+            quarter of the clip's own duration via
+            :func:`get_animation_duration`.
+
+    Returns:
+        The (possibly modified) clip. When ``animation_type`` is
+        ``"none"`` or MoviePy fx is unavailable, the original clip is
+        returned unchanged so the render pipeline degrades gracefully.
+
+    Notes:
+        * ``fade`` uses MoviePy's ``FadeIn`` effect for an opacity ramp.
+        * ``slide_up`` / ``slide_left`` interpolate the clip's position
+          from a small offset back to its resting location. When the clip
+          does not expose ``with_position`` (e.g. test mocks) we fall
+          back to a ``FadeIn`` so the animation is still applied.
+    """
+    # "none" (or any unknown type) → no-op. Be lenient: an unrecognised
+    # type must never crash a render, it simply degrades to no animation.
+    if not animation_type or animation_type == "none":
+        return clip
+
+    # Resolve a safe duration. If the clip reports no duration we cannot
+    # apply a meaningful animation, so return unchanged.
+    clip_duration = _safe_clip_duration(clip)
+    anim_dur = get_animation_duration(clip_duration, duration)
+    if anim_dur <= 0:
+        return clip
+
+    FadeIn = _import_fade_effect()
+
+    try:
+        if animation_type == "fade":
+            if FadeIn is not None:
+                return clip.with_effects([FadeIn(min(anim_dur, clip_duration))])
+            return clip
+
+        if animation_type in ("slide_up", "slide_left"):
+            slid = _apply_slide_entrance(clip, animation_type, anim_dur,
+                                         clip_duration, FadeIn)
+            if slid is not None:
+                return slid
+            # Fallback: fade.
+            if FadeIn is not None:
+                return clip.with_effects([FadeIn(min(anim_dur, clip_duration))])
+    except Exception:  # noqa: BLE001 — graceful degradation
+        # Any MoviePy fx failure must not abort the render.
+        return clip
+
+    return clip
+
+
+def _apply_slide_entrance(
+    clip: Any,
+    animation_type: str,
+    anim_dur: float,
+    clip_duration: float,
+    FadeIn: Optional[Any],
+) -> Optional[Any]:
+    """Apply a slide-up or slide-left entrance animation.
+
+    Interpolates the clip's position from a small offset to its resting
+    location (0, 0 for an overlay that is already positioned, or the
+    clip's current position when available). The slide distance is a
+    fixed fraction of the clip dimensions so it is visible but gentle.
+
+    Returns the modified clip, or ``None`` when the clip does not expose
+    the hooks needed for a positional animation (caller falls back to a
+    fade in that case).
+    """
+    has_with_position = callable(getattr(clip, "with_position", None))
+    if not has_with_position:
+        return None
+
+    # Slide distance: 6% of the relevant clip dimension.
+    w = getattr(clip, "w", None) or 0
+    h = getattr(clip, "h", None) or 0
+    if animation_type == "slide_up":
+        offset = float(h) * 0.06 if h else 0.0
+    else:  # slide_left
+        offset = float(w) * 0.06 if w else 0.0
+
+    # When offset cannot be derived (e.g. mock without size), fall back
+    # to a fixed pixel offset so the slide is still visible.
+    if offset <= 0:
+        offset = 20.0
+
+    in_dur = min(anim_dur, clip_duration)
+
+    # Subtitle overlays rest at their default position (top-left of the
+    # full-canvas image, i.e. (0, 0)). When a clip already has a static
+    # position stored (``clip.pos``) we animate relative to it so the
+    # text settles exactly where it was meant to be.
+    base = _read_base_position(clip)
+
+    def _pos_fn(t):
+        # ``t`` is relative to the clip's own start in MoviePy 2.x.
+        progress = max(0.0, min(1.0, t / in_dur)) if in_dur > 0 else 1.0
+        eased = progress
+        if animation_type == "slide_up":
+            return (base[0], base[1] + offset * (1.0 - eased))
+        # slide_left
+        return (base[0] + offset * (1.0 - eased), base[1])
+
+    try:
+        slid = clip.with_position(_pos_fn)
+        # Preserve the original start time so timeline ordering is intact.
+        start_t = getattr(clip, "start", None)
+        if start_t is not None:
+            slid = slid.with_start(start_t)
+        # Combine with a fade for opacity polish when available.
+        if FadeIn is not None and callable(getattr(slid, "with_effects", None)):
+            slid = slid.with_effects([FadeIn(in_dur)])
+        return slid
+    except Exception:  # noqa: BLE001 — graceful degradation
+        return None

--- a/src/movie_narrator/utils/transitions.py
+++ b/src/movie_narrator/utils/transitions.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Scene transition effects for v0.7.1 visual enhancement.
+
+Provides crossfade, dissolve, and slide transitions between video
+clips in the composite timeline. Each transition returns a list of
+MoviePy effects/clips that the render pipeline applies.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# Maximum fraction of a clip's duration that a transition may consume.
+# Keeping transitions short relative to the clip prevents a clip from
+# being entirely "in transition" (which would make it never reach full
+# opacity / correct position and look broken).
+_MAX_TRANSITION_RATIO = 1.0 / 3.0
+
+# Valid transition types and positions (kept here so the render pipeline
+# and tests share a single source of truth).
+VALID_TRANSITION_TYPES = frozenset({"none", "fade", "dissolve", "slide"})
+VALID_TRANSITION_POSITIONS = frozenset({"in", "out", "both"})
+
+
+def get_transition_duration(clip_duration: float, requested: float = 0.5) -> float:
+    """Clamp a transition duration so it never exceeds 1/3 of the clip.
+
+    A transition that is longer than the clip itself produces visual
+    glitches (the clip would never reach full opacity), so we cap the
+    effective duration at a third of the clip's runtime. Negative or
+    zero durations are normalised to a safe default.
+
+    Args:
+        clip_duration: Duration of the clip the transition is applied to.
+        requested: Desired transition duration in seconds (default 0.5).
+
+    Returns:
+        The clamped transition duration in seconds (never negative).
+    """
+    if clip_duration is None or clip_duration <= 0:
+        return 0.0
+    if requested is None or requested <= 0:
+        return 0.0
+    # Cap at 1/3 of the clip duration.
+    max_allowed = clip_duration * _MAX_TRANSITION_RATIO
+    return min(float(requested), max_allowed)
+
+
+def _import_fade_effects():
+    """Import MoviePy's FadeIn / FadeOut effects defensively.
+
+    MoviePy's ``video.fx`` submodule layout has shifted between minor
+    releases; importing inside a helper lets us catch ImportError /
+    AttributeError uniformly and fall back to a no-op transition.
+    """
+    try:
+        from moviepy.video.fx import FadeIn, FadeOut
+        return FadeIn, FadeOut
+    except Exception:  # noqa: BLE001 — broad on purpose, see docstring
+        return None, None
+
+
+def apply_transition(
+    clip: Any,
+    transition_type: str,
+    duration: float = 0.5,
+    position: str = "both",
+) -> Any:
+    """Apply a scene transition effect to a video clip.
+
+    Args:
+        clip: A MoviePy clip (e.g. the fitted source subclip).
+        transition_type: One of ``"none"``, ``"fade"``, ``"dissolve"``,
+            ``"slide"``. ``"none"`` returns the clip unchanged.
+        duration: Transition duration in seconds. Clamped to at most a
+            third of the clip's own duration via
+            :func:`get_transition_duration`.
+        position: Which end of the clip to animate — ``"in"``, ``"out"``
+            or ``"both"`` (default).
+
+    Returns:
+        The (possibly modified) clip. When ``transition_type`` is
+        ``"none"`` or MoviePy fx is unavailable, the original clip is
+        returned unchanged so the render pipeline degrades gracefully.
+
+    Notes:
+        * ``fade`` and ``dissolve`` both use MoviePy's ``FadeIn`` /
+          ``FadeOut`` effects (a dissolve is effectively a fade against
+          a held frame of the surrounding composite).
+        * ``slide`` animates the clip's x-position. When the clip does
+          not expose ``with_position`` (e.g. test mocks) we fall back to
+          a fade so the transition is still applied gracefully.
+    """
+    # "none" (or any unknown type) → no-op. Be lenient: an unrecognised
+    # type must never crash a render, it simply degrades to no transition.
+    if not transition_type or transition_type == "none":
+        return clip
+
+    if position not in VALID_TRANSITION_POSITIONS:
+        position = "both"
+
+    # Resolve a safe duration. If the clip reports no duration we cannot
+    # apply a meaningful transition, so return unchanged.
+    clip_duration = _safe_clip_duration(clip)
+    trans_dur = get_transition_duration(clip_duration, duration)
+    if trans_dur <= 0:
+        return clip
+
+    FadeIn, FadeOut = _import_fade_effects()
+
+    try:
+        if transition_type in ("fade", "dissolve"):
+            effects = []
+            if position in ("in", "both") and FadeIn is not None:
+                effects.append(FadeIn(min(trans_dur, clip_duration)))
+            if position in ("out", "both") and FadeOut is not None:
+                effects.append(FadeOut(min(trans_dur, clip_duration)))
+            if effects:
+                return clip.with_effects(effects)
+
+        if transition_type == "slide":
+            # Attempt a simple x-offset slide. If the clip does not
+            # support with_position / with_effects (e.g. test mocks),
+            # fall back to a fade so the transition is still applied.
+            slid = _apply_slide(clip, trans_dur, position, clip_duration,
+                                FadeIn, FadeOut)
+            if slid is not None:
+                return slid
+            # Fallback: fade.
+            effects = []
+            if position in ("in", "both") and FadeIn is not None:
+                effects.append(FadeIn(min(trans_dur, clip_duration)))
+            if position in ("out", "both") and FadeOut is not None:
+                effects.append(FadeOut(min(trans_dur, clip_duration)))
+            if effects:
+                return clip.with_effects(effects)
+    except Exception:  # noqa: BLE001 — graceful degradation
+        # Any MoviePy fx failure must not abort the render.
+        return clip
+
+    return clip
+
+
+def _safe_clip_duration(clip: Any) -> float:
+    """Return the clip's duration as a float, or 0.0 when unknown."""
+    try:
+        d = getattr(clip, "duration", None)
+        if d is None:
+            return 0.0
+        return float(d)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _read_base_position(clip: Any) -> tuple[float, float]:
+    """Return the clip's resting (x, y) position as a numeric tuple.
+
+    MoviePy 2.x stores the position set via ``with_position`` on
+    ``clip.pos``. When that attribute is a static 2-tuple of numbers we
+    use it as the slide base so a centered (contain-mode) clip keeps its
+    vertical centering during the animation. Falls back to ``(0, 0)``
+    for clips without a stored position or test mocks.
+    """
+    pos = getattr(clip, "pos", None)
+    if isinstance(pos, (tuple, list)) and len(pos) == 2:
+        try:
+            return (float(pos[0]), float(pos[1]))
+        except (TypeError, ValueError):
+            return (0.0, 0.0)
+    return (0.0, 0.0)
+
+
+def _apply_slide(
+    clip: Any,
+    trans_dur: float,
+    position: str,
+    clip_duration: float,
+    FadeIn: Optional[Any],
+    FadeOut: Optional[Any],
+) -> Optional[Any]:
+    """Apply a horizontal slide entrance/exit.
+
+    Uses MoviePy's ``with_position`` with a callable that interpolates
+    the x-offset from a small delta back to 0 (entrance) or from 0 to a
+    delta (exit). The slide distance is a fixed fraction of the clip
+    width so it is visible but not jarring.
+
+    Returns the modified clip, or ``None`` when the clip does not expose
+    the hooks needed for a positional animation (caller falls back to a
+    fade in that case).
+    """
+    width = getattr(clip, "w", None) or getattr(clip, "size", None)
+    if isinstance(width, (tuple, list)):
+        width = width[0]
+    if not width or width <= 0:
+        return None
+
+    # Slide offset: 8% of the clip width (a noticeable but gentle slide).
+    offset = float(width) * 0.08
+    start_t = getattr(clip, "start", None) or 0.0
+    in_dur = min(trans_dur, clip_duration) if position in ("in", "both") else 0.0
+    out_dur = min(trans_dur, clip_duration) if position in ("out", "both") else 0.0
+
+    has_with_position = callable(getattr(clip, "with_position", None))
+    if not has_with_position:
+        return None
+
+    # Respect an existing static position (e.g. contain-mode centering) so
+    # the slide animates relative to the clip's resting location instead of
+    # snapping it to the top-left corner. MoviePy 2.x stores the position on
+    # ``clip.pos`` after ``with_position``; falls back to (0, 0) otherwise.
+    base = _read_base_position(clip)
+
+    def _pos_fn(t):
+        # ``t`` is relative to the clip's own start in MoviePy 2.x.
+        x = base[0]
+        if in_dur > 0 and t < in_dur:
+            # Entrance: ease from +offset to base.
+            progress = max(0.0, min(1.0, t / in_dur))
+            x = base[0] + offset * (1.0 - progress)
+        elif out_dur > 0 and t > (clip_duration - out_dur):
+            # Exit: ease from base to -offset.
+            progress = max(0.0, min(1.0,
+                                     (t - (clip_duration - out_dur)) / out_dur))
+            x = base[0] - offset * progress
+        return (x, base[1])
+
+    try:
+        slid = clip.with_position(_pos_fn)
+        # Preserve the original start time so timeline ordering is intact.
+        if start_t:
+            slid = slid.with_start(start_t)
+        # Combine with a fade for opacity polish when available.
+        effects = []
+        if position in ("in", "both") and FadeIn is not None:
+            effects.append(FadeIn(min(trans_dur, clip_duration)))
+        if position in ("out", "both") and FadeOut is not None:
+            effects.append(FadeOut(min(trans_dur, clip_duration)))
+        if effects and callable(getattr(slid, "with_effects", None)):
+            slid = slid.with_effects(effects)
+        return slid
+    except Exception:  # noqa: BLE001 — graceful degradation
+        return None

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -104,6 +104,18 @@ class JobParams(BaseModel):
     render_vertical_safe_area: Optional[bool] = None
     # v0.7.0: GPU encoding — "auto" (default) | "cpu" | "nvenc" | "vaapi" | "videotoolbox"
     render_encoder: Optional[str] = None
+    # v0.7.1: scene transition type — "none" (default) | "fade" | "dissolve" | "slide"
+    render_transition: Optional[str] = None
+    # v0.7.1: transition duration in seconds (default 0.5)
+    render_transition_duration: Optional[float] = None
+    # v0.7.1: text animation type — "none" (default) | "fade" | "slide_up" | "slide_left"
+    render_text_animation: Optional[str] = None
+    # v0.7.1: text animation duration in seconds (default 0.3)
+    render_text_animation_duration: Optional[float] = None
+    # v0.7.1: ambient/SFX audio track for multi-track mixing
+    bgm_ambient_path: Optional[str] = None
+    # v0.7.1: ambient track gain reduction in dB (default -12)
+    bgm_ambient_gain_db: Optional[float] = None
     # ── QA ──
     qa_enabled: Optional[bool] = None
     qa_max_silence_db: Optional[float] = None

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 7, 0) — bumped for v0.7.0 cost tracking and GPU encoder."""
-        assert CONTRACT_VERSION == (0, 7, 0)
+        """CONTRACT_VERSION is (0, 7, 1) — bumped for v0.7.1 scene transitions and text animation."""
+        assert CONTRACT_VERSION == (0, 7, 1)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_m5_community.py
+++ b/tests/test_m5_community.py
@@ -28,7 +28,7 @@ class TestCheckVersion:
     def test_check_version_raises_when_below(self):
         """check_version raises ImportError when CONTRACT_VERSION < required."""
         with pytest.raises(ImportError, match="below the required"):
-            check_version((0, 7, 1))
+            check_version((0, 7, 2))
 
     def test_check_version_raises_with_future_major(self):
         with pytest.raises(ImportError, match="below the required"):

--- a/tests/test_text_anim.py
+++ b/tests/test_text_anim.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the v0.7.1 text animation utility (utils/text_anim.py).
+
+Uses MagicMock clips that mimic the MoviePy ImageClip surface
+(``duration``, ``with_effects``, ``with_position``, ``with_start``,
+``w``, ``h``) so the suite runs without ffmpeg or real image data.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from movie_narrator.utils.text_anim import (
+    apply_text_animation,
+    get_animation_duration,
+)
+
+
+def _make_clip(duration: float = 2.0, w: int = 1280, h: int = 720) -> MagicMock:
+    """Build a MagicMock that quacks like a MoviePy ImageClip.
+
+    Numeric ``duration`` / ``w`` / ``h`` are set explicitly so the slide
+    math does not trip over non-numeric MagicMock attributes. ``start``
+    mimics a subtitle clip that already had ``with_start`` applied.
+    """
+    clip = MagicMock()
+    clip.duration = duration
+    clip.w = w
+    clip.h = h
+    clip.start = 0.0
+    # with_position returns a fresh mock that also exposes with_effects /
+    # with_start for the slide code path (each returns itself so the
+    # builder chain resolves to a single object).
+    slid = MagicMock()
+    slid.with_effects = MagicMock(return_value=slid)
+    slid.with_start = MagicMock(return_value=slid)
+    clip.with_position = MagicMock(return_value=slid)
+    return clip
+
+
+# ── get_animation_duration (clamping) ─────────────────────
+
+
+class TestGetAnimationDuration:
+    def test_returns_requested_when_within_cap(self):
+        # 0.3s requested, clip is 2.0s → cap is 0.5s, so 0.3 passes through.
+        assert get_animation_duration(2.0, 0.3) == pytest.approx(0.3)
+
+    def test_clamps_to_one_quarter_of_clip(self):
+        # 0.3s requested on a 1.0s clip → cap is 1/4 = 0.25s.
+        assert get_animation_duration(1.0, 0.3) == pytest.approx(0.25)
+
+    def test_zero_clip_duration_returns_zero(self):
+        assert get_animation_duration(0.0, 0.3) == 0.0
+
+    def test_negative_clip_duration_returns_zero(self):
+        assert get_animation_duration(-1.0, 0.3) == 0.0
+
+    def test_non_positive_requested_returns_zero(self):
+        assert get_animation_duration(2.0, 0.0) == 0.0
+        assert get_animation_duration(2.0, -0.3) == 0.0
+
+    def test_default_requested_is_three_tenths(self):
+        assert get_animation_duration(2.0) == pytest.approx(0.3)
+
+
+# ── apply_text_animation: "none" and unknown types ────────
+
+
+class TestApplyTextAnimationNoOp:
+    def test_none_type_returns_clip_unchanged(self):
+        clip = _make_clip()
+        result = apply_text_animation(clip, "none", 0.3)
+        assert result is clip
+
+    def test_empty_type_returns_clip_unchanged(self):
+        clip = _make_clip()
+        result = apply_text_animation(clip, "", 0.3)
+        assert result is clip
+
+    def test_unknown_type_does_not_crash(self):
+        """An unrecognised animation type degrades gracefully to no-op."""
+        clip = _make_clip()
+        result = apply_text_animation(clip, "bogus", 0.3)
+        assert result is clip
+
+    def test_zero_duration_returns_clip_unchanged(self):
+        clip = _make_clip(duration=0.0)
+        result = apply_text_animation(clip, "fade", 0.3)
+        assert result is clip
+
+
+# ── apply_text_animation: fade ────────────────────────────
+
+
+class TestApplyTextAnimationFade:
+    def test_fade_applies_effects(self):
+        clip = _make_clip(duration=2.0)
+        result = apply_text_animation(clip, "fade", 0.3)
+        # with_effects must have been called with a non-empty effect list.
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        assert isinstance(effects, list)
+        assert len(effects) == 1  # FadeIn entrance only
+        # The returned clip is the with_effects result, not the original.
+        assert result is clip.with_effects.return_value
+
+    def test_fade_duration_is_clamped(self):
+        """A long requested duration on a short clip is clamped to 1/4."""
+        clip = _make_clip(duration=1.0)
+        apply_text_animation(clip, "fade", 1.0)
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        fx = effects[0]
+        assert fx.duration <= 0.25 + 1e-9
+
+
+# ── apply_text_animation: slide ───────────────────────────
+
+
+class TestApplyTextAnimationSlide:
+    def test_slide_up_uses_with_position(self):
+        clip = _make_clip(duration=2.0, w=1280, h=720)
+        result = apply_text_animation(clip, "slide_up", 0.3)
+        # The slide path animates position via with_position.
+        assert clip.with_position.called
+        # Result is the slid mock (the with_effects return value chain).
+        assert result is not clip
+
+    def test_slide_left_uses_with_position(self):
+        clip = _make_clip(duration=2.0, w=1280, h=720)
+        result = apply_text_animation(clip, "slide_left", 0.3)
+        assert clip.with_position.called
+        assert result is not clip
+
+    def test_slide_falls_back_when_no_with_position(self):
+        """When a clip lacks with_position, slide degrades to a fade."""
+        clip = _make_clip(duration=2.0, w=1280, h=720)
+        # Replace with_position with a non-callable so the slide helper
+        # cannot animate position and must fall back to a fade.
+        clip.with_position = None
+        result = apply_text_animation(clip, "slide_up", 0.3)
+        # Fade fallback still applies effects via with_effects.
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        assert len(effects) >= 1
+        assert result is clip.with_effects.return_value

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the v0.7.1 scene transition utility (utils/transitions.py).
+
+Uses MagicMock clips that mimic the MoviePy clip surface (``duration``,
+``with_effects``, ``with_position``, ``with_start``, ``w``, ``h``) so the
+suite runs without touching ffmpeg or real video data.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from movie_narrator.utils.transitions import (
+    apply_transition,
+    get_transition_duration,
+)
+
+
+def _make_clip(duration: float = 2.0, w: int = 1920, h: int = 1080) -> MagicMock:
+    """Build a MagicMock that quacks like a MoviePy clip.
+
+    Numeric ``duration`` / ``w`` / ``h`` are set explicitly so the slide
+    math does not trip over non-numeric MagicMock attributes. ``start``
+    is left as ``None`` so the slide helper skips re-applying it.
+    """
+    clip = MagicMock()
+    clip.duration = duration
+    clip.w = w
+    clip.h = h
+    clip.start = None
+    # with_position returns a fresh mock that also exposes with_effects /
+    # with_start for the slide code path.
+    slid = MagicMock()
+    slid.with_effects = MagicMock(return_value=slid)
+    slid.with_start = MagicMock(return_value=slid)
+    clip.with_position = MagicMock(return_value=slid)
+    return clip
+
+
+# ── get_transition_duration (clamping) ────────────────────
+
+
+class TestGetTransitionDuration:
+    def test_returns_requested_when_within_cap(self):
+        # 0.5s requested, clip is 3.0s → cap is 1.0s, so 0.5 passes through.
+        assert get_transition_duration(3.0, 0.5) == pytest.approx(0.5)
+
+    def test_clamps_to_one_third_of_clip(self):
+        # 0.5s requested on a 1.0s clip → cap is 1/3 ≈ 0.333s.
+        assert get_transition_duration(1.0, 0.5) == pytest.approx(1.0 / 3.0)
+
+    def test_zero_clip_duration_returns_zero(self):
+        assert get_transition_duration(0.0, 0.5) == 0.0
+
+    def test_negative_clip_duration_returns_zero(self):
+        assert get_transition_duration(-1.0, 0.5) == 0.0
+
+    def test_non_positive_requested_returns_zero(self):
+        assert get_transition_duration(3.0, 0.0) == 0.0
+        assert get_transition_duration(3.0, -0.5) == 0.0
+
+    def test_default_requested_is_half_second(self):
+        assert get_transition_duration(3.0) == pytest.approx(0.5)
+
+
+# ── apply_transition: "none" and unknown types ────────────
+
+
+class TestApplyTransitionNoOp:
+    def test_none_type_returns_clip_unchanged(self):
+        clip = _make_clip()
+        result = apply_transition(clip, "none", 0.5)
+        assert result is clip
+
+    def test_empty_type_returns_clip_unchanged(self):
+        clip = _make_clip()
+        result = apply_transition(clip, "", 0.5)
+        assert result is clip
+
+    def test_unknown_type_does_not_crash(self):
+        """An unrecognised transition type degrades gracefully to no-op."""
+        clip = _make_clip()
+        result = apply_transition(clip, "bogus", 0.5)
+        assert result is clip
+
+    def test_zero_duration_returns_clip_unchanged(self):
+        clip = _make_clip(duration=0.0)
+        result = apply_transition(clip, "fade", 0.5)
+        assert result is clip
+
+
+# ── apply_transition: fade / dissolve ─────────────────────
+
+
+class TestApplyTransitionFade:
+    def test_fade_applies_effects(self):
+        clip = _make_clip(duration=2.0)
+        result = apply_transition(clip, "fade", 0.5, position="both")
+        # with_effects must have been called with a non-empty effect list.
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        assert isinstance(effects, list)
+        assert len(effects) == 2  # FadeIn + FadeOut for position="both"
+        # The returned clip is the with_effects result, not the original.
+        assert result is clip.with_effects.return_value
+
+    def test_fade_position_in_only(self):
+        clip = _make_clip(duration=2.0)
+        apply_transition(clip, "fade", 0.5, position="in")
+        effects = clip.with_effects.call_args.args[0]
+        assert len(effects) == 1  # FadeIn only
+
+    def test_fade_position_out_only(self):
+        clip = _make_clip(duration=2.0)
+        apply_transition(clip, "fade", 0.5, position="out")
+        effects = clip.with_effects.call_args.args[0]
+        assert len(effects) == 1  # FadeOut only
+
+    def test_dissolve_applies_effects(self):
+        clip = _make_clip(duration=2.0)
+        apply_transition(clip, "dissolve", 0.5)
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        assert len(effects) == 2
+
+    def test_fade_duration_is_clamped(self):
+        """A long requested duration on a short clip is clamped to 1/3."""
+        clip = _make_clip(duration=1.0)
+        apply_transition(clip, "fade", 2.0)
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        # Each effect's duration arg should be <= 1/3 of the clip.
+        for fx in effects:
+            assert fx.duration <= 1.0 / 3.0 + 1e-9
+
+
+# ── apply_transition: slide ───────────────────────────────
+
+
+class TestApplyTransitionSlide:
+    def test_slide_uses_with_position(self):
+        clip = _make_clip(duration=2.0, w=1920, h=1080)
+        result = apply_transition(clip, "slide", 0.5)
+        # The slide path animates position via with_position.
+        assert clip.with_position.called
+        # The returned clip is the slid mock (with_effects return value).
+        assert result is clip.with_position.return_value.with_effects.return_value
+
+    def test_slide_falls_back_when_no_with_position(self):
+        """When a clip lacks with_position, slide degrades to a fade."""
+        clip = _make_clip(duration=2.0, w=1920, h=1080)
+        # Replace with_position with a non-callable so the slide helper
+        # cannot animate position and must fall back to a fade.
+        clip.with_position = None
+        result = apply_transition(clip, "slide", 0.5)
+        # Fade fallback still applies effects via with_effects.
+        assert clip.with_effects.called
+        effects = clip.with_effects.call_args.args[0]
+        assert len(effects) >= 1
+        assert result is clip.with_effects.return_value

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 7, 0)
+        assert CONTRACT_VERSION == (0, 7, 1)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 7, 0)."""
+        """CONTRACT_VERSION is (0, 7, 1)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 7, 0)
+        assert CONTRACT_VERSION == (0, 7, 1)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""


### PR DESCRIPTION
## v0.7.1 — Visual Enhancement

### Added
- Scene transition effects (fade, dissolve, slide) between video clips
- Text animation effects (fade, slide_up, slide_left) for subtitle overlays
- Multi-track audio mixing with optional ambient/SFX track
- New job params: render_transition, render_text_animation, bgm_ambient_path

### Changed
- Version bumped to 0.7.1, CONTRACT_VERSION to (0, 7, 1)