### PR TITLE
feat(v0.7.2): 10-second preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `mkdocs.yml`: added "Best Practices" navigation entry.
 - **Internal terminology cleanup**: replaced all "L2 hand-test" / "L2+" / "Q-X" internal QA references with community-friendly terms ("manual QA verification") across documentation (`ROADMAP`, `ARCHITECTURE`, `METADATA_SCHEMA` — EN/ZH), source code comments (`align.py`, `match.py`, `scene_filter.py`, `_align_backend.py`, `metadata_export.py`, `scenes.py`, `deliverable_qa.py`), test files (`test_audit_integration.py`, `test_e2e_smoke.py`, `test_match.py`), and scripts (`compare_runs.py`). CHANGELOG historical entries preserved as immutable records.
 
+## [0.7.2] - 2026-07-30
+
+### Added
+
+- 10-second preview mode for fast iteration before full render
+- `render_preview_mode` and `render_preview_sec` job parameters
+- Preview mode skips non-essential steps (research, translate, QA, clips)
+
+### Changed
+
+- Version bumped to 0.7.2, CONTRACT_VERSION to (0, 7, 2)
+
 ## [0.7.1] - 2026-07-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.7.1"
+version = "0.7.2"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -49,7 +49,7 @@ from typing import Any, Callable, Dict, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 7, 1)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 7, 2)
 
 
 def check_version(required: tuple[int, int, int]) -> None:

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -253,6 +253,28 @@ def render_video(ctx: Context) -> Context:
     audio_clip = AudioFileClip(audio_path)
     total_duration = audio_clip.duration
 
+    # v0.7.2: Preview mode — truncate to first N seconds for fast iteration.
+    # When enabled the audio, background clip and subtitle segments are all
+    # cut to the preview window so the rendered file is a faithful (short)
+    # representation of the final output.  Preview mode is OFF by default
+    # (backward compatible).
+    preview_mode = ctx.metadata.get("render_preview_mode", False)
+    if preview_mode:
+        from ..utils.preview import get_preview_duration, truncate_segments_for_preview
+        preview_sec = get_preview_duration(
+            ctx.metadata.get("render_preview_sec", 10.0), total_duration
+        )
+        total_duration = min(total_duration, preview_sec)
+        ctx.services.console.info(f"  Preview mode: rendering first {preview_sec:.0f}s")
+        # Truncate the audio so the muxed output is exactly preview_sec long.
+        audio_clip = audio_clip.subclipped(0, total_duration)
+        # Truncate timed segments so subtitle overlays respect the preview
+        # window (segments beyond the cut are dropped; spanning segments are
+        # clamped to end at the boundary).
+        ctx.timed_segments = truncate_segments_for_preview(
+            ctx.timed_segments, total_duration
+        )
+
     # Production-quality render knobs (spec §7.2).
     fit_mode = ctx.metadata.get("render_fit_mode", "cover")
     subtitle_position = ctx.metadata.get("render_subtitle_position", "bottom")
@@ -493,7 +515,11 @@ def render_video(ctx: Context) -> Context:
     # and dropping it lets GC reclaim the list shell during the expensive
     # write_videofile call below.
     del clips
-    video_path = output_dir / ctx.metadata.get("render_output_name", "final.mp4")
+    # v0.7.2: In preview mode, default the output name to preview.mp4 so the
+    # short render is never mistaken for the final deliverable.  An explicit
+    # render_output_name from the user always takes precedence.
+    default_output_name = "preview.mp4" if preview_mode else "final.mp4"
+    video_path = output_dir / ctx.metadata.get("render_output_name", default_output_name)
 
 
     tmp_dir = output_dir / ".tmp"

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -239,6 +239,12 @@ def build_context(
             "research_provider": (params or {}).get("research_provider", "llm"),
             # R2-NA-LANG: single source of truth for narration language.
             "lang": lang,
+            # v0.7.2: preview mode — render only the first N seconds for quick
+            # iteration.  OFF by default (backward compatible).  These keys are
+            # also propagated via PARAM_WHITELIST below when explicitly set;
+            # setting defaults here keeps them visible in metadata.json.
+            "render_preview_mode": (params or {}).get("render_preview_mode", False),
+            "render_preview_sec": (params or {}).get("render_preview_sec", 10.0),
         }
     )
 
