### PR TITLE
fix(queue): wait() must not short-circuit on terminal state (active_count race)

### DIFF
--- a/src/movie_narrator/cloud/queue.py
+++ b/src/movie_narrator/cloud/queue.py
@@ -290,13 +290,22 @@ class LocalTaskQueue:
         """
         start = time.time()
 
-        # Fast path: check if already terminal (handles already-completed
-        # tasks and cross-process scenarios where no Event is available)
+        # Load task metadata; a missing task cannot be waited on.
         task = self._storage.load(task_id)
         if not task:
             return None
-        if task.is_terminal:
-            return task.result if task.result else None
+
+        # NOTE: We deliberately do NOT short-circuit on ``task.is_terminal``
+        # here. The in-memory accounting (``active_count`` and
+        # ``_completion_events``) is only finalized inside the worker's
+        # ``finally`` block, which runs *after* the terminal state has been
+        # persisted to storage. Returning early on a terminal task would let
+        # a caller observe ``active_count`` before it has been decremented,
+        # producing intermittent ``active_count != 0`` races (see the
+        # active_count concurrency tests). Instead we always block on the
+        # completion Event below — it is set *after* the decrement — or fall
+        # back to storage polling only once the Event is already gone
+        # (which means the worker's finally has already run).
 
         # Try the in-process Event path (efficient, no busy-waiting)
         with self._lock:


### PR DESCRIPTION
## Summary
- `LocalTaskQueue.wait()` 之前在任务 storage 已终态时提前返回，但 in-memory 计数（`active_count` 与 completion events）只在 worker 的 `finally` 块里、终态落盘**之后**才最终化。提前返回会让调用方在 `active_count` 被 decrement 之前就观察到它，导致间歇性 `active_count != 0` 竞态。
- 移除 `is_terminal` 提前返回，强制走 completion Event 路径（Event 在 decrement 之后才 set），或仅当 Event 已消失（即 worker `finally` 已跑）才回退到 storage polling。
- 修复了 PR #128 解除 gap6 并发测试 quarantine 后在 main 上暴露的 flaky：`test_active_count_multiple_concurrent` 偶发 `assert active_count == 0` 实际为 1。

## Verification
- 本地对同一测试高频复现 50/50 全过；整个 `tests/test_v062_gap6_concurrency.py`（18 用例）连跑 20/20 全过，无回归。
- polling 分支的 `is_terminal` 检查保持原样，不影响 `wait()` 的跨进程/终态路径用例。

## Note
- 本次红 CI（run 30667241320）由 #128 引入的 flaky 测试触发，与 #127 死锁无关；#127 已随 #128 合并关闭。