### PR TITLE
release: v0.8.1 — observability (structured JSON logging + Prometheus /metrics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,20 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # When unset, the server runs unauthenticated — safe only on loopback (127.0.0.1).
 # Clients must send this value in the X-API-Key HTTP header.
 # MN_API_KEY=your-secret-api-key
+
+# ============================================================
+# Observability (v0.8.1)
+# ============================================================
+# Structured logging and Prometheus metrics for the API server.
+# See docs/OBSERVABILITY.md (English) / docs/OBSERVABILITY.zh-CN.md.
+
+# Log format: "json" for structured JSON lines (ELK/Loki/CloudWatch),
+# or "text" for human-readable output (default).
+# MN_LOG_FORMAT=text
+
+# Root log level: DEBUG, INFO (default), WARNING, ERROR.
+# MN_LOG_LEVEL=INFO
+
+# Set to 1/true/yes/on to expose GET /metrics WITHOUT an API key.
+# Off by default — the metrics payload leaks task volumes and error rates.
+# MN_METRICS_PUBLIC=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-03
+
+### Added
+
+- **Structured logging** — opt-in JSON log format with correlation IDs. New `movie_narrator.utils.logging_config` module provides `JsonFormatter`, a `contextvars`-backed correlation ID (`set_correlation_id`, `get_correlation_id`, `new_correlation_id`, `correlation_scope`) and an idempotent `configure_logging()`. Enable with `mn serve --log-format json` or `MN_LOG_FORMAT=json`; level via `--log-level` or `MN_LOG_LEVEL`.
+- The API server accepts an inbound `X-Request-ID` / `X-Correlation-ID` header (generating one when absent), binds it for the duration of the request, echoes it back as `X-Correlation-ID` on every response, and propagates it to the worker so task logs share the same ID.
+- `Task.correlation_id` optional field for backward-compatible task persistence.
+- **Prometheus metrics** — new `GET /metrics` endpoint rendering the Prometheus text exposition format v0.0.4. Exposes `mn_build_info`, `mn_tasks_total{status}`, `mn_queue_depth`, `mn_active_tasks`, `mn_task_duration_seconds`, `mn_render_duration_seconds`, `mn_errors_total{type}` and `mn_http_requests_total{method,path,code}`. HTTP paths are recorded as route templates to bound label cardinality. Authenticated like other endpoints by default; set `MN_METRICS_PUBLIC=1` for unauthenticated in-cluster scraping.
+- Dependency-free metrics primitives (`Counter`, `Gauge`, `Histogram`, `MetricsRegistry`) in `movie_narrator.cloud.metrics`, exported via the SDK.
+- `docs/OBSERVABILITY.md` and `docs/OBSERVABILITY.zh-CN.md` — bilingual observability guide.
+- `tests/test_v081_logging.py` and `tests/test_v081_metrics.py` — 34 test cases covering JSON rendering, cross-thread correlation propagation, metric primitives, exposition-format escaping and route-template mapping.
+
+### Changed
+
+- `CONTRACT_VERSION` bumped from (0, 8, 0) to (0, 8, 1).
+
 ## [0.8.0] - 2026-07-31
 
 ### Added

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,135 @@
+[![English](https://img.shields.io/badge/English-Observability-blue)](OBSERVABILITY.md)
+[![简体中文](https://img.shields.io/badge/简体中文-可观测性-green)](OBSERVABILITY.zh-CN.md)
+
+# Observability (v0.8.1)
+
+> Structured logging and Prometheus metrics for the `mn serve` API server.
+> No new third-party dependencies — the JSON formatter and the metrics
+> renderer are implemented with the Python standard library only.
+
+## 1. Structured logging
+
+### 1.1 JSON mode
+
+By default the server emits human-readable text lines. Enable JSON to
+ship logs to ELK / Loki / CloudWatch without a grok pattern:
+
+```bash
+mn serve --log-format json
+# or
+export MN_LOG_FORMAT=json
+mn serve
+```
+
+Each line is a single JSON object with a stable key set:
+
+| Key              | Present            | Meaning                                   |
+|------------------|--------------------|-------------------------------------------|
+| `ts`             | always             | ISO-8601 UTC, millisecond precision (`Z`) |
+| `level`          | always             | level name (`INFO`, `ERROR`, …)           |
+| `logger`         | always             | logger name                               |
+| `msg`            | always             | interpolated message                      |
+| `correlation_id` | when bound         | ties records of one unit of work together |
+| `exc_type`       | on exception       | exception class name                      |
+| `exc_message`    | on exception       | `str(exc)`                                |
+| `traceback`      | on exception       | formatted traceback                       |
+| `<extra>`        | when provided      | any field passed via `extra=`             |
+
+`correlation_id` is **omitted** (not `null`) when no ID is bound, so
+un-correlated lines stay compact.
+
+### 1.2 Correlation IDs
+
+A `contextvars.ContextVar` carries a 12-hex-char correlation ID across
+threads. The API server adopts an inbound ID from the `X-Request-ID` or
+`X-Correlation-ID` request header (so an upstream trace continues here),
+otherwise it generates a fresh one. Every response echoes the active ID
+in the `X-Correlation-ID` header. The ID also propagates from a
+submitted task into its worker thread, so the request log, the
+`/tasks/{id}` log, and the worker log all share one ID.
+
+In application code:
+
+```python
+from movie_narrator.utils.logging_config import correlation_scope, get_correlation_id
+
+with correlation_scope() as cid:
+    logger.info("handling request")  # record carries cid
+```
+
+### 1.3 Log level
+
+```bash
+mn serve --log-level DEBUG
+# or
+export MN_LOG_LEVEL=DEBUG
+```
+
+Default: `INFO`. Server logs default to INFO even though pipeline runs
+default lower, to avoid flooding long-running services.
+
+## 2. Prometheus metrics
+
+### 2.1 Endpoint
+
+`GET /metrics` serves the text exposition format (version `0.0.4`).
+
+The endpoint is **authenticated by default** — the payload leaks task
+volumes and error rates. Send the same `X-API-Key` as every other route.
+To let in-cluster scrapers without a secret, opt out:
+
+```bash
+export MN_METRICS_PUBLIC=1   # 1/true/yes/on
+```
+
+### 2.2 Metric families
+
+| Name                            | Type       | Labels                          | Description                          |
+|---------------------------------|------------|---------------------------------|--------------------------------------|
+| `mn_build_info`                 | gauge      | `version`                       | constant `1` with the version label  |
+| `mn_tasks_total`                | counter    | `status`                        | tasks by lifecycle status            |
+| `mn_queue_depth`                | gauge      | —                               | pending tasks                        |
+| `mn_active_tasks`               | gauge      | —                               | currently executing tasks            |
+| `mn_task_duration_seconds`      | histogram  | —                               | end-to-end task duration             |
+| `mn_render_duration_seconds`     | histogram  | —                               | `render_video` step duration         |
+| `mn_errors_total`               | counter    | `type`                          | errors by coarse type (`http_401`, …)|
+| `mn_http_requests_total`        | counter    | `method`, `path`, `code`        | HTTP requests (path is a template)   |
+
+Histograms use buckets (seconds):
+`0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800`.
+
+The `mn_http_requests_total` `path` label is always a **route template**
+(e.g. `/tasks/{id}`), never a concrete path containing an ID, so
+cardinality stays bounded. Unrecognised paths collapse to `/other`.
+
+### 2.3 Sample scrape config
+
+```yaml
+scrape_configs:
+  - job_name: movie-narrator
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /run/secrets/mn-api-key   # when MN_METRICS_PUBLIC != 1
+    static_configs:
+      - targets: ['movie-narrator:8765']
+```
+
+### 2.4 Note on helpers
+
+Every `record_*` / `observe_*` / `set_*` helper is best-effort: a
+telemetry failure is swallowed and debug-logged, never propagated, so it
+can never break a request or kill a worker thread.
+
+## 3. Programmatic access
+
+```python
+from movie_narrator.cloud import metrics
+
+metrics.record_task_submitted()
+text = metrics.render_prometheus_text()
+```
+
+```python
+from movie_narrator.utils.logging_config import configure_logging, JsonFormatter
+```

--- a/docs/OBSERVABILITY.zh-CN.md
+++ b/docs/OBSERVABILITY.zh-CN.md
@@ -1,0 +1,119 @@
+[![English](https://img.shields.io/badge/English-Observability-blue)](OBSERVABILITY.md)
+[![简体中文](https://img.shields.io/badge/简体中文-可观测性-green)](OBSERVABILITY.zh-CN.md)
+
+# 可观测性（v0.8.1）
+
+> 面向 `mn serve` API 服务的结构化日志与 Prometheus 指标。
+> 不引入任何新的第三方依赖——JSON 格式化器与指标渲染器仅使用 Python 标准库实现。
+
+## 1. 结构化日志
+
+### 1.1 JSON 模式
+
+默认情况下服务输出人类可读的文本日志。开启 JSON 模式以便将日志发送到 ELK / Loki / CloudWatch，无需编写 grok 解析规则：
+
+```bash
+mn serve --log-format json
+# 或
+export MN_LOG_FORMAT=json
+mn serve
+```
+
+每行是一个独立的 JSON 对象，键集合固定：
+
+| 键                | 出现条件       | 含义                                      |
+|-------------------|----------------|-------------------------------------------|
+| `ts`              | 始终           | ISO-8601 UTC，毫秒精度（`Z` 后缀）         |
+| `level`           | 始终           | 级别名称（`INFO`、`ERROR` 等）             |
+| `logger`          | 始终           | 日志器名称                                |
+| `msg`             | 始终           | 已插值的消息                              |
+| `correlation_id`  | 绑定后         | 串联同一工作单元所有记录                  |
+| `exc_type`        | 异常时         | 异常类名                                  |
+| `exc_message`     | 异常时         | `str(exc)`                                |
+| `traceback`       | 异常时         | 格式化后的堆栈                             |
+| `<extra>`         | 提供时         | 通过 `extra=` 传入的任意字段               |
+
+当未绑定关联 ID 时，`correlation_id` 会被**省略**（而不是输出 `null`），以保持无关联行简洁。
+
+### 1.2 关联 ID（Correlation ID）
+
+`contextvars.ContextVar` 会跨线程携带 12 位十六进制关联 ID。API 服务优先采用请求头 `X-Request-ID` 或 `X-Correlation-ID` 中的入站 ID（以便上游链路在此延续），否则生成新的 ID。每个响应都会通过 `X-Correlation-ID` 响应头回显当前 ID。该 ID 还会从已提交的任务传播到其工作线程，因此请求日志、`/tasks/{id}` 日志与工作线程日志共享同一 ID。
+
+在应用代码中：
+
+```python
+from movie_narrator.utils.logging_config import correlation_scope, get_correlation_id
+
+with correlation_scope() as cid:
+    logger.info("处理请求")  # 记录携带 cid
+```
+
+### 1.3 日志级别
+
+```bash
+mn serve --log-level DEBUG
+# 或
+export MN_LOG_LEVEL=DEBUG
+```
+
+默认：`INFO`。服务日志默认为 INFO（即便流水线运行默认更低），以避免长时间运行的服务被日志淹没。
+
+## 2. Prometheus 指标
+
+### 2.1 端点
+
+`GET /metrics` 提供文本暴露格式（版本 `0.0.4`）。
+
+该端点**默认需要鉴权**——其负载会泄露任务量与错误率。发送与其他路由相同的 `X-API-Key`。若希望集群内 scraper 无需密钥即可抓取，可关闭鉴权：
+
+```bash
+export MN_METRICS_PUBLIC=1   # 1/true/yes/on
+```
+
+### 2.2 指标族
+
+| 名称                            | 类型       | 标签                            | 说明                                 |
+|---------------------------------|------------|---------------------------------|--------------------------------------|
+| `mn_build_info`                 | gauge      | `version`                       | 常量 `1`，带版本标签                 |
+| `mn_tasks_total`                | counter    | `status`                        | 按生命周期状态统计的任务数           |
+| `mn_queue_depth`                | gauge      | —                               | 等待中的任务数                       |
+| `mn_active_tasks`               | gauge      | —                               | 当前正在执行的任务数                 |
+| `mn_task_duration_seconds`      | histogram  | —                               | 端到端任务耗时                       |
+| `mn_render_duration_seconds`     | histogram  | —                               | `render_video` 步骤耗时              |
+| `mn_errors_total`               | counter    | `type`                          | 按粗粒度类型统计的错误（`http_401` 等）|
+| `mn_http_requests_total`        | counter    | `method`, `path`, `code`        | HTTP 请求（`path` 为路由模板）       |
+
+直方图分桶（秒）：
+`0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800`。
+
+`mn_http_requests_total` 的 `path` 标签始终是**路由模板**（如 `/tasks/{id}`），绝不会是包含具体 ID 的路径，从而保持基数可控。无法识别的路径会被折叠为 `/other`。
+
+### 2.3 抓取配置示例
+
+```yaml
+scrape_configs:
+  - job_name: movie-narrator
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /run/secrets/mn-api-key   # 当 MN_METRICS_PUBLIC != 1 时
+    static_configs:
+      - targets: ['movie-narrator:8765']
+```
+
+### 2.4 关于辅助函数的说明
+
+所有 `record_*` / `observe_*` / `set_*` 辅助函数都是尽力而为的：遥测失败会被吞掉并记录为 debug 日志，绝不会向上抛出，因此永远不会破坏请求或终止工作线程。
+
+## 3. 编程式访问
+
+```python
+from movie_narrator.cloud import metrics
+
+metrics.record_task_submitted()
+text = metrics.render_prometheus_text()
+```
+
+```python
+from movie_narrator.utils.logging_config import configure_logging, JsonFormatter
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,8 +53,8 @@ The original v0.6.2–v0.6.4 plan (distributed rendering, API gateway & auth, cl
 - [ ] docker-compose.yml — local cluster (API + N workers + storage)
 - [ ] Storage backend abstraction — `StorageBackend` protocol (local / S3)
 - [ ] Artifact lifecycle — TTL-based cleanup
-- [ ] Structured logging — JSON format with correlation IDs
-- [ ] Prometheus metrics — `/metrics` endpoint (task count, queue depth, render duration, error rate)
+- [x] Structured logging — JSON format with correlation IDs (v0.8.1)
+- [x] Prometheus metrics — `/metrics` endpoint (task count, queue depth, render duration, error rate) (v0.8.1)
 - [ ] Health/readiness probes — `/ready` endpoint + deep health check with dependency connectivity (`/health` already exists in v0.6.1)
 - [ ] OpenAPI spec — auto-generated API documentation
 

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -53,8 +53,8 @@
 - [ ] docker-compose.yml — 本地集群（API + N workers + 存储）
 - [ ] 存储后端抽象 — `StorageBackend` 协议（local / S3）
 - [ ] 产物生命周期 — 基于 TTL 的清理
-- [ ] 结构化日志 — JSON 格式，带关联 ID
-- [ ] Prometheus 指标 — `/metrics` 端点（任务数、队列深度、渲染时长、错误率）
+- [x] 结构化日志 — JSON 格式，带关联 ID（v0.8.1）
+- [x] Prometheus 指标 — `/metrics` 端点（任务数、队列深度、渲染时长、错误率）（v0.8.1）
 - [ ] 健康/就绪探针 — `/ready` 端点 + 带依赖连通性的深度健康检查（`/health` 已在 v0.6.1 实现）
 - [ ] OpenAPI 规范 — 自动生成的 API 文档
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.8.0"
+version = "0.8.1"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -1328,6 +1328,14 @@ def serve(
         False, "--insecure",
         help="Allow starting on public interface without API key (not recommended).",
     ),
+    log_format: Optional[str] = typer.Option(
+        None, "--log-format",
+        help="日志格式 / Log format: text|json (default: MN_LOG_FORMAT, else text).",
+    ),
+    log_level: Optional[str] = typer.Option(
+        None, "--log-level",
+        help="日志级别 / Log level: DEBUG|INFO|WARNING|ERROR (default: MN_LOG_LEVEL, else INFO).",
+    ),
 ):
     """启动远程推理服务 / Start the remote inference API server.
 
@@ -1350,10 +1358,29 @@ def serve(
     MN_API_KEY 环境变量),否则拒绝启动. 使用 --insecure 可跳过此
     安��检查(不推荐).
     v0.8.0 已增加 X-API-Key 认证支持,通过 --api-key 启用.
+
+    \b
+    v0.8.1 观测性 / Observability:
+        mn serve --log-format json --log-level INFO
+        GET /metrics — Prometheus 指标(默认需 X-API-Key;
+        设置 MN_METRICS_PUBLIC=1 可免认证供集群内抓取).
+        每个响应都会回显 X-Correlation-ID.
     """
     from .cloud import run_daemon
     from .config import get_settings
+    from .utils.logging_config import configure_logging
     from pathlib import Path
+
+    # v0.8.1: configure structured logging before anything can log.
+    # Flags are left at None by default so MN_LOG_FORMAT / MN_LOG_LEVEL
+    # still apply; an explicit flag overrides the environment.
+    if log_format is not None and log_format.lower() not in {"text", "json"}:
+        typer.echo("--log-format must be 'text' or 'json'", err=True)
+        raise typer.Exit(2)
+    configure_logging(
+        json_mode=(log_format.lower() == "json") if log_format else None,
+        level=log_level,
+    )
 
     if public:
         host = "0.0.0.0"

--- a/src/movie_narrator/cloud/__init__.py
+++ b/src/movie_narrator/cloud/__init__.py
@@ -15,6 +15,8 @@ are:
 - ``ProgressConsole`` — progress-tracking console wrapper
 - ``run_task`` — pipeline execution with retry support
 - ``run_daemon`` / ``WorkerDaemon`` — server-side worker process (v0.6.1)
+- ``metrics`` — Prometheus counters/gauges/histograms and the text
+  exposition renderer behind ``GET /metrics`` (v0.8.1)
 
 Typical usage (local)::
 
@@ -35,6 +37,15 @@ Typical usage (remote)::
 
 from __future__ import annotations
 
+from .metrics import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Gauge,
+    Histogram,
+    MetricsRegistry,
+    get_registry,
+    render_prometheus_text,
+)
 from .models import (
     ACTIVE_STATES,
     TERMINAL_STATES,
@@ -93,4 +104,12 @@ __all__ = [
     # Remote providers (v0.6.1)
     "register_remote_llm",
     "register_remote_tts",
+    # Metrics (v0.8.1)
+    "CONTENT_TYPE_LATEST",
+    "Counter",
+    "Gauge",
+    "Histogram",
+    "MetricsRegistry",
+    "get_registry",
+    "render_prometheus_text",
 ]

--- a/src/movie_narrator/cloud/api.py
+++ b/src/movie_narrator/cloud/api.py
@@ -19,6 +19,7 @@ Endpoints::
     GET    /tasks/{id}/download/{file}  — download an output file
     GET    /health                      — health check
     GET    /info                        — server info (version, worker count)
+    GET    /metrics                     — Prometheus metrics (v0.8.1)
 
 Typical usage::
 
@@ -33,13 +34,26 @@ from __future__ import annotations
 import hmac
 import json
 import logging
+import os
 import re
 import threading
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from .. import __version__
+from ..utils.logging_config import (
+    CORRELATION_HEADER,
+    REQUEST_ID_HEADER,
+    correlation_scope,
+    get_correlation_id,
+)
+from .metrics import (
+    CONTENT_TYPE_LATEST,
+    record_error,
+    record_http_request,
+    render_prometheus_text,
+)
 from .models import Task, TaskRequest, TaskStatus
 from .queue import LocalTaskQueue
 
@@ -51,6 +65,54 @@ _TASK_PATTERN = re.compile(r"^/tasks/([a-f0-9]+)$")
 _TASK_RESULT_PATTERN = re.compile(r"^/tasks/([a-f0-9]+)/result$")
 _TASK_ARTIFACTS_PATTERN = re.compile(r"^/tasks/([a-f0-9]+)/artifacts$")
 _TASK_DOWNLOAD_PATTERN = re.compile(r"^/tasks/([a-f0-9]+)/download/(.+)$")
+
+# ── Observability (v0.8.1) ─────────────────────────────────
+
+_METRICS_PATH = "/metrics"
+
+#: Environment variable opting ``/metrics`` out of API-key auth.
+_ENV_METRICS_PUBLIC = "MN_METRICS_PUBLIC"
+
+#: Paths that are already templates (no variable segment).
+_STATIC_PATHS = frozenset({"/health", "/info", "/tasks", _METRICS_PATH})
+
+#: Concrete path -> route template. Labelling the HTTP metric with the
+#: raw path would give every task ID its own time series, so each match
+#: is folded back into the template that produced it. Order matters:
+#: ``_TASK_PATTERN`` is last because it is the least specific.
+_ROUTE_TEMPLATES = (
+    (_TASK_RESULT_PATTERN, "/tasks/{id}/result"),
+    (_TASK_ARTIFACTS_PATTERN, "/tasks/{id}/artifacts"),
+    (_TASK_DOWNLOAD_PATTERN, "/tasks/{id}/download/{filename}"),
+    (_TASK_PATTERN, "/tasks/{id}"),
+)
+
+
+def _route_template(path: str) -> str:
+    """Map a concrete request path onto a bounded route template.
+
+    Unrecognised paths collapse to ``/other`` so that a scanner probing
+    random URLs cannot grow the metric's cardinality without bound.
+    """
+    if path in _STATIC_PATHS:
+        return path
+    for pattern, template in _ROUTE_TEMPLATES:
+        if pattern.match(path):
+            return template
+    return "/other"
+
+
+def _metrics_public() -> bool:
+    """Whether ``/metrics`` may be scraped without an API key.
+
+    In-cluster Prometheus scrapers usually cannot present a secret, so
+    ``MN_METRICS_PUBLIC=1`` opts the endpoint out of authentication.
+    It stays authenticated by default: the payload leaks task volumes
+    and error rates.
+    """
+    return os.environ.get(_ENV_METRICS_PUBLIC, "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
 
 
 class _APIHandler(BaseHTTPRequestHandler):
@@ -94,6 +156,60 @@ class _APIHandler(BaseHTTPRequestHandler):
         """Send an error response."""
         self._send_json({"error": message}, status=status)
 
+    # ── Observability (v0.8.1) ──────────────────────────────
+
+    def _dispatch(self, handler: Callable[[], None]) -> None:
+        """Run one request inside a correlation scope.
+
+        The ID is adopted from ``X-Request-ID`` / ``X-Correlation-ID``
+        when the client supplies one, so a trace started upstream (load
+        balancer, another service) continues here; otherwise a fresh one
+        is generated. :meth:`send_response` echoes it on every response.
+        """
+        inbound = (
+            self.headers.get(REQUEST_ID_HEADER)
+            or self.headers.get(CORRELATION_HEADER)
+            or None
+        )
+        with correlation_scope(inbound):
+            handler()
+
+    def send_response(self, code: int, message: Optional[str] = None) -> None:
+        """Echo the correlation ID and count the request.
+
+        Overriding the single point every response funnels through —
+        including ``send_error`` and the artifact download path — means
+        the header and the metric cannot be forgotten at a call site.
+        """
+        super().send_response(code, message)
+        correlation_id = get_correlation_id()
+        if correlation_id:
+            self.send_header(CORRELATION_HEADER, correlation_id)
+        try:
+            # ``path`` / ``command`` are unset when the request line
+            # itself failed to parse, hence the broad guard.
+            path = self.path.split("?")[0]
+            status = int(code)
+            record_http_request(self.command or "", _route_template(path), status)
+            if status >= 400:
+                record_error(f"http_{status}")
+        except Exception:  # noqa: BLE001 — telemetry must never break a response
+            logger.debug("Failed to record request metrics", exc_info=True)
+
+    def _send_metrics(self) -> None:
+        """Serve the Prometheus text exposition payload."""
+        try:
+            body = render_prometheus_text().encode("utf-8")
+        except Exception:  # noqa: BLE001 — a bad scrape must not take the server down
+            logger.exception("Failed to render metrics")
+            self._send_error(HTTPStatus.INTERNAL_SERVER_ERROR, "metrics unavailable")
+            return
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     @property
     def queue(self) -> LocalTaskQueue:
         """Access the task queue from the server instance."""
@@ -128,11 +244,22 @@ class _APIHandler(BaseHTTPRequestHandler):
     # ── GET ─────────────────────────────────────────────────
 
     def do_GET(self) -> None:
+        self._dispatch(self._do_GET)
+
+    def _do_GET(self) -> None:
         path = self.path.split("?")[0]
 
         # Health check — exempt from authentication (always allowed)
         if path == "/health":
             self._send_json({"status": "ok"})
+            return
+
+        # Metrics (v0.8.1) — authenticated like every other route unless
+        # MN_METRICS_PUBLIC opts in to unauthenticated scraping.
+        if path == _METRICS_PATH:
+            if not _metrics_public() and not self._check_auth():
+                return
+            self._send_metrics()
             return
 
         # Authenticate all other routes
@@ -217,6 +344,9 @@ class _APIHandler(BaseHTTPRequestHandler):
     # ── POST ────────────────────────────────────────────────
 
     def do_POST(self) -> None:
+        self._dispatch(self._do_POST)
+
+    def _do_POST(self) -> None:
         path = self.path.split("?")[0]
 
         # Authenticate all routes
@@ -233,6 +363,7 @@ class _APIHandler(BaseHTTPRequestHandler):
             try:
                 request = TaskRequest(**body)
             except Exception as e:  # noqa: BLE001
+                logger.debug("POST /tasks rejected: invalid TaskRequest payload: %s", e)
                 self._send_error(HTTPStatus.BAD_REQUEST, f"Invalid task request: {e}")
                 return
 
@@ -248,6 +379,9 @@ class _APIHandler(BaseHTTPRequestHandler):
     # ── DELETE ──────────────────────────────────────────────
 
     def do_DELETE(self) -> None:
+        self._dispatch(self._do_DELETE)
+
+    def _do_DELETE(self) -> None:
         path = self.path.split("?")[0]
 
         # Authenticate all routes
@@ -331,6 +465,7 @@ class _APIHandler(BaseHTTPRequestHandler):
                 self._send_error(HTTPStatus.FORBIDDEN, "Access denied")
                 return
         except Exception:  # noqa: BLE001
+            logger.debug("Rejected artifact download: unsafe path %r failed resolution", filename)
             self._send_error(HTTPStatus.BAD_REQUEST, "Invalid filename")
             return
 

--- a/src/movie_narrator/cloud/metrics.py
+++ b/src/movie_narrator/cloud/metrics.py
@@ -1,0 +1,661 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Prometheus metrics registry and exposition renderer (v0.8.1).
+
+A deliberately small, dependency-free implementation of the three
+metric types the project actually needs — Counter, Gauge and Histogram
+— plus a renderer for the Prometheus text exposition format (version
+0.0.4). Taking ``prometheus_client`` as a hard dependency would be
+disproportionate: the exposition format is a handful of lines of text,
+and the scrape path is not performance critical.
+
+All metrics share a single registry-wide lock. Contention is negligible
+because every operation is a dict lookup plus an arithmetic update,
+whereas per-metric locks would complicate taking a consistent snapshot
+during a scrape.
+
+Instrumentation helpers (``record_*`` / ``observe_*`` / ``set_*``) never
+raise: telemetry must not be able to fail a request or kill a worker
+thread. They swallow and debug-log any error instead.
+
+Typical usage::
+
+    from movie_narrator.cloud import metrics
+
+    metrics.record_task_submitted()
+    body = metrics.render_prometheus_text()
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, TypeVar
+
+from .. import __version__
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ACTIVE_TASKS",
+    "BUILD_INFO",
+    "CONTENT_TYPE_LATEST",
+    "Counter",
+    "DEFAULT_DURATION_BUCKETS",
+    "ERRORS_TOTAL",
+    "Gauge",
+    "HTTP_REQUESTS_TOTAL",
+    "Histogram",
+    "MetricsRegistry",
+    "QUEUE_DEPTH",
+    "RENDER_DURATION",
+    "TASKS_TOTAL",
+    "TASK_DURATION",
+    "get_registry",
+    "observe_render_duration",
+    "observe_task_duration",
+    "record_error",
+    "record_http_request",
+    "record_task_submitted",
+    "record_task_terminal",
+    "render_prometheus_text",
+    "reset_registry",
+    "set_active_tasks",
+    "set_queue_depth",
+]
+
+#: Content-Type Prometheus scrapers expect for the text format.
+CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+# ── Metric family names ────────────────────────────────────
+
+BUILD_INFO = "mn_build_info"
+TASKS_TOTAL = "mn_tasks_total"
+QUEUE_DEPTH = "mn_queue_depth"
+ACTIVE_TASKS = "mn_active_tasks"
+TASK_DURATION = "mn_task_duration_seconds"
+RENDER_DURATION = "mn_render_duration_seconds"
+ERRORS_TOTAL = "mn_errors_total"
+HTTP_REQUESTS_TOTAL = "mn_http_requests_total"
+
+#: Bucket boundaries (seconds) tuned for end-to-end pipeline runs, which
+#: span from a few seconds (fully cached, no render) to tens of minutes.
+DEFAULT_DURATION_BUCKETS: Tuple[float, ...] = (
+    0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0,
+)
+
+_LabelKey = Tuple[str, ...]
+
+
+# ── Escaping helpers ───────────────────────────────────────
+
+
+def _escape_help(text: str) -> str:
+    """Escape a HELP string: backslash and newline only (per spec)."""
+    return text.replace("\\", "\\\\").replace("\n", "\\n")
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape a label value: backslash, double quote and newline."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+    )
+
+
+def _format_float(value: float) -> str:
+    """Render a float the way Prometheus expects.
+
+    Integral values lose the fractional part, and the infinities use the
+    ``+Inf`` / ``-Inf`` spellings the exposition format mandates.
+    """
+    if value == float("inf"):
+        return "+Inf"
+    if value == float("-inf"):
+        return "-Inf"
+    if value != value:  # NaN
+        return "NaN"
+    if float(value).is_integer() and abs(value) < 1e15:
+        return str(int(value))
+    return repr(float(value))
+
+
+def _render_labels(
+    label_names: Sequence[str],
+    label_values: Sequence[str],
+    extra: Optional[Tuple[str, str]] = None,
+) -> str:
+    """Build the ``{k="v",...}`` suffix for a sample line."""
+    parts = [
+        f'{name}="{_escape_label_value(value)}"'
+        for name, value in zip(label_names, label_values)
+    ]
+    if extra is not None:
+        parts.append(f'{extra[0]}="{_escape_label_value(extra[1])}"')
+    if not parts:
+        return ""
+    return "{" + ",".join(parts) + "}"
+
+
+# ── Metric base ────────────────────────────────────────────
+
+
+class _Metric:
+    """Common state for all metric types.
+
+    Args:
+        name: Metric family name (must be a valid Prometheus name).
+        help_text: One-line description emitted as ``# HELP``.
+        label_names: Ordered label names; every sample must supply
+            exactly these labels.
+        lock: Registry-wide lock shared by all metrics.
+    """
+
+    metric_type = "untyped"
+
+    def __init__(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+        lock: Optional[threading.Lock] = None,
+    ) -> None:
+        self.name = name
+        self.help_text = help_text or name
+        self.label_names: Tuple[str, ...] = tuple(label_names)
+        self._lock = lock or threading.Lock()
+
+    def _key(self, labels: Optional[Dict[str, str]]) -> _LabelKey:
+        """Normalise a label mapping into an ordered tuple key.
+
+        Mismatched label sets raise rather than being coerced: a typo
+        would otherwise silently split one time series into two.
+        """
+        if not self.label_names:
+            if labels:
+                raise ValueError(f"Metric {self.name!r} takes no labels")
+            return ()
+        labels = labels or {}
+        missing = set(self.label_names) - set(labels)
+        if missing:
+            raise ValueError(
+                f"Metric {self.name!r} missing labels: {sorted(missing)}"
+            )
+        unexpected = set(labels) - set(self.label_names)
+        if unexpected:
+            raise ValueError(
+                f"Metric {self.name!r} got unexpected labels: {sorted(unexpected)}"
+            )
+        return tuple(str(labels[n]) for n in self.label_names)
+
+    def render(self) -> List[str]:
+        """Render this metric family as exposition-format sample lines."""
+        raise NotImplementedError
+
+
+# ── Counter ────────────────────────────────────────────────
+
+
+class Counter(_Metric):
+    """Monotonically increasing cumulative value."""
+
+    metric_type = "counter"
+
+    def __init__(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+        lock: Optional[threading.Lock] = None,
+    ) -> None:
+        super().__init__(name, help_text, label_names, lock)
+        self._values: Dict[_LabelKey, float] = {}
+
+    def inc(
+        self,
+        amount: float = 1.0,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Increment by ``amount`` (must be non-negative)."""
+        if amount < 0:
+            raise ValueError("Counter increments must be non-negative")
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def value(self, labels: Optional[Dict[str, str]] = None) -> float:
+        """Return the current value for a label set (0.0 if never set)."""
+        key = self._key(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def render(self) -> List[str]:
+        with self._lock:
+            items = sorted(self._values.items())
+        return [
+            f"{self.name}{_render_labels(self.label_names, key)} {_format_float(value)}"
+            for key, value in items
+        ]
+
+
+# ── Gauge ──────────────────────────────────────────────────
+
+
+class Gauge(_Metric):
+    """Value that can go up and down (queue depth, active workers…)."""
+
+    metric_type = "gauge"
+
+    def __init__(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+        lock: Optional[threading.Lock] = None,
+    ) -> None:
+        super().__init__(name, help_text, label_names, lock)
+        self._values: Dict[_LabelKey, float] = {}
+
+    def set(self, value: float, labels: Optional[Dict[str, str]] = None) -> None:
+        """Set the gauge to an absolute value."""
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = float(value)
+
+    def inc(
+        self,
+        amount: float = 1.0,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Add ``amount`` to the gauge."""
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def dec(
+        self,
+        amount: float = 1.0,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Subtract ``amount`` from the gauge."""
+        self.inc(-amount, labels=labels)
+
+    def value(self, labels: Optional[Dict[str, str]] = None) -> float:
+        """Return the current value for a label set (0.0 if never set)."""
+        key = self._key(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def render(self) -> List[str]:
+        with self._lock:
+            items = sorted(self._values.items())
+        return [
+            f"{self.name}{_render_labels(self.label_names, key)} {_format_float(value)}"
+            for key, value in items
+        ]
+
+
+# ── Histogram ──────────────────────────────────────────────
+
+
+class Histogram(_Metric):
+    """Cumulative histogram with configurable bucket boundaries.
+
+    Buckets follow ``le`` semantics: an observation counts towards every
+    bucket whose upper bound is greater than or equal to the observed
+    value. The implicit ``+Inf`` bucket is always emitted and equals
+    ``_count``.
+    """
+
+    metric_type = "histogram"
+
+    def __init__(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+        lock: Optional[threading.Lock] = None,
+        buckets: Iterable[float] = DEFAULT_DURATION_BUCKETS,
+    ) -> None:
+        super().__init__(name, help_text, label_names, lock)
+        bounds = sorted(float(b) for b in buckets if b != float("inf"))
+        if not bounds:
+            raise ValueError("Histogram needs at least one finite bucket")
+        self.buckets: Tuple[float, ...] = tuple(bounds)
+        self._counts: Dict[_LabelKey, List[int]] = {}
+        self._sums: Dict[_LabelKey, float] = {}
+        self._totals: Dict[_LabelKey, int] = {}
+
+    def observe(
+        self,
+        value: float,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Record one observation."""
+        key = self._key(labels)
+        with self._lock:
+            counts = self._counts.get(key)
+            if counts is None:
+                counts = [0] * len(self.buckets)
+                self._counts[key] = counts
+                self._sums[key] = 0.0
+                self._totals[key] = 0
+            for i, bound in enumerate(self.buckets):
+                if value <= bound:
+                    counts[i] += 1
+            self._sums[key] += float(value)
+            self._totals[key] += 1
+
+    def count(self, labels: Optional[Dict[str, str]] = None) -> int:
+        """Total number of observations for a label set."""
+        key = self._key(labels)
+        with self._lock:
+            return self._totals.get(key, 0)
+
+    def sum(self, labels: Optional[Dict[str, str]] = None) -> float:
+        """Sum of all observed values for a label set."""
+        key = self._key(labels)
+        with self._lock:
+            return self._sums.get(key, 0.0)
+
+    def bucket_counts(
+        self,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> List[int]:
+        """Cumulative counts aligned with :attr:`buckets`."""
+        key = self._key(labels)
+        with self._lock:
+            counts = self._counts.get(key)
+            return list(counts) if counts else [0] * len(self.buckets)
+
+    def render(self) -> List[str]:
+        with self._lock:
+            keys = sorted(self._counts)
+            snapshot = {
+                key: (list(self._counts[key]), self._sums[key], self._totals[key])
+                for key in keys
+            }
+        lines: List[str] = []
+        for key in keys:
+            counts, total_sum, total_count = snapshot[key]
+            for bound, cumulative in zip(self.buckets, counts):
+                suffix = _render_labels(
+                    self.label_names, key, extra=("le", _format_float(bound))
+                )
+                lines.append(f"{self.name}_bucket{suffix} {cumulative}")
+            inf_suffix = _render_labels(self.label_names, key, extra=("le", "+Inf"))
+            lines.append(f"{self.name}_bucket{inf_suffix} {total_count}")
+            plain = _render_labels(self.label_names, key)
+            lines.append(f"{self.name}_sum{plain} {_format_float(total_sum)}")
+            lines.append(f"{self.name}_count{plain} {total_count}")
+        return lines
+
+
+# ── Registry ───────────────────────────────────────────────
+
+_M = TypeVar("_M", bound=_Metric)
+
+
+class MetricsRegistry:
+    """Thread-safe collection of metric families keyed by name.
+
+    The ``counter`` / ``gauge`` / ``histogram`` methods are
+    get-or-create, so a call site can fetch its metric inline without
+    module-level wiring, and :func:`reset_registry` cannot leave stale
+    references behind. A mismatch in type or label names raises, which
+    catches typos early instead of silently splitting a series.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._metrics: Dict[str, _Metric] = {}
+
+    def _get_or_create(
+        self,
+        cls: Type[_M],
+        name: str,
+        help_text: str,
+        label_names: Sequence[str],
+        **kwargs: Any,
+    ) -> _M:
+        with self._lock:
+            existing = self._metrics.get(name)
+            if existing is not None:
+                if not isinstance(existing, cls):
+                    raise ValueError(
+                        f"Metric {name!r} already registered as "
+                        f"{type(existing).__name__}"
+                    )
+                if existing.label_names != tuple(label_names):
+                    raise ValueError(
+                        f"Metric {name!r} already registered with labels "
+                        f"{list(existing.label_names)}"
+                    )
+                return existing
+            metric = cls(
+                name,
+                help_text,
+                tuple(label_names),
+                self._lock,
+                **kwargs,
+            )
+            self._metrics[name] = metric
+            return metric
+
+    def counter(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+    ) -> Counter:
+        """Get or create a Counter."""
+        return self._get_or_create(Counter, name, help_text, label_names)
+
+    def gauge(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+    ) -> Gauge:
+        """Get or create a Gauge."""
+        return self._get_or_create(Gauge, name, help_text, label_names)
+
+    def histogram(
+        self,
+        name: str,
+        help_text: str = "",
+        label_names: Sequence[str] = (),
+        buckets: Iterable[float] = DEFAULT_DURATION_BUCKETS,
+    ) -> Histogram:
+        """Get or create a Histogram."""
+        return self._get_or_create(
+            Histogram, name, help_text, label_names, buckets=buckets
+        )
+
+    def names(self) -> List[str]:
+        """Sorted names of all registered metric families."""
+        with self._lock:
+            return sorted(self._metrics)
+
+    def clear(self) -> None:
+        """Drop all registered metrics."""
+        with self._lock:
+            self._metrics.clear()
+
+    def render(self) -> str:
+        """Render every family in Prometheus text exposition format."""
+        with self._lock:
+            families = [self._metrics[name] for name in sorted(self._metrics)]
+        chunks: List[str] = []
+        for metric in families:
+            # Families with no samples yet still advertise HELP/TYPE, so
+            # dashboards can tell "zero" apart from "metric unknown".
+            chunks.append(f"# HELP {metric.name} {_escape_help(metric.help_text)}")
+            chunks.append(f"# TYPE {metric.name} {metric.metric_type}")
+            chunks.extend(metric.render())
+        return "\n".join(chunks) + "\n" if chunks else ""
+
+
+# ── Default registry + application metrics ─────────────────
+
+_registry = MetricsRegistry()
+
+
+def get_registry() -> MetricsRegistry:
+    """Return the process-wide default registry."""
+    return _registry
+
+
+def _declare_app_metrics() -> None:
+    """Register the standard metric families up front.
+
+    Declaring eagerly means ``/metrics`` advertises every family from
+    the very first scrape, even before any task has run — otherwise a
+    fresh server renders "no data" panels in Grafana.
+    """
+    _registry.gauge(
+        BUILD_INFO,
+        "Build information; constant 1 with the version as a label.",
+        ("version",),
+    ).set(1, labels={"version": __version__})
+    _registry.counter(
+        TASKS_TOTAL,
+        "Total tasks by lifecycle status (submitted plus terminal states).",
+        ("status",),
+    )
+    _registry.gauge(QUEUE_DEPTH, "Tasks waiting in the queue (pending).")
+    _registry.gauge(ACTIVE_TASKS, "Tasks currently executing (running).")
+    _registry.histogram(
+        TASK_DURATION,
+        "End-to-end task execution duration in seconds.",
+        (),
+        DEFAULT_DURATION_BUCKETS,
+    )
+    _registry.histogram(
+        RENDER_DURATION,
+        "Duration of the render_video pipeline step in seconds.",
+        (),
+        DEFAULT_DURATION_BUCKETS,
+    )
+    _registry.counter(
+        ERRORS_TOTAL,
+        "Total errors by coarse type label.",
+        ("type",),
+    )
+    _registry.counter(
+        HTTP_REQUESTS_TOTAL,
+        "Total HTTP API requests by method, route template and status code.",
+        ("method", "path", "code"),
+    )
+
+
+_declare_app_metrics()
+
+
+def reset_registry() -> None:
+    """Clear the default registry and re-declare the standard families.
+
+    Intended for tests, which need each case to start from a known
+    state without leaking counts into the next one.
+    """
+    _registry.clear()
+    _declare_app_metrics()
+
+
+# ── Instrumentation helpers ────────────────────────────────
+#
+# Every helper below is best-effort. Telemetry is never worth failing a
+# request or killing a worker thread over, so errors are swallowed and
+# logged at DEBUG rather than propagated.
+
+
+def record_task_submitted() -> None:
+    """Count a task accepted into the queue."""
+    try:
+        _registry.counter(TASKS_TOTAL, label_names=("status",)).inc(
+            labels={"status": "submitted"}
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to record task submission metric", exc_info=True)
+
+
+def record_task_terminal(status: str) -> None:
+    """Count a task reaching a terminal state (completed/failed/cancelled)."""
+    try:
+        _registry.counter(TASKS_TOTAL, label_names=("status",)).inc(
+            labels={"status": status}
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to record terminal task metric", exc_info=True)
+
+
+def set_queue_depth(value: int) -> None:
+    """Publish the number of pending tasks."""
+    try:
+        _registry.gauge(QUEUE_DEPTH).set(value)
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to set queue depth gauge", exc_info=True)
+
+
+def set_active_tasks(value: int) -> None:
+    """Publish the number of running tasks."""
+    try:
+        _registry.gauge(ACTIVE_TASKS).set(value)
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to set active tasks gauge", exc_info=True)
+
+
+def observe_task_duration(seconds: float) -> None:
+    """Record an end-to-end task duration observation."""
+    try:
+        _registry.histogram(TASK_DURATION).observe(seconds)
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to observe task duration", exc_info=True)
+
+
+def observe_render_duration(seconds: float) -> None:
+    """Record a ``render_video`` step duration observation."""
+    try:
+        _registry.histogram(RENDER_DURATION).observe(seconds)
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to observe render duration", exc_info=True)
+
+
+def record_error(error_type: str) -> None:
+    """Count an error, bucketed by a coarse ``type`` label.
+
+    Callers must pass a bounded set of values (exception class names,
+    ``http_500``…) — never a message or an ID, which would blow up
+    series cardinality.
+    """
+    try:
+        _registry.counter(ERRORS_TOTAL, label_names=("type",)).inc(
+            labels={"type": error_type or "unknown"}
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to record error metric", exc_info=True)
+
+
+def record_http_request(method: str, path: str, code: int) -> None:
+    """Count an HTTP request.
+
+    Args:
+        method: HTTP verb.
+        path: **Route template** (``/tasks/{id}``), never a concrete
+            path containing an ID — raw paths would make cardinality
+            grow without bound.
+        code: HTTP status code.
+    """
+    try:
+        _registry.counter(
+            HTTP_REQUESTS_TOTAL, label_names=("method", "path", "code")
+        ).inc(labels={"method": method, "path": path, "code": str(code)})
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        logger.debug("Failed to record HTTP request metric", exc_info=True)
+
+
+def render_prometheus_text(registry: Optional[MetricsRegistry] = None) -> str:
+    """Render a registry (default: the process-wide one) as text."""
+    return (registry or _registry).render()

--- a/src/movie_narrator/cloud/models.py
+++ b/src/movie_narrator/cloud/models.py
@@ -195,6 +195,11 @@ class Task(BaseModel):
     retries: int = 0
     last_error: Optional[str] = None
     worker_id: Optional[str] = None
+    # v0.8.1: correlation ID captured at submission time, so worker-side
+    # logs can be joined with the API access log for the same request.
+    # Optional because task JSON persisted by earlier versions has no
+    # such key and must still load.
+    correlation_id: Optional[str] = None
 
     # Allow arbitrary types for future extensibility
     model_config = {"arbitrary_types_allowed": True}

--- a/src/movie_narrator/cloud/queue.py
+++ b/src/movie_narrator/cloud/queue.py
@@ -20,6 +20,15 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Dict, List, Optional, Protocol, runtime_checkable
 
+from ..utils.logging_config import correlation_scope, get_correlation_id
+from .metrics import (
+    observe_task_duration,
+    record_error,
+    record_task_submitted,
+    record_task_terminal,
+    set_active_tasks,
+    set_queue_depth,
+)
 from .models import Task, TaskProgress, TaskRequest, TaskResult, TaskStatus
 from .storage import TaskStorage
 from .worker import CancelController, run_task
@@ -185,7 +194,9 @@ class LocalTaskQueue:
         if not self._started or not self._executor:
             raise RuntimeError("TaskQueue is not started. Call start() first.")
 
-        task = Task(request=request)
+        # v0.8.1: inherit the caller's correlation ID (set per-request by
+        # the API server) so the worker's logs join the access log.
+        task = Task(request=request, correlation_id=get_correlation_id())
         self._storage.save(task)
 
         # Create cancellation controller and completion event
@@ -195,6 +206,9 @@ class LocalTaskQueue:
             self._controllers[task.id] = controller
             self._completion_events[task.id] = event
             self._active_count += 1
+
+        record_task_submitted()
+        self._publish_queue_metrics()
 
         # Submit to executor
         future = self._executor.submit(
@@ -255,6 +269,8 @@ class LocalTaskQueue:
         with self._lock:
             self._active_count = max(0, self._active_count - 1)
             event = self._completion_events.pop(task_id, None)
+        record_task_terminal(TaskStatus.CANCELLED.value)
+        self._publish_queue_metrics()
         if event is not None:
             event.set()
         return True
@@ -368,19 +384,28 @@ class LocalTaskQueue:
                 logger.error("Task %s not found in storage", task_id)
                 return
 
-            def on_status_change(updated: Task) -> None:
-                self._storage.save(updated)
+            # v0.8.1: re-bind the submitter's correlation ID inside the
+            # worker thread. contextvars are copied per-thread at thread
+            # creation, so the executor thread would otherwise start with
+            # an empty context and its logs would not join the request.
+            with correlation_scope(task.correlation_id):
+                started = time.monotonic()
 
-            def on_progress(updated: Task) -> None:
-                self._storage.save(updated)
+                def on_status_change(updated: Task) -> None:
+                    self._storage.save(updated)
+                    self._publish_queue_metrics()
 
-            task = run_task(
-                task,
-                controller=controller,
-                on_progress=on_progress,
-                on_status_change=on_status_change,
-            )
-            self._storage.save(task)
+                def on_progress(updated: Task) -> None:
+                    self._storage.save(updated)
+
+                task = run_task(
+                    task,
+                    controller=controller,
+                    on_progress=on_progress,
+                    on_status_change=on_status_change,
+                )
+                self._storage.save(task)
+                self._record_task_outcome(task, time.monotonic() - started)
 
         except Exception as e:  # noqa: BLE001 — worker top-level must never crash the executor
             logger.exception("Worker thread error for task %s: %s", task_id, e)
@@ -395,6 +420,8 @@ class LocalTaskQueue:
                     self._storage.save(task)
             except (OSError, ValueError):
                 logger.debug("Failed to mark task as failed after worker error", exc_info=True)
+            record_error("worker_thread")
+            record_task_terminal(TaskStatus.FAILED.value)
 
         finally:
             with self._lock:
@@ -402,8 +429,48 @@ class LocalTaskQueue:
                 self._controllers.pop(task_id, None)
                 self._active_count = max(0, self._active_count - 1)
                 event = self._completion_events.pop(task_id, None)
+            self._publish_queue_metrics()
             if event is not None:
                 event.set()
+
+    # ── Observability (v0.8.1) ───────────────────────────────
+
+    def _publish_queue_metrics(self) -> None:
+        """Refresh the queue depth / active task gauges.
+
+        Reads from ``TaskStorage``, whose counts are served from an
+        in-memory dict, so this is a cheap scan rather than disk I/O.
+        It runs on task lifecycle events (submit, status change,
+        completion) instead of on scrape, which keeps ``/metrics`` free
+        of side effects.
+        """
+        try:
+            set_queue_depth(self._storage.count(TaskStatus.PENDING))
+            set_active_tasks(self._storage.count(TaskStatus.RUNNING))
+        except Exception:  # noqa: BLE001 — telemetry must never break the queue
+            logger.debug("Failed to publish queue gauges", exc_info=True)
+
+    def _record_task_outcome(self, task: Task, duration: float) -> None:
+        """Count a terminal transition and record its duration.
+
+        ``duration`` is the worker-side execution span (all retry
+        attempts included) rather than time since submission, so queue
+        waiting time does not inflate the histogram.
+        """
+        try:
+            if not task.is_terminal:
+                return
+            record_task_terminal(task.status.value)
+            observe_task_duration(duration)
+            if task.status == TaskStatus.FAILED:
+                error_type = (
+                    task.result.error_type
+                    if task.result and task.result.error_type
+                    else "unknown"
+                )
+                record_error(error_type)
+        except Exception:  # noqa: BLE001 — telemetry must never break the queue
+            logger.debug("Failed to record task outcome metrics", exc_info=True)
 
     # ── Properties ───────────────────────────────────────────
 

--- a/src/movie_narrator/cloud/worker.py
+++ b/src/movie_narrator/cloud/worker.py
@@ -31,12 +31,19 @@ from ..utils.console import (
     build_console,
 )
 from ..utils.log import resolve_log_level
+from .metrics import observe_render_duration
 from .models import Task, TaskProgress, TaskRequest, TaskResult, TaskStatus
 
 logger = logging.getLogger(__name__)
 
 # Total pipeline steps for progress calculation
 _TOTAL_STEPS = len(STEPS)
+
+# v0.8.1: name of the pipeline step whose duration feeds
+# ``mn_render_duration_seconds``. The runner labels each step with the
+# step function's ``__name__``, so this is the hook point that does not
+# require touching the pipeline package.
+_RENDER_STEP = "render_video"
 
 
 # ── CancelController ───────────────────────────────────────
@@ -102,6 +109,8 @@ class ProgressConsole(BaseConsole):
 
     def step_ok(self, name: str, elapsed: float) -> None:
         self._progress.mark_completed(name)
+        if name == _RENDER_STEP:
+            observe_render_duration(elapsed)
         self._step_index += 1
         self._progress.update_step(
             step_name=name,

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -50,7 +50,7 @@ from typing import Callable, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 0)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 1)
 
 
 def check_version(required: tuple[int, int, int]) -> None:
@@ -79,6 +79,17 @@ def check_version(required: tuple[int, int, int]) -> None:
 
 from .utils.console import BaseConsole, Console
 from .utils.sanitize import sanitize_filename
+
+# ── Re-exports: structured logging / correlation (v0.8.1) ──
+
+from .utils.logging_config import (
+    JsonFormatter,
+    configure_logging,
+    correlation_scope,
+    get_correlation_id,
+    new_correlation_id,
+    set_correlation_id,
+)
 
 # ── Re-exports: pipeline errors ────────────────────────────
 
@@ -313,6 +324,17 @@ __all__ = [
     "list_artifacts",
     "register_remote_llm",
     "register_remote_tts",
+    # Observability (v0.8.1)
+    "JsonFormatter",
+    "configure_logging",
+    "correlation_scope",
+    "get_correlation_id",
+    "new_correlation_id",
+    "set_correlation_id",
+    "CONTENT_TYPE_LATEST",
+    "MetricsRegistry",
+    "get_registry",
+    "render_prometheus_text",
 ]
 
 
@@ -362,4 +384,12 @@ from .cloud import (  # noqa: E402
     register_remote_llm,
     register_remote_tts,
     run_daemon,
+)
+
+# Cloud / metrics (v0.8.1) — new exports, backward compatible.
+from .cloud import (  # noqa: E402
+    CONTENT_TYPE_LATEST,
+    MetricsRegistry,
+    get_registry,
+    render_prometheus_text,
 )

--- a/src/movie_narrator/utils/log.py
+++ b/src/movie_narrator/utils/log.py
@@ -18,9 +18,23 @@ from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+from .logging_config import CORRELATION_FIELD, get_correlation_id
+
 
 class _JsonFormatter(logging.Formatter):
-    """JSON line formatter for structured log aggregation (ELK/Loki)."""
+    """JSON line formatter for structured log aggregation (ELK/Loki).
+
+    When a correlation ID is bound to the current context (see
+    :mod:`movie_narrator.utils.logging_config`), it is added under the
+    ``correlation_id`` key so that all records belonging to one request
+    or task can be joined downstream. The key is omitted entirely when
+    no ID is bound — emitting an explicit null would bloat every line
+    and force consumers to special-case it.
+
+    A record attribute of the same name takes precedence, which lets
+    callers attach an ID explicitly via ``logger.info(msg, extra=...)``
+    from a thread that does not own the context.
+    """
 
     def format(self, record: logging.LogRecord) -> str:
         log_entry = {
@@ -31,6 +45,9 @@ class _JsonFormatter(logging.Formatter):
             "message": record.getMessage(),
             "logger": record.name,
         }
+        correlation_id = getattr(record, CORRELATION_FIELD, None) or get_correlation_id()
+        if correlation_id:
+            log_entry[CORRELATION_FIELD] = correlation_id
         if record.exc_info and record.exc_info[1] is not None:
             log_entry["traceback"] = self.formatException(record.exc_info)
         return json.dumps(log_entry, ensure_ascii=False)

--- a/src/movie_narrator/utils/logging_config.py
+++ b/src/movie_narrator/utils/logging_config.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Structured logging configuration and correlation IDs (v0.8.1).
+
+This module targets the *library / server* logging side — the
+``logger = logging.getLogger(__name__)`` calls scattered across the
+``cloud`` and ``workflow`` packages. It is deliberately separate from
+:mod:`movie_narrator.utils.console` (the user-facing output façade) and
+from :class:`movie_narrator.utils.log.AppLogger` (per-run file logging).
+
+Two capabilities are provided:
+
+**1. JSON log lines.** :class:`JsonFormatter` renders one JSON object
+per record with a stable key set (``ts``, ``level``, ``logger``,
+``msg``), so logs can be shipped to ELK / Loki / CloudWatch without a
+grok pattern. Formatting is defensive: a log call must never crash the
+code that emitted it, so unserializable values degrade to ``repr()``
+rather than raising.
+
+**2. Correlation IDs.** A :class:`contextvars.ContextVar` carries an ID
+that ties together every record belonging to one logical unit of work —
+an HTTP request, or the task it spawned. ``contextvars`` (rather than
+``threading.local``) is used because each thread started by
+``ThreadingHTTPServer`` / ``ThreadPoolExecutor`` gets its own copy of
+the context, so IDs never leak between concurrently served requests,
+and the same code keeps working if an async front end is ever added.
+
+Typical usage::
+
+    from movie_narrator.utils.logging_config import (
+        configure_logging,
+        correlation_scope,
+    )
+
+    configure_logging(json_mode=True, level="INFO")
+
+    with correlation_scope() as cid:
+        logger.info("handling request")   # record carries ``cid``
+
+Configuration is driven by two environment variables, both optional:
+
+``MN_LOG_FORMAT``
+    ``json`` or ``text`` (default ``text``).
+``MN_LOG_LEVEL``
+    Standard level name (default ``INFO``).
+
+Explicit arguments to :func:`configure_logging` win over the
+environment.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator, Optional
+
+__all__ = [
+    "CORRELATION_FIELD",
+    "CORRELATION_HEADER",
+    "CorrelationIdFilter",
+    "ENV_LOG_FORMAT",
+    "ENV_LOG_LEVEL",
+    "JsonFormatter",
+    "REQUEST_ID_HEADER",
+    "TextFormatter",
+    "configure_logging",
+    "correlation_scope",
+    "get_correlation_id",
+    "new_correlation_id",
+    "reset_logging",
+    "set_correlation_id",
+]
+
+#: Record attribute / JSON key holding the correlation ID.
+CORRELATION_FIELD = "correlation_id"
+
+#: Response header the server always echoes the correlation ID on.
+CORRELATION_HEADER = "X-Correlation-ID"
+
+#: Additional request header accepted as an inbound correlation ID.
+REQUEST_ID_HEADER = "X-Request-ID"
+
+#: Environment variable selecting ``json`` or ``text`` output.
+ENV_LOG_FORMAT = "MN_LOG_FORMAT"
+
+#: Environment variable selecting the root log level.
+ENV_LOG_LEVEL = "MN_LOG_LEVEL"
+
+_DEFAULT_LEVEL = logging.INFO
+
+_correlation_id: ContextVar[Optional[str]] = ContextVar(
+    "movie_narrator_correlation_id",
+    default=None,
+)
+
+
+# ── Correlation ID ─────────────────────────────────────────
+
+
+def new_correlation_id() -> str:
+    """Return a fresh correlation ID (12 hex chars).
+
+    Twelve hex characters carry 48 bits of entropy — ample to stay
+    unique inside a log-retention window, while remaining short enough
+    to eyeball in a terminal and to grep for.
+    """
+    return uuid.uuid4().hex[:12]
+
+
+def get_correlation_id() -> Optional[str]:
+    """Return the correlation ID bound to the current context, if any."""
+    return _correlation_id.get()
+
+
+def set_correlation_id(cid: Optional[str]) -> Token[Optional[str]]:
+    """Bind ``cid`` as the current correlation ID.
+
+    Args:
+        cid: The ID to bind, or None to unbind.
+
+    Returns:
+        A token accepted by :meth:`contextvars.ContextVar.reset`, so
+        callers that cannot use :func:`correlation_scope` (for example
+        because bind and release happen in different functions) can
+        still restore the previous value.
+    """
+    return _correlation_id.set(cid)
+
+
+@contextmanager
+def correlation_scope(cid: Optional[str] = None) -> Iterator[str]:
+    """Bind a correlation ID for the duration of the ``with`` block.
+
+    The previous value is restored on exit — including when the body
+    raises — so nested scopes (a task running inside a request) do not
+    clobber the caller's ID.
+
+    Args:
+        cid: ID to bind. When None or empty, a fresh one is generated.
+
+    Yields:
+        The correlation ID active inside the block.
+    """
+    resolved = cid or new_correlation_id()
+    token = _correlation_id.set(resolved)
+    try:
+        yield resolved
+    finally:
+        _correlation_id.reset(token)
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Inject the ambient correlation ID onto every record.
+
+    Attached to the handler rather than to individual loggers so that
+    the text formatter can reference ``%(correlation_id)s`` without
+    risking a ``KeyError`` on records emitted by third-party libraries.
+
+    An ID already present on the record wins: that lets a caller attach
+    an explicit ID via ``logger.info(msg, extra={"correlation_id": ...})``
+    from a thread that does not own the context.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not getattr(record, CORRELATION_FIELD, None):
+            setattr(record, CORRELATION_FIELD, get_correlation_id() or "")
+        return True
+
+
+# ── Formatters ─────────────────────────────────────────────
+
+#: Attributes present on every ``LogRecord``; anything else a caller
+#: passed via ``extra=`` is emitted as a top-level JSON field.
+_RESERVED_ATTRS = frozenset({
+    "args", "asctime", "created", "exc_info", "exc_text", "filename",
+    "funcName", "levelname", "levelno", "lineno", "message", "module",
+    "msecs", "msg", "name", "pathname", "process", "processName",
+    "relativeCreated", "stack_info", "taskName", "thread", "threadName",
+})
+
+
+def _isoformat_utc(timestamp: float) -> str:
+    """Render an epoch timestamp as ISO-8601 in UTC with a ``Z`` suffix."""
+    return (
+        datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _dumps(payload: Dict[str, Any]) -> str:
+    """Serialize ``payload``, degrading unserializable values to ``repr``.
+
+    ``default=repr`` covers unserializable *values*, but not exotic
+    *keys* (a dict keyed by tuples raises before ``default`` is
+    consulted). The second pass therefore repr-s offending entries
+    whole, and a final minimal payload guarantees this never raises —
+    a logging call must not be able to crash its caller.
+    """
+    try:
+        return json.dumps(payload, ensure_ascii=False, default=repr)
+    except (TypeError, ValueError):
+        pass
+
+    safe: Dict[str, Any] = {}
+    for key, value in payload.items():
+        try:
+            json.dumps(value, ensure_ascii=False, default=repr)
+            safe[str(key)] = value
+        except (TypeError, ValueError):
+            safe[str(key)] = repr(value)
+    try:
+        return json.dumps(safe, ensure_ascii=False, default=repr)
+    except (TypeError, ValueError):
+        return json.dumps({
+            "ts": payload.get("ts", ""),
+            "level": payload.get("level", "ERROR"),
+            "logger": payload.get("logger", ""),
+            "msg": "<unserializable log record>",
+        })
+
+
+def _safe_message(record: logging.LogRecord) -> str:
+    """Interpolate the record message, tolerating bad format arguments."""
+    try:
+        return record.getMessage()
+    except (TypeError, ValueError):
+        return f"{record.msg!r} % {record.args!r}"
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a record as a single-line JSON object.
+
+    Key set::
+
+        ts             ISO-8601 UTC, millisecond precision
+        level          level name (INFO, ERROR, …)
+        logger         logger name
+        msg            interpolated message
+        correlation_id present only when an ID is bound
+        exc_type       \\
+        exc_message     > present only when the record carries an exception
+        traceback      /
+        <extra>        any field passed via ``extra=``
+
+    ``correlation_id`` is omitted rather than emitted as ``null`` when
+    unset: a null would bloat every line and force every consumer to
+    special-case it.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: Dict[str, Any] = {
+            "ts": _isoformat_utc(record.created),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": _safe_message(record),
+        }
+
+        correlation_id = getattr(record, CORRELATION_FIELD, None) or get_correlation_id()
+        if correlation_id:
+            payload[CORRELATION_FIELD] = correlation_id
+
+        if record.exc_info and record.exc_info[1] is not None:
+            exc = record.exc_info[1]
+            payload["exc_type"] = type(exc).__name__
+            payload["exc_message"] = str(exc)
+            payload["traceback"] = self.formatException(record.exc_info)
+        elif record.exc_text:
+            payload["traceback"] = record.exc_text
+
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+
+        for key, value in record.__dict__.items():
+            # ``correlation_id`` is handled by the block above so that an
+            # empty value (the filter sets it to "" when unset) is omitted
+            # rather than emitted as ``"correlation_id": ""`` on every line.
+            if (
+                key in _RESERVED_ATTRS
+                or key == CORRELATION_FIELD
+                or key in payload
+                or key.startswith("_")
+            ):
+                continue
+            payload[key] = value
+
+        return _dumps(payload)
+
+
+class TextFormatter(logging.Formatter):
+    """Human-readable formatter that surfaces the correlation ID.
+
+    The ID is appended in brackets only when present, so local runs
+    without a bound ID keep the familiar terse output.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+        correlation_id = getattr(record, CORRELATION_FIELD, None) or get_correlation_id()
+        if correlation_id:
+            return f"{base} [{CORRELATION_FIELD}={correlation_id}]"
+        return base
+
+
+# ── Configuration ──────────────────────────────────────────
+
+#: Marker attribute identifying the handler this module installed, so
+#: repeated ``configure_logging()`` calls update it instead of stacking
+#: duplicates, and ``reset_logging()`` leaves foreign handlers alone.
+_MANAGED_FLAG = "_mn_observability_handler"
+
+_config_lock = threading.Lock()
+
+_LEVEL_NAMES: Dict[str, int] = {
+    "CRITICAL": logging.CRITICAL,
+    "FATAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
+
+
+def _resolve_level(level: Optional[str]) -> int:
+    """Resolve a case-insensitive level name, falling back to INFO.
+
+    Unlike :func:`movie_narrator.utils.log.resolve_log_level` (which
+    defaults to DEBUG for pipeline debugging), server logs default to
+    INFO — DEBUG on a long-running service is far too chatty.
+    """
+    if level is None:
+        return _DEFAULT_LEVEL
+    return _LEVEL_NAMES.get(level.strip().upper(), _DEFAULT_LEVEL)
+
+
+def _resolve_json_mode(json_mode: Optional[bool]) -> bool:
+    """Decide between JSON and text output (explicit arg wins over env)."""
+    if json_mode is not None:
+        return json_mode
+    return os.environ.get(ENV_LOG_FORMAT, "text").strip().lower() == "json"
+
+
+def _find_managed_handler(logger: logging.Logger) -> Optional[logging.Handler]:
+    """Return the handler previously installed by this module, if any."""
+    for handler in logger.handlers:
+        if getattr(handler, _MANAGED_FLAG, False):
+            return handler
+    return None
+
+
+def configure_logging(
+    *,
+    json_mode: Optional[bool] = None,
+    level: Optional[str] = None,
+) -> logging.Handler:
+    """Install (or update) the process-wide structured log handler.
+
+    Idempotent: calling this repeatedly reconfigures the single handler
+    this module owns rather than stacking duplicates, so a library that
+    calls it defensively cannot cause double-logging.
+
+    The handler is attached to the **root** logger on purpose. Attaching
+    it to the ``movie_narrator`` logger would be more polite, but
+    :class:`movie_narrator.utils.log.AppLogger` calls ``handlers.clear()``
+    on exactly that logger when a pipeline run starts, which would
+    silently detach server logging mid-run.
+
+    Args:
+        json_mode: Force JSON (True) or text (False). When None, read
+            ``MN_LOG_FORMAT`` (default text).
+        level: Level name such as ``"DEBUG"``. When None, read
+            ``MN_LOG_LEVEL`` (default ``INFO``).
+
+    Returns:
+        The managed handler, so callers can attach extra filters.
+    """
+    resolved_json = _resolve_json_mode(json_mode)
+    resolved_level = _resolve_level(
+        level if level is not None else os.environ.get(ENV_LOG_LEVEL)
+    )
+
+    with _config_lock:
+        root = logging.getLogger()
+        handler = _find_managed_handler(root)
+        if handler is None:
+            handler = logging.StreamHandler(sys.stderr)
+            setattr(handler, _MANAGED_FLAG, True)
+            handler.addFilter(CorrelationIdFilter())
+            root.addHandler(handler)
+        handler.setFormatter(JsonFormatter() if resolved_json else TextFormatter())
+        handler.setLevel(resolved_level)
+        root.setLevel(resolved_level)
+        return handler
+
+
+def reset_logging() -> None:
+    """Remove the handler installed by :func:`configure_logging`.
+
+    Only the managed handler is touched; handlers installed by the
+    application or by pytest are left in place. Primarily useful in
+    tests, and when embedding the package in a host process that owns
+    its own logging setup.
+    """
+    with _config_lock:
+        root = logging.getLogger()
+        handler = _find_managed_handler(root)
+        if handler is not None:
+            root.removeHandler(handler)
+            handler.close()

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 8, 0) — bumped for v0.8.0 video_format rename."""
-        assert CONTRACT_VERSION == (0, 8, 0)
+        """CONTRACT_VERSION is (0, 8, 1) — bumped for v0.8.1 observability exports."""
+        assert CONTRACT_VERSION == (0, 8, 1)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 0)
+        assert CONTRACT_VERSION == (0, 8, 1)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 8, 0)."""
+        """CONTRACT_VERSION is (0, 8, 1)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 0)
+        assert CONTRACT_VERSION == (0, 8, 1)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""

--- a/tests/test_v080_format_rename.py
+++ b/tests/test_v080_format_rename.py
@@ -73,5 +73,5 @@ class TestContractVersionBump:
     """Tests for CONTRACT_VERSION bump."""
 
     def test_contract_version_is_0_8_0(self):
-        """CONTRACT_VERSION is (0, 8, 0)."""
-        assert CONTRACT_VERSION == (0, 8, 0)
+        """CONTRACT_VERSION is (0, 8, 1)."""
+        assert CONTRACT_VERSION == (0, 8, 1)

--- a/tests/test_v081_logging.py
+++ b/tests/test_v081_logging.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for v0.8.1 structured logging and correlation IDs.
+
+Covers :mod:`movie_narrator.utils.logging_config`: JSON rendering, the
+correlation-ID context var (including cross-thread propagation), and the
+idempotent :func:`configure_logging` / :func:`reset_logging` lifecycle.
+
+These tests need no network and no API keys.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import sys
+import threading
+from typing import Any, Dict, List
+
+import pytest
+
+from movie_narrator.utils.logging_config import (
+    CORRELATION_FIELD,
+    JsonFormatter,
+    TextFormatter,
+    configure_logging,
+    correlation_scope,
+    get_correlation_id,
+    new_correlation_id,
+    reset_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _managed_logging():
+    """Ensure no managed handler leaks across tests."""
+    reset_logging()
+    yield
+    reset_logging()
+
+
+def _emit(handler: logging.Handler, record: logging.LogRecord) -> str:
+    return handler.format(record)
+
+
+def _make_record(
+    msg: str,
+    args: tuple = (),
+    exc_info: Any = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> logging.LogRecord:
+    if exc_info is True:
+        exc_info = sys.exc_info()
+    record = logging.LogRecord(
+        "movie_narrator.test.logging",
+        logging.INFO,
+        "path",
+        1,
+        msg,
+        args,
+        exc_info,
+    )
+    for key, value in (extra or {}).items():
+        setattr(record, key, value)
+    return record
+
+
+# ── JSON formatter ──────────────────────────────────────────
+
+
+def test_json_formatter_basic_fields():
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(JsonFormatter())
+    record = _make_record("hello %s", ("world",))
+    out = _emit(handler, record)
+    payload = json.loads(out)
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "movie_narrator.test.logging"
+    assert payload["msg"] == "hello world"
+    assert "ts" in payload
+    # No correlation id bound → key is omitted, not null.
+    assert CORRELATION_FIELD not in payload
+
+
+def test_json_formatter_correlation_id_present():
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(JsonFormatter())
+    with correlation_scope("abc123deadbe"):
+        record = _make_record("working")
+        out = _emit(handler, record)
+    payload = json.loads(out)
+    assert payload[CORRELATION_FIELD] == "abc123deadbe"
+
+
+def test_json_formatter_omits_empty_correlation():
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(JsonFormatter())
+    record = _make_record("no id")
+    # Explicitly set an empty correlation id.
+    setattr(record, CORRELATION_FIELD, "")
+    out = _emit(handler, record)
+    payload = json.loads(out)
+    assert CORRELATION_FIELD not in payload
+
+
+def test_json_formatter_extra_fields():
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(JsonFormatter())
+    record = _make_record("with extra", extra={"task_id": "abc", "n": 3})
+    payload = json.loads(_emit(handler, record))
+    assert payload["task_id"] == "abc"
+    assert payload["n"] == 3
+
+
+def test_json_formatter_exc_info():
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(JsonFormatter())
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = _make_record("failed", exc_info=True)
+    payload = json.loads(_emit(handler, record))
+    assert payload["exc_type"] == "ValueError"
+    assert payload["exc_message"] == "boom"
+    assert "ValueError" in payload["traceback"]
+
+
+def test_json_formatter_unserializable_degrades():
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(JsonFormatter())
+
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    record = _make_record("odd", extra={"obj": Weird()})
+    out = _emit(handler, record)
+    payload = json.loads(out)  # must still be valid JSON
+    assert payload["obj"] == "<weird>"
+
+
+def test_text_formatter_surfaces_correlation():
+    formatter = TextFormatter()
+    with correlation_scope("id-xyz"):
+        record = _make_record("doing work")
+        out = formatter.format(record)
+    assert "correlation_id=id-xyz" in out
+
+
+# ── Correlation ID context var ─────────────────────────────
+
+
+def test_new_correlation_id_format():
+    cid = new_correlation_id()
+    assert len(cid) == 12
+    assert all(c in "0123456789abcdef" for c in cid)
+
+
+def test_correlation_scope_restores_previous():
+    assert get_correlation_id() is None
+    with correlation_scope("outer") as outer:
+        assert get_correlation_id() == "outer"
+        with correlation_scope("inner") as inner:
+            assert get_correlation_id() == "inner"
+        assert get_correlation_id() == outer
+    assert get_correlation_id() is None
+
+
+def test_correlation_not_auto_propagated_to_thread():
+    # A plain ``threading.Thread`` does NOT inherit the parent's ContextVar
+    # value, so the ID must be re-bound explicitly inside the worker — which
+    # is exactly what ``cloud/queue.py`` does via
+    # ``correlation_scope(task.correlation_id)``.
+    captured: Dict[str, Any] = {}
+
+    with correlation_scope("parent-cid"):
+        def worker() -> None:
+            captured["auto"] = get_correlation_id()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+    assert captured["auto"] is None
+
+
+def test_correlation_explicitly_bound_in_thread():
+    captured: Dict[str, Any] = {}
+
+    def worker(cid: str) -> None:
+        with correlation_scope(cid):
+            captured["bound"] = get_correlation_id()
+
+    t = threading.Thread(target=worker, args=("worker-cid",))
+    t.start()
+    t.join()
+
+    assert captured["bound"] == "worker-cid"
+
+
+# ── configure_logging lifecycle ─────────────────────────────
+
+
+def test_configure_logging_idempotent():
+    root = logging.getLogger()
+    before = len(root.handlers)
+    h1 = configure_logging(json_mode=False, level="INFO")
+    after_one = len(root.handlers)
+    assert after_one == before + 1
+    h2 = configure_logging(json_mode=True, level="DEBUG")
+    # Re-running must update the SAME handler, not stack a second one.
+    assert len(root.handlers) == after_one
+    assert h1 is h2
+    assert isinstance(h2.formatter, JsonFormatter)
+
+
+def test_configure_logging_json_env(monkeypatch):
+    monkeypatch.setenv("MN_LOG_FORMAT", "json")
+    monkeypatch.setenv("MN_LOG_LEVEL", "WARNING")
+    handler = configure_logging()
+    assert isinstance(handler.formatter, JsonFormatter)
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_configure_logging_explicit_overrides_env(monkeypatch):
+    monkeypatch.setenv("MN_LOG_FORMAT", "json")
+    # Explicit argument must win over the environment.
+    handler = configure_logging(json_mode=False)
+    assert isinstance(handler.formatter, TextFormatter)
+
+
+def test_configure_logging_level_env(monkeypatch):
+    monkeypatch.setenv("MN_LOG_LEVEL", "DEBUG")
+    configure_logging(json_mode=False)
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_reset_logging_removes_handler():
+    root = logging.getLogger()
+    before = len(root.handlers)
+    configure_logging(json_mode=False)
+    assert len(root.handlers) == before + 1
+    reset_logging()
+    assert len(root.handlers) == before
+
+
+def test_configure_logging_emits_json_line(monkeypatch):
+    monkeypatch.setenv("MN_LOG_FORMAT", "json")
+    stream = io.StringIO()
+    handler = configure_logging(json_mode=True)
+    old = handler.stream
+    handler.stream = stream
+    try:
+        logging.getLogger("movie_narrator.test.logging").info("structured")
+    finally:
+        handler.stream = old
+    payload = json.loads(stream.getvalue().splitlines()[-1])
+    assert payload["msg"] == "structured"
+    assert payload["level"] == "INFO"

--- a/tests/test_v081_metrics.py
+++ b/tests/test_v081_metrics.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for v0.8.1 Prometheus metrics (v0.8.1).
+
+Covers the dependency-free metric primitives, the text exposition
+renderer (version 0.0.4), label escaping, and the real instrumentation
+helpers wired into the server. Also touches the route-template /
+``/metrics``-auth helpers in :mod:`movie_narrator.cloud.api`.
+
+These tests need no network and no API keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from movie_narrator.cloud import metrics
+from movie_narrator.cloud.metrics import (
+    ACTIVE_TASKS,
+    BUILD_INFO,
+    CONTENT_TYPE_LATEST,
+    ERRORS_TOTAL,
+    HTTP_REQUESTS_TOTAL,
+    QUEUE_DEPTH,
+    RENDER_DURATION,
+    TASKS_TOTAL,
+    TASK_DURATION,
+    MetricsRegistry,
+    get_registry,
+    render_prometheus_text,
+    reset_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+# ── Constants / content type ────────────────────────────────
+
+
+def test_metric_name_constants():
+    assert BUILD_INFO == "mn_build_info"
+    assert TASKS_TOTAL == "mn_tasks_total"
+    assert QUEUE_DEPTH == "mn_queue_depth"
+    assert ACTIVE_TASKS == "mn_active_tasks"
+    assert TASK_DURATION == "mn_task_duration_seconds"
+    assert RENDER_DURATION == "mn_render_duration_seconds"
+    assert ERRORS_TOTAL == "mn_errors_total"
+    assert HTTP_REQUESTS_TOTAL == "mn_http_requests_total"
+
+
+def test_content_type_latest():
+    assert CONTENT_TYPE_LATEST == "text/plain; version=0.0.4; charset=utf-8"
+
+
+# ── Primitives ──────────────────────────────────────────────
+
+
+def test_counter_render():
+    reg = MetricsRegistry()
+    reg.counter("my_counter", "A counter", ("code",)).inc(
+        2, labels={"code": "200"}
+    )
+    out = reg.render()
+    assert "# HELP my_counter A counter" in out
+    assert "# TYPE my_counter counter" in out
+    assert 'my_counter{code="200"} 2' in out
+
+
+def test_gauge_render():
+    reg = MetricsRegistry()
+    reg.gauge("my_gauge").set(7)
+    out = reg.render()
+    assert "# TYPE my_gauge gauge" in out
+    assert "my_gauge 7" in out
+
+
+def test_histogram_render_has_buckets_sum_count():
+    reg = MetricsRegistry()
+    hist = reg.histogram("my_hist", "A hist", (), buckets=[1.0, 5.0])
+    hist.observe(3.0)
+    out = reg.render()
+    assert "# TYPE my_hist histogram" in out
+    # Cumulative buckets: 3.0 <= 5.0 but not <= 1.0.
+    # Note: integer-valued bucket bounds render without a decimal (1 not 1.0).
+    assert 'my_hist_bucket{le="1"} 0' in out
+    assert 'my_hist_bucket{le="5"} 1' in out
+    assert 'my_hist_bucket{le="+Inf"} 1' in out  # equals _count
+    assert "my_hist_sum 3" in out
+    assert "my_hist_count 1" in out
+
+
+def test_label_value_escaping():
+    reg = MetricsRegistry()
+    reg.counter("esc", "esc", ("path",)).inc(1, labels={"path": 'a\\b"c\nd'})
+    out = reg.render()
+    # backslash, double-quote and newline must be escaped.
+    assert 'path="a\\\\b\\"c\\nd"' in out
+
+
+# ── Real instrumentation helpers ────────────────────────────
+
+
+def test_render_prometheus_text_all_families():
+    text = render_prometheus_text()
+    for name in (
+        BUILD_INFO,
+        TASKS_TOTAL,
+        QUEUE_DEPTH,
+        ACTIVE_TASKS,
+        TASK_DURATION,
+        RENDER_DURATION,
+        ERRORS_TOTAL,
+        HTTP_REQUESTS_TOTAL,
+    ):
+        assert f"# TYPE {name} " in text
+    # Build info carries the version label.
+    assert 'mn_build_info{version=' in text
+
+
+def test_record_task_submitted_and_terminal():
+    metrics.record_task_submitted()
+    metrics.record_task_terminal("completed")
+    metrics.record_task_terminal("failed")
+    c = get_registry().counter(TASKS_TOTAL, label_names=("status",))
+    assert c.value({"status": "submitted"}) == 1
+    assert c.value({"status": "completed"}) == 1
+    assert c.value({"status": "failed"}) == 1
+
+
+def test_set_queue_depth_and_active_tasks():
+    metrics.set_queue_depth(4)
+    metrics.set_active_tasks(2)
+    g = get_registry()
+    assert g.gauge(QUEUE_DEPTH).value() == 4
+    assert g.gauge(ACTIVE_TASKS).value() == 2
+
+
+def test_observe_durations():
+    metrics.observe_task_duration(1.5)
+    metrics.observe_render_duration(2.5)
+    reg = get_registry()
+    assert reg.histogram(TASK_DURATION).count() == 1
+    assert reg.histogram(RENDER_DURATION).count() == 1
+    assert reg.histogram(TASK_DURATION).sum() == 1.5
+    assert reg.histogram(RENDER_DURATION).sum() == 2.5
+
+
+def test_record_error_buckets_by_type():
+    metrics.record_error("http_401")
+    metrics.record_error("http_401")
+    metrics.record_error("worker_thread")
+    c = get_registry().counter(ERRORS_TOTAL, label_names=("type",))
+    assert c.value({"type": "http_401"}) == 2
+    assert c.value({"type": "worker_thread"}) == 1
+
+
+def test_record_error_defaults_unknown():
+    metrics.record_error("")  # empty type
+    c = get_registry().counter(ERRORS_TOTAL, label_names=("type",))
+    assert c.value({"type": "unknown"}) == 1
+
+
+def test_record_http_request_uses_path_template():
+    metrics.record_http_request("GET", "/tasks/{id}", 200)
+    metrics.record_http_request("GET", "/tasks/{id}", 200)
+    c = get_registry().counter(
+        HTTP_REQUESTS_TOTAL, label_names=("method", "path", "code")
+    )
+    assert c.value({"method": "GET", "path": "/tasks/{id}", "code": "200"}) == 2
+
+
+def test_helpers_never_raise_on_bad_input():
+    # Telemetry must never break a request or worker thread.
+    metrics.record_error(None)  # type: ignore[arg-type]
+    metrics.observe_task_duration(float("nan"))
+    metrics.record_http_request("", "", 0)
+    metrics.set_queue_depth(-1)
+    # No exception raised.
+    assert True
+
+
+# ── API observability wiring ────────────────────────────────
+
+
+def test_route_template_static_and_unknown():
+    from movie_narrator.cloud.api import _route_template
+
+    assert _route_template("/health") == "/health"
+    assert _route_template("/metrics") == "/metrics"
+    assert _route_template("/tasks") == "/tasks"
+    assert _route_template("/info") == "/info"
+    assert _route_template("/totally/unknown/path") == "/other"
+
+
+def test_route_template_folds_task_paths():
+    from movie_narrator.cloud.api import _route_template
+
+    assert _route_template("/tasks/abc123") == "/tasks/{id}"
+    assert _route_template("/tasks/abc123/result") == "/tasks/{id}/result"
+    assert (
+        _route_template("/tasks/abc123/artifacts") == "/tasks/{id}/artifacts"
+    )
+    assert (
+        _route_template("/tasks/abc123/download/video.mp4")
+        == "/tasks/{id}/download/{filename}"
+    )
+
+
+def test_metrics_public_env(monkeypatch):
+    from movie_narrator.cloud.api import _metrics_public
+
+    monkeypatch.delenv("MN_METRICS_PUBLIC", raising=False)
+    assert _metrics_public() is False
+    monkeypatch.setenv("MN_METRICS_PUBLIC", "1")
+    assert _metrics_public() is True
+    monkeypatch.setenv("MN_METRICS_PUBLIC", "true")
+    assert _metrics_public() is True
+    monkeypatch.setenv("MN_METRICS_PUBLIC", "0")
+    assert _metrics_public() is False


### PR DESCRIPTION
## v0.8.1 — Observability

Closes the first two deferred v0.8.x roadmap items.

### Added
- **Structured logging** — opt-in JSON log format with correlation IDs (`mn serve --log-format json` / `MN_LOG_FORMAT=json`). New `utils/logging_config` module: `JsonFormatter`, `contextvars`-backed correlation ID, idempotent `configure_logging()`.
- API server accepts/echoes `X-Correlation-ID` (or `X-Request-ID`) and propagates it to worker logs via `Task.correlation_id`.
- **Prometheus metrics** — `GET /metrics` (text exposition v0.0.4): `mn_build_info`, `mn_tasks_total{status}`, `mn_queue_depth`, `mn_active_tasks`, `mn_task_duration_seconds`, `mn_render_duration_seconds`, `mn_errors_total{type}`, `mn_http_requests_total{method,path,code}`. Paths recorded as route templates. Auth by default; `MN_METRICS_PUBLIC=1` for unauthenticated scraping.
- Dependency-free metrics primitives (`Counter`/`Gauge`/`Histogram`/`MetricsRegistry`) exported via SDK.
- `docs/OBSERVABILITY.md` + `.zh-CN.md`; 34 new tests.

### Changed
- `CONTRACT_VERSION` → (0, 8, 1); package version 0.8.1.
- Server-side debug logging for rejected API requests.

### Verification
- Local full suite: 1582 passed / 0 failed / 3 skipped.