### PR TITLE
fix(queue): release lock before executor.shutdown (deadlock #127) + real scenedetect test (gap-A)

### DIFF
--- a/src/movie_narrator/cloud/queue.py
+++ b/src/movie_narrator/cloud/queue.py
@@ -157,12 +157,22 @@ class LocalTaskQueue:
         self._init_active_count()
 
     def shutdown(self, wait: bool = True) -> None:
-        """Shut down the executor."""
+        """Shut down the executor.
+
+        The executor is shut down *after* releasing ``self._lock`` so that
+        worker threads are not blocked from completing their ``finally``
+        blocks (which acquire the lock to decrement ``_active_count`` and
+        signal completion events). Holding the lock across
+        ``executor.shutdown(wait=True)`` deadlocks: the shutdown thread waits
+        for workers that are waiting for the lock. See issue #127.
+        """
+        executor = None
         with self._lock:
-            if self._executor:
-                self._executor.shutdown(wait=wait, cancel_futures=not wait)
-                self._executor = None
+            executor = self._executor
+            self._executor = None
             self._started = False
+        if executor is not None:
+            executor.shutdown(wait=wait, cancel_futures=not wait)
 
     # ── TaskQueue protocol ───────────────────────────────────
 

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -1074,15 +1074,6 @@ class TestIntegration:
         finally:
             queue.shutdown()
 
-    @pytest.mark.skip(
-        reason=(
-            "FLAKY / pre-existing hang under CI on Python 3.11: 3 concurrent tasks under "
-            "CI=1 trigger a real ffmpeg/asyncio race (pydub CouldntDecodeError), a worker "
-            "thread never reaches finally, its completion event is never set, and wait() "
-            "blocks until pytest-timeout (300s). Unrelated to the CI-fix PR. Real fix tracked "
-            "in https://github.com/zcbacxc/movie-narrator/issues/127"
-        )
-    )
     def test_multiple_tasks_concurrent(self, tmp_path, monkeypatch):
         """Submit multiple tasks and verify they all complete."""
         from movie_narrator.models import Context

--- a/tests/test_v062_gap6_concurrency.py
+++ b/tests/test_v062_gap6_concurrency.py
@@ -115,17 +115,6 @@ class TestActiveCountOptimization:
         finally:
             queue.shutdown()
 
-    @pytest.mark.skip(
-        reason=(
-            "Quarantined: under CI=1 this test submits 3 concurrent blockable "
-            "tasks to LocalTaskQueue(max_workers=4) and asserts active_count "
-            "returns to 0, but run_task performs real ffmpeg/asyncio work in "
-            "CI=1 that deadlocks in the sandbox (worker thread never reaches "
-            "finally -> active_count stuck at 1, wait() hangs past "
-            "pytest-timeout 300s). Pre-existing, masked by the prior lint "
-            "failure. Real fix tracked in #127."
-        )
-    )
     def test_active_count_multiple_concurrent(self, tmp_path, monkeypatch):
         """active_count tracks multiple concurrent tasks correctly."""
         block_event = threading.Event()

--- a/tests/test_v080_real_scenedetect.py
+++ b/tests/test_v080_real_scenedetect.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Real PySceneDetect end-to-end test (gap-A coverage).
+
+``tests/test_scenes.py`` only injects a *fake* scenedetect module, so it can
+run on the standard CI runner (which lacks the ``[media]`` extra). That leaves
+a real-library gap: regressions in the actual detection path — threshold
+wiring, scene-list parsing, ``scenes.json`` persistence, the MS-01 0-scene
+fallback — are never exercised against the genuine PySceneDetect / OpenCV
+backend.
+
+This module fills that gap. It is skipped automatically when PySceneDetect or
+OpenCV is unavailable (i.e. on CI); run it locally after
+``pip install "movie-narrator[media]"``.
+"""
+from pathlib import Path
+
+import pytest
+
+from movie_narrator.models import Context
+from movie_narrator.pipeline.scenes import detect_scenes
+from movie_narrator.utils.optional_deps import probe
+
+# ── Availability gate ─────────────────────────────────────────────
+_SCENEDET_OK, _ = probe("scenedetect")
+try:
+    import cv2  # noqa: F401  (PySceneDetect video backend)
+
+    _CV2_OK = True
+except Exception:  # noqa: BLE001
+    _CV2_OK = False
+
+pytestmark = pytest.mark.skipif(
+    not (_SCENEDET_OK and _CV2_OK),
+    reason="requires [media] extra (PySceneDetect + OpenCV); skipped in CI",
+)
+
+
+def _write_synthetic_video(path: Path, seconds: float = 2.0, fps: int = 30) -> None:
+    """Write a tiny mp4 with one clear mid-clip cut (black -> white)."""
+    import numpy as np
+
+    width, height = 320, 240
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, fps, (width, height))
+    n = int(round(seconds * fps))
+    for i in range(n):
+        # First half black, second half white -> one obvious cut near halfway.
+        color = 0 if i < n // 2 else 255
+        frame = np.full((height, width, 3), color, dtype=np.uint8)
+        writer.write(frame)
+    writer.release()
+
+
+def test_detect_scenes_real_end_to_end(tmp_path):
+    """Real PySceneDetect finds the synthetic cut and returns >=1 scene."""
+    video_path = tmp_path / "src.mp4"
+    _write_synthetic_video(video_path)
+
+    ctx = Context(
+        movie_name="real-scene-test",
+        output_dir=str(tmp_path),
+        source_video_path=str(video_path),
+    )
+    detect_scenes(ctx)
+
+    assert ctx.status.scene == "success"
+    # A clear black->white cut should yield at least 2 scenes.
+    assert len(ctx.scenes) >= 2
+    # scenes.json persisted for debugging.
+    assert (tmp_path / "scenes.json").exists()
+    # Not degraded — a real cut was detected.
+    assert ctx.metadata.get("scene_detection_degraded") is None
+
+
+def test_detect_scenes_real_low_contrast_fallback(tmp_path):
+    """Real detection on a flat (single-color) clip hits the MS-01 fallback."""
+    video_path = tmp_path / "flat.mp4"
+    import numpy as np
+
+    width, height = 320, 240
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(video_path), fourcc, 30, (width, height))
+    for _ in range(60):
+        writer.write(np.full((height, width, 3), 128, dtype=np.uint8))
+    writer.release()
+
+    ctx = Context(
+        movie_name="real-flat-test",
+        output_dir=str(tmp_path),
+        source_video_path=str(video_path),
+    )
+    detect_scenes(ctx)
+
+    assert ctx.status.scene == "success"
+    # MS-01: 0 cuts -> synthesized single full-length scene.
+    assert len(ctx.scenes) == 1
+    assert ctx.metadata.get("scene_detection_degraded") is True


### PR DESCRIPTION
# PR: fix LocalTaskQueue deadlock (#127) + real scenedetect integration test (gap-A)

## 1. Bug fix — `LocalTaskQueue.shutdown` deadlock (issue #127)

**Root cause (finally found via the pytest-timeout stack dump):**
`shutdown()` acquired `self._lock` and then called
`self._executor.shutdown(wait=True)` **while still holding the lock**.
Worker threads complete in their `_run_task_threadsafe` `finally` block,
which must acquire `self._lock` to decrement `_active_count` and signal the
completion event. So the shutdown thread waits for workers that are waiting
for the lock it holds → permanent deadlock → `wait()` blocks until
`pytest-timeout` (300s) kills the test.

This is why the two concurrent tests (`test_multiple_tasks_concurrent` on 3.11,
`test_active_count_multiple_concurrent` on 3.12) hung only under multi-concurrent
load — `shutdown(wait=True)` is hit while a worker is still finishing.

**Fix:** capture the executor reference under the lock, release the lock, then
shut the executor down. Workers can now finish their `finally` blocks.

```python
def shutdown(self, wait: bool = True) -> None:
    executor = None
    with self._lock:
        executor = self._executor
        self._executor = None
        self._started = False
    if executor is not None:
        executor.shutdown(wait=wait, cancel_futures=not wait)
```

**Verification:** the two previously-quarantined tests now pass (no deadlock).
The `@pytest.mark.skip` markers added in PR #126 are removed.

## 2. New test — real PySceneDetect end-to-end (gap-A)

`tests/test_scenes.py` only injects a *fake* scenedetect module, so the real
detection path (threshold wiring, scene-list parsing, `scenes.json` persistence,
MS-01 0-scene fallback) was never exercised against the genuine library.

`tests/test_v080_real_scenedetect.py` adds an end-to-end test that writes a tiny
synthetic mp4 (clear black→white cut, and a flat clip for the fallback) and runs
the **real** `detect_scenes`. It is skipped automatically when PySceneDetect /
OpenCV are unavailable (i.e. on CI); run locally after
`pip install "movie-narrator[media]"`.

## Files
- `src/movie_narrator/cloud/queue.py` — deadlock fix in `shutdown()`.
- `tests/test_v060_task_queue.py` — remove quarantine skip.
- `tests/test_v062_gap6_concurrency.py` — remove quarantine skip.
- `tests/test_v080_real_scenedetect.py` — new real-scenedetect integration test (gap-A).

## Note
#127 can be closed once this merges — the root cause is fixed, not just
quarantined.
