### PR TITLE
docs: institutionalize golden sample regression (SOP + match_trend.py)

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -275,6 +275,46 @@ For a stronger first-second impact, write more powerful hooks in `hook_templates
 
 ---
 
+## Golden Sample Regression
+
+Generated videos can silently drift in quality across releases. Institutionalize a golden-sample regression so quality changes are caught *before* shipping, not after users report them.
+
+### When to Run
+
+- **Before every release** (at tag cut).
+- **On any PR that touches** `render`, `match`, `bgm`, `script`, or `tts`.
+
+### Sample Matrix
+
+| ID | Source | Aspect | Language | Why |
+|----|--------|--------|----------|-----|
+| G1 | Trailer / HD film | 16:9 | Chinese | Primary use case |
+| G2 | Trailer / HD film | 16:9 | English | Translation + TTS path |
+| G3 | Trailer / HD film | 9:16 | Chinese | Portrait publishing path |
+
+Archive each run under `output/l2-runs/<date>-<sample>-<sha>/` (local, gitignored) so trends stay comparable across versions.
+
+### Pass / Fail Thresholds
+
+Carried from the L2 hand-test acceptance (`§B.3.5`):
+
+- `match_summary.heuristic_ratio` ≤ 0.5
+- `match_summary.scenes_after_drop` ≥ 3
+- `speed_factor` must **not** be pinned at the clamp boundary (not exactly `match_speed_clamp_max` / `min`)
+
+### Tools
+
+- `scripts/compare_runs.py` — diff two `metadata.json` files (baseline vs new) for manual QA.
+- `scripts/match_trend.py` — scan all `output/l2-runs/*/metadata.json` and print a `heuristic_ratio` / `embedding_ratio` / `score.avg` / `speed_factor.avg` trend table; alerts when `heuristic_ratio` regresses by more than `0.1` between consecutive runs.
+
+```bash
+python scripts/match_trend.py --root output/l2-runs --warn-delta 0.1
+```
+
+Any run that pushes `heuristic_ratio` above threshold (or above the previous release's value by > 0.1) must be investigated before the release ships.
+
+---
+
 ## Quick Decision Tree
 
 ```
@@ -297,6 +337,7 @@ Output not good enough?
 | `scripts/llm_check.py` | Check LLM connectivity and response quality | LLM Selection |
 | `scripts/bgm_analyze.py` | Analyze BGM characteristics (BPM / energy / duration) | BGM Selection |
 | `scripts/genre_advisor.py` | Recommend preset and parameters by genre | Genre Routing |
+| `scripts/match_trend.py` | Trend analysis across regression runs (heuristic_ratio / embedding_ratio) | Golden Sample Regression |
 
 All tools are standalone scripts with no `movie_narrator` package dependency:
 

--- a/docs/BEST_PRACTICES.zh-CN.md
+++ b/docs/BEST_PRACTICES.zh-CN.md
@@ -275,6 +275,46 @@ params:
 
 ---
 
+## 黄金样片回归
+
+成片质量可能在版本间悄悄退化。把黄金样片回归制度化，让质量变化在**发版前**就被发现，而不是等用户反馈。
+
+### 何时运行
+
+- **每次发版前**（打 tag 时）。
+- **任何触及** `render`、`match`、`bgm`、`script`、`tts` **的 PR**。
+
+### 样片矩阵
+
+| ID | 源片 | 比例 | 语言 | 目的 |
+|----|------|------|------|------|
+| G1 | 预告片 / 高清正片 | 16:9 | 中文 | 主要使用场景 |
+| G2 | 预告片 / 高清正片 | 16:9 | 英文 | 翻译 + TTS 路径 |
+| G3 | 预告片 / 高清正片 | 9:16 | 中文 | 竖屏发布路径 |
+
+每次运行归档到 `output/l2-runs/<date>-<sample>-<sha>/`（本地，gitignored），保证跨版本可比。
+
+### 通过 / 失败阈值
+
+沿用 L2 手测验收（`§B.3.5`）：
+
+- `match_summary.heuristic_ratio` ≤ 0.5
+- `match_summary.scenes_after_drop` ≥ 3
+- `speed_factor` **不能**钉在 clamp 边界（不能正好等于 `match_speed_clamp_max` / `min`）
+
+### 工具
+
+- `scripts/compare_runs.py` — 对比两份 `metadata.json`（基线 vs 新版）用于人工 QA。
+- `scripts/match_trend.py` — 扫描全部 `output/l2-runs/*/metadata.json`，输出 `heuristic_ratio` / `embedding_ratio` / `score.avg` / `speed_factor.avg` 趋势表；相邻运行间 `heuristic_ratio` 回升超过 `0.1` 时告警。
+
+```bash
+python scripts/match_trend.py --root output/l2-runs --warn-delta 0.1
+```
+
+任何把 `heuristic_ratio` 推过阈值（或较上一版本回升 > 0.1）的运行，必须在发版前排查清楚。
+
+---
+
 ## 快速决策树
 
 ```
@@ -297,6 +337,7 @@ params:
 | `scripts/llm_check.py` | 检查 LLM 连通性和响应质量 | LLM 选择 |
 | `scripts/bgm_analyze.py` | 分析 BGM 特征（BPM/能量/时长） | BGM 选择 |
 | `scripts/genre_advisor.py` | 按片种推荐 preset 和参数 | 片种分流 |