@@ -415,6 +421,19 @@ def run_pipeline(
             continue
 
         check_cancelled(controller)
+
+        # v0.7.2: Skip non-essential steps in preview mode.
+        # Only SOFT steps (research_plot, translate_subtitles, run_qa_gate,
+        # export_clips) are skipped — hard steps always run so the preview is
+        # a faithful representation of the final output.
+        if ctx.metadata.get("render_preview_mode"):
+            from ..utils.preview import should_skip_step_for_preview
+            if should_skip_step_for_preview(name, True):
+                ctx.step_state = StepState(
+                    result=StepResult.SKIPPED, message="skipped in preview mode"
+                )
+                console.debug(f"  Preview: skipping {name}")
+                continue
 
         # ── Execute step with soft/hard exception fork ───────
         # Soft steps: exception → ⚠ + continue (no abort).

--- a/src/movie_narrator/utils/preview.py
+++ b/src/movie_narrator/utils/preview.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Preview mode utilities for v0.7.2.
+
+Provides functions to truncate pipeline data (timed segments, matched
+clips, audio) to a preview duration, enabling fast iteration without
+a full render.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+# v0.7.2: Steps that are non-essential for preview rendering.  These are
+# all SOFT steps whose output is not required to validate the first N
+# seconds of a render.  Hard steps (generate_script, generate_voice,
+# render_video, etc.) must always run.
+_PREVIEW_SKIPPABLE_STEPS = frozenset({
+    "research_plot",
+    "translate_subtitles",
+    "run_qa_gate",
+    "export_clips",
+})
+
+# Clamping bounds for the preview duration, in seconds.  The lower bound
+# avoids uselessly short previews; the upper bound caps cost so a typo
+# (e.g. 3600s) cannot accidentally trigger a near-full render.
+_PREVIEW_MIN_SEC = 3.0
+_PREVIEW_MAX_SEC = 60.0
+
+
+def truncate_segments_for_preview(segments: List, preview_sec: float) -> List:
+    """Return segments that start before ``preview_sec``, truncated to end at it.
+
+    Each returned segment is a shallow copy with ``end`` clamped to
+    ``preview_sec`` so the preview never extends past the requested
+    window.  Segments that start at or after ``preview_sec`` are dropped
+    entirely — they would not be visible in the truncated output.
+
+    The input list is not mutated; segments that already fit inside the
+    window are reused by reference (no copy needed).
+    """
+    result: List = []
+    for seg in segments:
+        # Drop segments that begin at or beyond the preview boundary.
+        if seg.start >= preview_sec:
+            continue
+        # Reuse the original reference when no truncation is needed.
+        if seg.end <= preview_sec:
+            result.append(seg)
+        else:
+            result.append(seg.model_copy(update={"end": min(seg.end, preview_sec)}))
+    return result
+
+
+def truncate_clips_for_preview(clips: List, preview_sec: float) -> List:
+    """Return clips whose ``narr_start < preview_sec``, truncated.
+
+    Each returned clip is a shallow copy with ``narr_end`` clamped to
+    ``preview_sec``.  Clips that start at or after ``preview_sec`` are
+    dropped — they fall outside the preview window.
+
+    The input list is not mutated; clips that already fit inside the
+    window are reused by reference (no copy needed).
+    """
+    result: List = []
+    for clip in clips:
+        # Drop clips that begin at or beyond the preview boundary.
+        if clip.narr_start >= preview_sec:
+            continue
+        # Reuse the original reference when no truncation is needed.
+        if clip.narr_end <= preview_sec:
+            result.append(clip)
+        else:
+            result.append(clip.model_copy(update={"narr_end": min(clip.narr_end, preview_sec)}))
+    return result
+
+
+def get_preview_duration(requested: float, total_duration: float) -> float:
+    """Return the effective preview duration in seconds.
+
+    Computes ``min(requested, total_duration)`` then clamps the result
+    to the range ``[3, 60]`` seconds.  The clamp prevents absurdly short
+    or long previews regardless of what the caller requests.
+
+    Note: when ``total_duration`` is itself below the lower clamp (e.g.
+    a 2-second source), the returned value may exceed the real duration.
+    Callers that need a hard ceiling should apply ``min(result, total)``
+    themselves (the render pipeline does exactly this).
+    """
+    effective = min(requested, total_duration)
+    return max(_PREVIEW_MIN_SEC, min(_PREVIEW_MAX_SEC, effective))
+
+
+def should_skip_step_for_preview(step_name: str, preview_mode: bool) -> bool:
+    """Return True when *step_name* may be skipped during preview rendering.
+
+    Only SOFT steps that are non-essential for validating the first N
+    seconds (``research_plot``, ``translate_subtitles``, ``run_qa_gate``,
+    ``export_clips``) are skippable.  Hard steps (``generate_script``,
+    ``generate_voice``, ``render_video``, etc.) always run so the preview
+    is a faithful representation of the final output.
+
+    When ``preview_mode`` is False the function always returns False,
+    preserving full-pipeline behaviour and keeping preview mode OFF by
+    default (backward compatible).
+    """
+    if not preview_mode:
+        return False
+    return step_name in _PREVIEW_SKIPPABLE_STEPS

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -116,6 +116,10 @@ class JobParams(BaseModel):
     bgm_ambient_path: Optional[str] = None
     # v0.7.1: ambient track gain reduction in dB (default -12)
     bgm_ambient_gain_db: Optional[float] = None
+    # v0.7.2: preview mode — render only first N seconds for quick iteration
+    render_preview_mode: Optional[bool] = None
+    # v0.7.2: preview duration in seconds (default 10, range 3-60)
+    render_preview_sec: Optional[float] = None
     # ── QA ──
     qa_enabled: Optional[bool] = None
     qa_max_silence_db: Optional[float] = None

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 7, 1) — bumped for v0.7.1 scene transitions and text animation."""
-        assert CONTRACT_VERSION == (0, 7, 1)
+        """CONTRACT_VERSION is (0, 7, 2) — bumped for v0.7.2 preview mode."""
+        assert CONTRACT_VERSION == (0, 7, 2)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_m5_community.py
+++ b/tests/test_m5_community.py
@@ -28,7 +28,7 @@ class TestCheckVersion:
     def test_check_version_raises_when_below(self):
         """check_version raises ImportError when CONTRACT_VERSION < required."""
         with pytest.raises(ImportError, match="below the required"):
-            check_version((0, 7, 2))
+            check_version((0, 7, 3))
 
     def test_check_version_raises_with_future_major(self):
         with pytest.raises(ImportError, match="below the required"):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,235 @@
+"""Tests for v0.7.2 preview mode utilities (movie_narrator.utils.preview).
+
+Verifies:
+- truncate_segments_for_preview: filtering + boundary clamping
+- truncate_clips_for_preview: filtering + narr_end clamping
+- get_preview_duration: min(requested, total) clamped to [3, 60]
+- should_skip_step_for_preview: only soft steps skipped, off by default
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from movie_narrator.models import MatchedClip, TimedSegment
+from movie_narrator.utils.preview import (
+    get_preview_duration,
+    should_skip_step_for_preview,
+    truncate_clips_for_preview,
+    truncate_segments_for_preview,
+)
+
+
+# ── truncate_segments_for_preview ─────────────────────────
+
+
+class TestTruncateSegmentsForPreview:
+    """truncate_segments_for_preview filters and clamps timed segments."""
+
+    def test_segments_entirely_before_window_kept_unchanged(self):
+        """Segments fully inside the window are reused by reference."""
+        segs = [
+            TimedSegment(text="A", start=0.0, end=3.0),
+            TimedSegment(text="B", start=3.0, end=7.0),
+        ]
+        result = truncate_segments_for_preview(segs, 10.0)
+        assert len(result) == 2
+        assert result[0].end == 3.0
+        assert result[1].end == 7.0
+
+    def test_spanning_segment_clamped_to_boundary(self):
+        """A segment that crosses the boundary is clamped to end at preview_sec."""
+        segs = [
+            TimedSegment(text="A", start=0.0, end=5.0),
+            TimedSegment(text="B", start=5.0, end=15.0),
+        ]
+        result = truncate_segments_for_preview(segs, 10.0)
+        assert len(result) == 2
+        assert result[0].end == 5.0
+        assert result[1].end == 10.0
+        assert result[1].start == 5.0
+
+    def test_segment_starting_at_boundary_dropped(self):
+        """A segment starting exactly at preview_sec is dropped."""
+        segs = [
+            TimedSegment(text="A", start=0.0, end=10.0),
+            TimedSegment(text="B", start=10.0, end=20.0),
+        ]
+        result = truncate_segments_for_preview(segs, 10.0)
+        assert len(result) == 1
+        assert result[0].text == "A"
+
+    def test_segment_starting_after_boundary_dropped(self):
+        """Segments starting after preview_sec are dropped."""
+        segs = [
+            TimedSegment(text="late", start=12.0, end=20.0),
+        ]
+        result = truncate_segments_for_preview(segs, 10.0)
+        assert result == []
+
+    def test_does_not_mutate_input(self):
+        """The original segment list and objects are not mutated."""
+        seg = TimedSegment(text="B", start=5.0, end=15.0)
+        segs = [seg]
+        result = truncate_segments_for_preview(segs, 10.0)
+        assert result[0].end == 10.0
+        # Original untouched
+        assert seg.end == 15.0
+        assert segs[0].end == 15.0
+
+    def test_empty_list_returns_empty(self):
+        assert truncate_segments_for_preview([], 10.0) == []
+
+    def test_exact_boundary_segment_kept(self):
+        """A segment ending exactly at preview_sec is kept unchanged."""
+        seg = TimedSegment(text="A", start=0.0, end=10.0)
+        result = truncate_segments_for_preview([seg], 10.0)
+        assert len(result) == 1
+        assert result[0].end == 10.0
+
+
+# ── truncate_clips_for_preview ────────────────────────────
+
+
+class TestTruncateClipsForPreview:
+    """truncate_clips_for_preview filters and clamps matched clips."""
+
+    def _make_clip(self, narr_start, narr_end, idx=0):
+        return MatchedClip(
+            segment_index=idx,
+            text="x",
+            narr_start=narr_start,
+            narr_end=narr_end,
+            src_start=0.0,
+            src_end=narr_end - narr_start,
+            score=0.5,
+        )
+
+    def test_clips_inside_window_kept(self):
+        clips = [self._make_clip(0.0, 4.0, 0), self._make_clip(4.0, 8.0, 1)]
+        result = truncate_clips_for_preview(clips, 10.0)
+        assert len(result) == 2
+        assert result[0].narr_end == 4.0
+        assert result[1].narr_end == 8.0
+
+    def test_spanning_clip_clamped(self):
+        clips = [self._make_clip(6.0, 18.0, 0)]
+        result = truncate_clips_for_preview(clips, 10.0)
+        assert len(result) == 1
+        assert result[0].narr_start == 6.0
+        assert result[0].narr_end == 10.0
+
+    def test_clip_at_boundary_dropped(self):
+        clips = [self._make_clip(0.0, 5.0, 0), self._make_clip(10.0, 20.0, 1)]
+        result = truncate_clips_for_preview(clips, 10.0)
+        assert len(result) == 1
+        assert result[0].segment_index == 0
+
+    def test_clip_after_boundary_dropped(self):
+        clips = [self._make_clip(15.0, 25.0, 0)]
+        result = truncate_clips_for_preview(clips, 10.0)
+        assert result == []
+
+    def test_does_not_mutate_input(self):
+        clip = self._make_clip(6.0, 18.0, 0)
+        result = truncate_clips_for_preview([clip], 10.0)
+        assert result[0].narr_end == 10.0
+        assert clip.narr_end == 18.0
+
+    def test_empty_list_returns_empty(self):
+        assert truncate_clips_for_preview([], 10.0) == []
+
+
+# ── get_preview_duration ──────────────────────────────────
+
+
+class TestGetPreviewDuration:
+    """get_preview_duration clamps min(requested, total) to [3, 60]."""
+
+    def test_normal_request_within_range(self):
+        assert get_preview_duration(10.0, 120.0) == 10.0
+
+    def test_requested_exceeds_total(self):
+        """When total is shorter than requested, total wins."""
+        assert get_preview_duration(10.0, 5.0) == 5.0
+
+    def test_clamp_lower_bound(self):
+        """A request below 3s is clamped up to 3s."""
+        assert get_preview_duration(2.0, 120.0) == 3.0
+
+    def test_clamp_upper_bound(self):
+        """A request above 60s is clamped down to 60s."""
+        assert get_preview_duration(100.0, 120.0) == 60.0
+
+    def test_clamp_upper_bound_with_short_total(self):
+        """When total < 60 but requested > total, total wins (no upper clamp)."""
+        assert get_preview_duration(100.0, 50.0) == 50.0
+
+    def test_exact_lower_bound(self):
+        assert get_preview_duration(3.0, 120.0) == 3.0
+
+    def test_exact_upper_bound(self):
+        assert get_preview_duration(60.0, 120.0) == 60.0
+
+    def test_default_ten_seconds(self):
+        """The conventional 10s preview is returned unchanged for normal sources."""
+        assert get_preview_duration(10.0, 60.0) == 10.0
+
+    def test_very_large_request(self):
+        assert get_preview_duration(3600.0, 300.0) == 60.0
+
+    def test_returns_float(self):
+        result = get_preview_duration(10.0, 120.0)
+        assert isinstance(result, float)
+
+
+# ── should_skip_step_for_preview ──────────────────────────
+
+
+class TestShouldSkipStepForPreview:
+    """should_skip_step_for_preview only skips soft steps when preview is on."""
+
+    @pytest.mark.parametrize("step", [
+        "research_plot",
+        "translate_subtitles",
+        "run_qa_gate",
+        "export_clips",
+    ])
+    def test_soft_steps_skipped_in_preview(self, step):
+        assert should_skip_step_for_preview(step, True) is True
+
+    @pytest.mark.parametrize("step", [
+        "resolve_video",
+        "prepare_assets",
+        "generate_script",
+        "export_script_md",
+        "generate_voice",
+        "align_audio",
+        "detect_scenes",
+        "match_clips",
+        "mix_bgm",
+        "generate_subtitle",
+        "render_video",
+        "validate_deliverable",
+    ])
+    def test_hard_steps_never_skipped(self, step):
+        """Hard steps run even in preview mode."""
+        assert should_skip_step_for_preview(step, True) is False
+
+    @pytest.mark.parametrize("step", [
+        "research_plot",
+        "translate_subtitles",
+        "run_qa_gate",
+        "export_clips",
+        "generate_script",
+        "render_video",
+    ])
+    def test_nothing_skipped_when_preview_off(self, step):
+        """Preview off = nothing skipped (backward compatible)."""
+        assert should_skip_step_for_preview(step, False) is False
+
+    def test_unknown_step_not_skipped(self):
+        assert should_skip_step_for_preview("unknown_step", True) is False
+
+    def test_empty_string_not_skipped(self):
+        assert should_skip_step_for_preview("", True) is False

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 7, 1)
+        assert CONTRACT_VERSION == (0, 7, 2)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 7, 1)."""
+        """CONTRACT_VERSION is (0, 7, 2)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 7, 1)
+        assert CONTRACT_VERSION == (0, 7, 2)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""


### PR DESCRIPTION
## v0.7.2 — Preview Mode

### Added
- 10-second preview mode for fast iteration before full render
- `render_preview_mode` and `render_preview_sec` job parameters
- Preview mode skips non-essential steps (research, translate, QA, clips)
- Preview output named `preview.mp4` by default

### Changed
- Version bumped to 0.7.2, CONTRACT_VERSION to (0, 7, 2)