+| `scripts/match_trend.py` | 回归样片趋势分析（heuristic_ratio / embedding_ratio） | 黄金样片回归 |
 
 所有工具均为独立脚本，不依赖 movie_narrator 包安装，可直接运行：
 

--- a/scripts/match_trend.py
+++ b/scripts/match_trend.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Trend analysis across golden-sample regression runs.
+
+Scans ``output/l2-runs/<run>/metadata.json`` and prints a trend table of
+match-quality metrics, alerting when ``heuristic_ratio`` regresses beyond a
+threshold between consecutive runs.
+
+Usage:
+    python scripts/match_trend.py [--root output/l2-runs] [--warn-delta 0.1]
+
+This tool is part of the Golden Sample Regression SOP (see
+``docs/BEST_PRACTICES.md``). It is standalone and does not import
+``movie_narrator``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ROOT = Path("output/l2-runs")
+WARN_DELTA = 0.1  # heuristic_ratio 环比回升超过此值即告警
+
+
+def safe_get(d: dict, *keys: str, default: Any = None) -> Any:
+    """Safely traverse nested dict keys (mirrors compare_runs.py)."""
+    cur: Any = d
+    for k in keys:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(k, default)
+    return cur
+
+
+def fmt(v: float | None) -> str:
+    return "-" if v is None else f"{v:.4f}"
+
+
+def load_runs(root: Path) -> list[tuple[str, dict[str, Any]]]:
+    """Return (run_name, metadata) for each run exposing metadata.json."""
+    runs: list[tuple[str, dict[str, Any]]] = []
+    if not root.exists():
+        print(f"WARN: regression root not found: {root}", file=sys.stderr)
+        return runs
+    for child in sorted(root.iterdir()):
+        meta = child / "metadata.json"
+        if child.is_dir() and meta.exists():
+            try:
+                with open(meta, encoding="utf-8") as f:
+                    runs.append((child.name, json.load(f)))
+            except (json.JSONDecodeError, OSError) as e:  # noqa: BLE001
+                print(f"WARN: skip {meta}: {e}", file=sys.stderr)
+    return runs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Trend analysis across golden-sample regression runs."
+    )
+    parser.add_argument(
+        "--root", default=str(DEFAULT_ROOT),
+        help=f"Regression runs root (default: {DEFAULT_ROOT})",
+    )
+    parser.add_argument(
+        "--warn-delta", type=float, default=WARN_DELTA,
+        help=f"heuristic_ratio ring-ratio alert threshold (default: {WARN_DELTA})",
+    )
+    args = parser.parse_args()
+
+    runs = load_runs(Path(args.root))
+    if not runs:
+        print("No regression runs found.")
+        return 0
+
+    print(f"# Match Trend - {len(runs)} runs from {args.root}\n")
+    print("| Run | heuristic_ratio | embedding_ratio | score.avg | "
+          "speed_factor.avg |")
+    print("|-----|-----------------|-----------------|-----------|"
+          "------------------|")
+
+    prev_hr: float | None = None
+    alerts: list[str] = []
+    for name, meta in runs:
+        ms = safe_get(meta, "match_summary", default={}) or {}
+        hr = ms.get("heuristic_ratio")
+        er = ms.get("embedding_ratio")
+        sa = safe_get(ms, "score", "avg")
+        sfa = safe_get(ms, "speed_factor", "avg")
+        print(f"| {name} | {fmt(hr)} | {fmt(er)} | {fmt(sa)} | {fmt(sfa)} |")
+
+        if prev_hr is not None and hr is not None:
+            delta = hr - prev_hr
+            if delta > args.warn_delta:
+                alerts.append(
+                    f"  [!] {name}: heuristic_ratio 环比回升 +{delta:.4f} "
+                    f"(> {args.warn_delta}) - match quality may have regressed"
+                )
+        prev_hr = hr
+
+    print()
+    if alerts:
+        print("## Alerts")
+        for a in alerts:
+            print(a)
+        print("\nAction: before releasing, re-check the flagged sample and "
+              "identify the PR that raised heuristic_ratio.")
+        return 1
+    print(f"OK: no heuristic_ratio ring-ratio regression beyond "
+          f"{args.warn_delta}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds a bilingual **Golden Sample Regression** SOP section to `docs/BEST_PRACTICES.md` (EN) and `docs/BEST_PRACTICES.zh-CN.md` (ZH), closing **GAP-8** of the v0.8.0 localization assessment.
- Adds `scripts/match_trend.py`: scans `output/l2-runs/*/metadata.json`, prints a `heuristic_ratio` / `embedding_ratio` / `score.avg` / `speed_factor.avg` trend table, and warns when `heuristic_ratio` rebounds > 0.1 versus the previous run.
- Registers `match_trend.py` in the BEST_PRACTICES helper-tools table (both languages).

## Why

Output quality can silently regress between versions. Institutionalizing a golden-sample regression makes quality drift visible **before release** rather than via user feedback. The SOP reuses existing assets (`match_summary` / `qa_report` / `script_target_count` already exported to `metadata.json`) and the matured §B.3.5 read thresholds (heuristic_ratio ≤ 0.5, scenes_after_drop ≥ 3, speed not clamped).

## Test plan

- [x] `python scripts/match_trend.py --help` works; dry run on an existing `output/l2-runs/*/` directory prints the trend table or "no runs found" without crashing.
- [x] Bilingual SOP sections present and aligned (EN / ZH).

Closes GAP-8.
