### PR TITLE
release: v0.8.3 — storage backend abstraction & artifact lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,3 +113,29 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # Set to 1/true/yes/on to expose GET /metrics WITHOUT an API key.
 # Off by default — the metrics payload leaks task volumes and error rates.
 # MN_METRICS_PUBLIC=0
+
+# ============================================================
+# Artifact storage & lifecycle (v0.8.3)
+# ============================================================
+# Where rendered artifacts (final.mp4, narration audio, subtitles,
+# metadata.json) are stored, and how long they are kept.
+# The default is the local filesystem — leaving all of this unset keeps
+# the pre-v0.8.3 behaviour exactly (artifacts are never deleted).
+
+# Backend: local (default) | s3
+# MN_STORAGE_BACKEND=local
+# MN_STORAGE_ROOT=output            # root directory for the local backend
+
+# ---- S3 / MinIO / R2 (active when MN_STORAGE_BACKEND=s3) ----
+# Requires the optional extra:  pip install 'movie-narrator[s3]'
+# MN_S3_BUCKET=movie-narrator-artifacts
+# MN_S3_PREFIX=runs                 # key prefix inside the bucket
+# MN_S3_ENDPOINT_URL=               # e.g. http://localhost:9000 for MinIO
+# MN_S3_REGION=us-east-1
+
+# ---- Retention (TTL cleanup) ----
+# Preview any policy first with:  mn artifacts cleanup --dry-run
+# MN_ARTIFACT_TTL=0                 # delete artifacts older than N seconds (0 = keep forever)
+# MN_ARTIFACT_MAX_BYTES=0           # evict oldest-first above this total size (0 = unlimited)
+# MN_ARTIFACT_KEEP_LAST=0           # always keep the N newest artifacts (0 = disabled)
+# MN_ARTIFACT_SWEEP_INTERVAL=3600   # seconds between background sweeps (mn serve)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-08-03
+
+### Added
+
+- **Artifact storage abstraction** — new `movie_narrator.cloud.artifact_store` module defining a `StorageBackend` protocol (`put` / `get` / `open` / `exists` / `delete` / `list` / `stat` / `url`) over an `ArtifactInfo` value object. Two backends ship: `LocalArtifactStore` (filesystem, the default) and `S3ArtifactStore` (S3 / MinIO / Cloudflare R2). A `get_artifact_store()` factory resolves the backend from `MN_STORAGE_BACKEND`, `MN_STORAGE_ROOT`, `MN_S3_BUCKET`, `MN_S3_PREFIX`, `MN_S3_ENDPOINT_URL` and `MN_S3_REGION`.
+- **Optional `s3` extra** — `pip install 'movie-narrator[s3]'` installs `boto3>=1.34`. `boto3` is imported lazily, so the default local backend never requires it; the S3 client is injectable for testing.
+- **Artifact lifecycle / TTL cleanup** — new `movie_narrator.cloud.lifecycle` module with `ArtifactLifecyclePolicy` (TTL, total-size cap, keep-last-N, dry-run), `cleanup_artifacts()` returning a `CleanupReport` (`deleted` / `freed_bytes` / `skipped` / `errors`), and a daemonised `ArtifactSweeper` thread. Artifacts belonging to pending/running tasks are never deleted.
+- **`mn artifacts` CLI group** — `mn artifacts list` and `mn artifacts cleanup --ttl / --max-bytes / --keep-last / --dry-run` print a human-readable retention report.
+- **Background artifact sweeper in `mn serve`** — the API server starts a daemon sweeper when a retention rule is configured (`MN_ARTIFACT_TTL` / `MN_ARTIFACT_MAX_BYTES`), sweeping every `MN_ARTIFACT_SWEEP_INTERVAL` seconds (default 3600). Sweep failures are logged and never propagate to the server.
+- New public exports on `movie_narrator.contract`: `ArtifactInfo`, `ArtifactLifecyclePolicy`, `ArtifactSweeper`, `CleanupReport`, `LocalArtifactStore`, `S3ArtifactStore`, `StorageBackend`, `cleanup_artifacts`, `get_artifact_store`.
+- `tests/test_v083_artifact_store.py` and `tests/test_v083_lifecycle.py` — 151 test cases covering key normalisation and traversal rejection, round-trip backend operations, the S3 backend against an injected fake client, TTL expiry boundaries, size-cap eviction order, keep-last-N, dry-run and protected in-flight keys.
+
+### Changed
+
+- `GET /tasks/{id}/artifacts` and `GET /tasks/{id}/download/{file}` now go through the artifact-store abstraction instead of touching the filesystem directly. Behaviour, response shapes and the path-traversal guard are unchanged; the local backend remains the default, so existing deployments see no difference.
+
 ## [0.8.2] - 2026-08-03
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,8 +51,8 @@ The original v0.6.2–v0.6.4 plan (distributed rendering, API gateway & auth, cl
 
 - [ ] Dockerfile — multi-stage build (builder + runtime), GPU support
 - [ ] docker-compose.yml — local cluster (API + N workers + storage)
-- [ ] Storage backend abstraction — `StorageBackend` protocol (local / S3)
-- [ ] Artifact lifecycle — TTL-based cleanup
+- [x] Storage backend abstraction — `StorageBackend` protocol (local / S3) (v0.8.3)
+- [x] Artifact lifecycle — TTL-based cleanup (v0.8.3)
 - [x] Structured logging — JSON format with correlation IDs (v0.8.1)
 - [x] Prometheus metrics — `/metrics` endpoint (task count, queue depth, render duration, error rate) (v0.8.1)
 - [x] Health/readiness probes — `/ready` endpoint + deep health check with dependency connectivity (`/health` already exists in v0.6.1) (v0.8.2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.8.2"
+version = "0.8.3"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -47,6 +47,7 @@ full = [
     'faster-whisper>=1.0; python_version < "3.14"',
     'sentence-transformers>=3.0; python_version < "3.14"',
 ]
+s3 = ["boto3>=1.34"]
 dev = ["pytest>=8.0", "pytest-timeout>=2.0", "mypy>=1.10", "ruff>=0.4"]
 docs = [
     "mkdocs>=1.5",

--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -1491,3 +1491,133 @@ def api_spec(
         typer.echo(f"OpenAPI spec written to {path}")
     else:
         typer.echo(text)
+
+
+# ── Artifact lifecycle commands (v0.8.3) ───────────────────
+
+artifacts_app = typer.Typer(
+    help="产物存储与生命周期管理 / Artifact storage and TTL lifecycle management.",
+    no_args_is_help=True,
+)
+app.add_typer(artifacts_app, name="artifacts")
+
+
+def _artifacts_open_store(backend: Optional[str], root: Optional[str]):
+    """Resolve the artifact store for the ``mn artifacts`` commands."""
+    from .cloud.artifact_store import ArtifactStoreError, get_artifact_store
+
+    try:
+        return get_artifact_store(backend=backend, root=root)
+    except ArtifactStoreError as e:
+        typer.echo(f"Artifact store unavailable: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@artifacts_app.command("list")
+def artifacts_list(
+    prefix: str = typer.Option("", "--prefix", help="仅列出该前缀下的产物 / Only list keys under this prefix"),
+    backend: Optional[str] = typer.Option(
+        None, "--backend", help="local 或 s3(默认读 MN_STORAGE_BACKEND) / Backend override"
+    ),
+    root: Optional[str] = typer.Option(
+        None, "--root", help="本地后端根目录(默认读 MN_STORAGE_ROOT) / Local store root"
+    ),
+):
+    """列出产物存储中的文件 / List artifacts in the configured store.
+
+    \b
+    示例 / Examples:
+        mn artifacts list
+        mn artifacts list --root output --prefix abc123
+    """
+    from .cloud.lifecycle import format_bytes
+
+    store = _artifacts_open_store(backend, root)
+    total = 0
+    count = 0
+    for info in store.list(prefix):
+        count += 1
+        total += info.size
+        typer.echo(f"  {info.key}  ({format_bytes(info.size)})")
+    if count == 0:
+        typer.echo("No artifacts found.")
+        return
+    typer.echo(f"{count} artifact(s), {format_bytes(total)} total.")
+
+
+@artifacts_app.command("cleanup")
+def artifacts_cleanup(
+    ttl: Optional[int] = typer.Option(
+        None, "--ttl", help="过期秒数,0=永久保留(默认读 MN_ARTIFACT_TTL) / TTL in seconds, 0 = keep forever"
+    ),
+    max_bytes: Optional[int] = typer.Option(
+        None, "--max-bytes", help="总容量上限字节数,0=不限(默认读 MN_ARTIFACT_MAX_BYTES) / Total size cap in bytes"
+    ),
+    keep_last: Optional[int] = typer.Option(
+        None, "--keep-last", help="始终保留最新 N 个产物(默认读 MN_ARTIFACT_KEEP_LAST) / Always keep the N newest"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="仅预览不删除 / Preview without deleting"
+    ),
+    prefix: str = typer.Option("", "--prefix", help="仅清理该前缀下的产物 / Restrict cleanup to this prefix"),
+    backend: Optional[str] = typer.Option(
+        None, "--backend", help="local 或 s3(默认读 MN_STORAGE_BACKEND) / Backend override"
+    ),
+    root: Optional[str] = typer.Option(
+        None, "--root", help="本地后端根目录(默认读 MN_STORAGE_ROOT) / Local store root"
+    ),
+):
+    """按 TTL / 容量上限清理产物 / Clean up artifacts by TTL and size cap.
+
+    未显式指定的选项回落到 MN_ARTIFACT_* 环境变量.
+    Options left unset fall back to the MN_ARTIFACT_* environment variables.
+
+    \b
+    示例 / Examples:
+        mn artifacts cleanup --dry-run
+        mn artifacts cleanup --ttl 604800 --keep-last 5
+        mn artifacts cleanup --max-bytes 10737418240
+    """
+    from .cloud.lifecycle import (
+        ArtifactLifecyclePolicy,
+        cleanup_artifacts,
+        describe_policy,
+    )
+
+    policy = ArtifactLifecyclePolicy.from_env(dry_run=dry_run)
+    if ttl is not None:
+        policy.ttl_seconds = max(ttl, 0)
+    if max_bytes is not None:
+        policy.max_total_bytes = max(max_bytes, 0)
+    if keep_last is not None:
+        policy.keep_last_n = max(keep_last, 0)
+
+    store = _artifacts_open_store(backend, root)
+
+    typer.echo("Artifact retention policy:")
+    for line in describe_policy(policy):
+        typer.echo(f"  {line}")
+
+    if not policy.enabled:
+        typer.echo(
+            "No retention rule active (--ttl / --max-bytes are both 0) — nothing to do."
+        )
+        return
+
+    report = cleanup_artifacts(store, policy, prefix=prefix)
+
+    if report.deleted:
+        header = "Would delete:" if report.dry_run else "Deleted:"
+        typer.echo(header)
+        for key in report.deleted:
+            typer.echo(f"  - {key}")
+    if report.skipped:
+        typer.echo(f"Kept (protected / keep-last): {len(report.skipped)}")
+    if report.errors:
+        typer.echo("Errors:", err=True)
+        for key, message in report.errors:
+            typer.echo(f"  ! {key}: {message}", err=True)
+
+    typer.echo(report.summary())
+    if report.errors:
+        raise typer.Exit(1)

--- a/src/movie_narrator/cloud/__init__.py
+++ b/src/movie_narrator/cloud/__init__.py
@@ -60,6 +60,23 @@ from .models import (
     TaskStatus,
 )
 from .storage import TaskStorage
+from .artifact_store import (
+    ArtifactInfo,
+    ArtifactNotFoundError,
+    ArtifactStoreError,
+    LocalArtifactStore,
+    S3ArtifactStore,
+    StorageBackend,
+    UnsafeKeyError,
+    get_artifact_store,
+    get_task_artifact_store,
+)
+from .lifecycle import (
+    ArtifactLifecyclePolicy,
+    ArtifactSweeper,
+    CleanupReport,
+    cleanup_artifacts,
+)
 from .queue import LocalTaskQueue, TaskQueue
 from .worker import CancelController, ProgressConsole, run_task
 from .health import build_health_payload, build_readiness_payload
@@ -87,6 +104,21 @@ __all__ = [
     "TERMINAL_STATES",
     # Storage
     "TaskStorage",
+    # Artifact store (v0.8.3)
+    "ArtifactInfo",
+    "ArtifactNotFoundError",
+    "ArtifactStoreError",
+    "LocalArtifactStore",
+    "S3ArtifactStore",
+    "StorageBackend",
+    "UnsafeKeyError",
+    "get_artifact_store",
+    "get_task_artifact_store",
+    # Artifact lifecycle (v0.8.3)
+    "ArtifactLifecyclePolicy",
+    "ArtifactSweeper",
+    "CleanupReport",
+    "cleanup_artifacts",
     # Queue
     "TaskQueue",
     "LocalTaskQueue",

--- a/src/movie_narrator/cloud/api.py
+++ b/src/movie_narrator/cloud/api.py
@@ -51,7 +51,21 @@ from ..utils.logging_config import (
     correlation_scope,
     get_correlation_id,
 )
+from .artifact_store import (  # v0.8.3 — artifact storage abstraction
+    ArtifactNotFoundError,
+    ArtifactStoreError,
+    StorageBackend,
+    UnsafeKeyError,
+    artifact_location,
+    get_artifact_store,
+    get_task_artifact_store,
+)
 from .health import build_health_payload, build_readiness_payload, parse_deep_flag
+from .lifecycle import (  # v0.8.3 — artifact lifecycle / TTL cleanup
+    ArtifactLifecyclePolicy,
+    ArtifactSweeper,
+    sweep_interval_from_env,
+)
 from .metrics import (
     CONTENT_TYPE_LATEST,
     record_error,
@@ -460,29 +474,25 @@ class _APIHandler(BaseHTTPRequestHandler):
     # ── Artifact helpers ────────────────────────────────────
 
     def _list_task_artifacts(self, task: Task) -> list:
-        """List available output files for a task."""
-        from pathlib import Path
-
-        result = task.result
-        if not result or not result.output_dir:
-            return []
-
-        output_dir = Path(result.output_dir)
-        if not output_dir.exists():
+        """List available output files for a task (v0.8.3: via the artifact store)."""
+        store = get_task_artifact_store(task.id, task.result.output_dir if task.result else None)
+        if store is None:
             return []
 
         artifacts = []
-        for item in sorted(output_dir.iterdir()):
-            if item.is_file() and not item.name.startswith("."):
-                artifacts.append({
-                    "filename": item.name,
-                    "size": item.stat().st_size,
-                    "path": str(item),
-                })
+        for info in sorted(store.list(), key=lambda i: i.key):
+            # Preserve v0.6.1 semantics: top-level files only, no dotfiles.
+            if "/" in info.key or info.key.startswith("."):
+                continue
+            artifacts.append({
+                "filename": info.key,
+                "size": info.size,
+                "path": artifact_location(store, info.key),
+            })
         return artifacts
 
     def _serve_task_artifact(self, task: Task, filename: str) -> None:
-        """Serve a file from the task's output directory."""
+        """Serve a file from the task's output directory (v0.8.3: via the artifact store)."""
         from pathlib import Path
         from urllib.parse import unquote
 
@@ -492,28 +502,29 @@ class _APIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.NOT_FOUND, "Task has no output directory")
             return
 
-        output_dir = Path(result.output_dir)
-        file_path = output_dir / filename
+        store = get_task_artifact_store(task.id, result.output_dir)
+        if store is None:
+            self._send_error(HTTPStatus.NOT_FOUND, f"File '{filename}' not found")
+            return
 
-        # Security: prevent path traversal
+        # Security: prevent path traversal (enforced by the store's key guard)
         try:
-            file_path = file_path.resolve()
-            output_dir = output_dir.resolve()
-            if not file_path.is_relative_to(output_dir):
-                self._send_error(HTTPStatus.FORBIDDEN, "Access denied")
-                return
+            info = store.stat(filename)
+        except UnsafeKeyError:
+            logger.debug("Rejected artifact download: unsafe key %r", filename)
+            self._send_error(HTTPStatus.FORBIDDEN, "Access denied")
+            return
+        except ArtifactNotFoundError:
+            self._send_error(HTTPStatus.NOT_FOUND, f"File '{filename}' not found")
+            return
         except Exception:  # noqa: BLE001
             logger.debug("Rejected artifact download: unsafe path %r failed resolution", filename)
             self._send_error(HTTPStatus.BAD_REQUEST, "Invalid filename")
             return
 
-        if not file_path.exists() or not file_path.is_file():
-            self._send_error(HTTPStatus.NOT_FOUND, f"File '{filename}' not found")
-            return
-
         # Determine content type
         content_type = "application/octet-stream"
-        ext = file_path.suffix.lower()
+        ext = Path(info.key).suffix.lower()
         if ext == ".mp4":
             content_type = "video/mp4"
         elif ext == ".mp3":
@@ -525,14 +536,14 @@ class _APIHandler(BaseHTTPRequestHandler):
         elif ext == ".md":
             content_type = "text/markdown"
 
-        file_size = file_path.stat().st_size
+        file_size = info.size
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(file_size))
         self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
         self.end_headers()
 
-        with open(file_path, "rb") as f:
+        with store.open(info.key) as f:
             while True:
                 chunk = f.read(64 * 1024)
                 if not chunk:
@@ -560,6 +571,12 @@ class TaskAPIServer:
         api_key: Optional X-API-Key for authenticating requests. When
             None (default), the server runs unauthenticated — safe only
             on loopback. Required when binding to a public interface.
+        artifact_store: Backend swept by the artifact lifecycle thread
+            (v0.8.3). Defaults to the store resolved from the
+            ``MN_STORAGE_*`` environment variables.
+        artifact_policy: Retention policy for that sweeper (v0.8.3).
+            Defaults to ``ArtifactLifecyclePolicy.from_env()``; when no
+            retention rule is configured no sweeper thread is started.
     """
 
     def __init__(
@@ -571,6 +588,8 @@ class TaskAPIServer:
         storage_dir=None,
         max_workers: int = 2,
         api_key: Optional[str] = None,
+        artifact_store: Optional[StorageBackend] = None,
+        artifact_policy: Optional[ArtifactLifecyclePolicy] = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -585,6 +604,9 @@ class TaskAPIServer:
         # Set by stop() so the /ready and /health probes can report that
         # the server is draining (v0.8.2).
         self._shutting_down = threading.Event()
+        self._artifact_store = artifact_store
+        self._artifact_policy = artifact_policy
+        self._sweeper: Optional[ArtifactSweeper] = None
 
     @property
     def queue(self) -> LocalTaskQueue:
@@ -627,6 +649,9 @@ class TaskAPIServer:
         # Update actual port (in case port=0 was used)
         self.port = self._server.server_address[1]
 
+        # v0.8.3: artifact TTL sweeper (no-op unless retention is configured)
+        self._start_artifact_sweeper()
+
         if blocking:
             logger.info("API server listening on %s:%d", self.host, self.port)
             try:
@@ -644,9 +669,47 @@ class TaskAPIServer:
             self._thread.start()
             logger.info("API server started on %s:%d", self.host, self.port)
 
+    # ── Artifact lifecycle (v0.8.3) ─────────────────────────
+
+    @property
+    def sweeper(self) -> Optional[ArtifactSweeper]:
+        """The running artifact sweeper, if artifact retention is enabled."""
+        return self._sweeper
+
+    def _active_task_ids(self) -> list:
+        """IDs of tasks that are still pending/running — never sweep those."""
+        return [t.id for t in self._queue.list_tasks(limit=1000) if t.is_active]
+
+    def _start_artifact_sweeper(self) -> None:
+        """Start the TTL sweeper when a retention rule is configured."""
+        if self._sweeper is not None:
+            return
+        policy = self._artifact_policy or ArtifactLifecyclePolicy.from_env()
+        if not policy.enabled:
+            return
+        store = self._artifact_store
+        if store is None:
+            try:
+                store = get_artifact_store()
+            except ArtifactStoreError as e:
+                logger.warning("Artifact sweeper disabled — store unavailable: %s", e)
+                return
+        self._sweeper = ArtifactSweeper(
+            store,
+            policy,
+            interval=sweep_interval_from_env(),
+            protected_ids=self._active_task_ids,
+        )
+        self._sweeper.start()
+
     def stop(self) -> None:
         """Stop the HTTP server."""
+        # Flag the draining state first so in-flight probes report it
+        # immediately, then tear the sweeper down.
         self._shutting_down.set()
+        if self._sweeper is not None:
+            self._sweeper.stop()
+            self._sweeper = None
         if self._server is not None:
             self._server.shutdown()
             self._server.server_close()

--- a/src/movie_narrator/cloud/artifact_store.py
+++ b/src/movie_narrator/cloud/artifact_store.py
@@ -1,0 +1,739 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Artifact (blob) storage abstraction (v0.8.3).
+
+This module abstracts *where the produced media files live* — the
+``final.mp4`` / narration audio / subtitles / ``metadata.json`` that a
+pipeline run writes into its output directory.
+
+It is deliberately **separate** from :mod:`movie_narrator.cloud.storage`,
+which persists *task state* (the ``TaskStorage`` JSON index of ``Task``
+records). The two solve different problems and must not be conflated:
+
+===========================  ==========================================
+``storage.TaskStorage``      task metadata (status, progress, result)
+``artifact_store``           the binary artifacts a task produced
+===========================  ==========================================
+
+The abstraction is a small, synchronous :class:`StorageBackend` protocol
+with two implementations:
+
+- :class:`LocalArtifactStore` — filesystem-backed, the **default**, and
+  the only backend needed for single-host deployments.
+- :class:`S3ArtifactStore` — S3 / MinIO / R2 compatible. ``boto3`` is an
+  optional dependency (``pip install movie-narrator[s3]``) imported
+  lazily so importing this module never requires it. The underlying
+  client is injectable, which keeps the class unit-testable without the
+  real library or network access.
+
+Keys are always **relative POSIX paths** (``"final.mp4"``,
+``"clips/001.mp4"``). Absolute paths, ``..`` segments, drive letters and
+anything that would escape the store root are rejected with
+:class:`UnsafeKeyError` — this preserves the path-traversal protection
+the REST API has enforced since v0.6.1.
+
+Typical usage::
+
+    from movie_narrator.cloud.artifact_store import get_artifact_store
+
+    store = get_artifact_store()              # resolves from env
+    store.put("final.mp4", "/tmp/final.mp4")
+    for info in store.list():
+        print(info.key, info.size)
+
+Environment variables:
+    ``MN_STORAGE_BACKEND``   ``local`` (default) or ``s3``
+    ``MN_STORAGE_ROOT``      root directory for the local backend
+    ``MN_S3_BUCKET``         bucket name (required for ``s3``)
+    ``MN_S3_PREFIX``         key prefix inside the bucket
+    ``MN_S3_ENDPOINT_URL``   custom endpoint (MinIO / Cloudflare R2)
+    ``MN_S3_REGION``         AWS region name
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import (
+    IO,
+    Any,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Union,
+    runtime_checkable,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Anything accepted where a filesystem path is expected.
+PathLike = Union[str, "os.PathLike[str]"]
+
+#: Default root for the local backend when ``MN_STORAGE_ROOT`` is unset.
+DEFAULT_LOCAL_ROOT = "output"
+
+
+# ── Errors ─────────────────────────────────────────────────
+
+
+class ArtifactStoreError(Exception):
+    """Base class for artifact-store failures."""
+
+
+class ArtifactNotFoundError(ArtifactStoreError):
+    """Raised when a key does not exist in the store."""
+
+
+class UnsafeKeyError(ArtifactStoreError):
+    """Raised when a key would escape the store root (path traversal)."""
+
+
+# ── Value objects ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ArtifactInfo:
+    """Metadata about a single stored artifact.
+
+    Attributes:
+        key: Store-relative POSIX key, e.g. ``"final.mp4"``.
+        size: Size in bytes.
+        modified_at: Last-modified time as a POSIX timestamp (seconds
+            since the epoch, UTC). Chosen over ``datetime`` so that TTL
+            arithmetic against :func:`time.time` stays trivial and
+            backend-agnostic.
+        etag: Backend-provided content hash, when available (S3). Always
+            ``None`` for the local backend.
+    """
+
+    key: str
+    size: int
+    modified_at: float
+    etag: Optional[str] = None
+
+
+# ── Protocol ───────────────────────────────────────────────
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """Synchronous key/blob storage for pipeline artifacts.
+
+    Implementations must treat *key* as a relative POSIX path and reject
+    anything that escapes their root (see :func:`normalize_key`).
+    """
+
+    def put(self, key: str, src_path: PathLike) -> ArtifactInfo:
+        """Upload/copy the local file *src_path* to *key*."""
+        ...
+
+    def get(self, key: str, dest_path: PathLike) -> Path:
+        """Download/copy *key* to the local file *dest_path*."""
+        ...
+
+    def open(self, key: str) -> IO[bytes]:  # noqa: A003 - mirrors builtin open() intent
+        """Return a readable binary stream for *key*."""
+        ...
+
+    def exists(self, key: str) -> bool:
+        """Return True when *key* exists."""
+        ...
+
+    def delete(self, key: str) -> bool:
+        """Delete *key*; return True when something was removed."""
+        ...
+
+    def list(self, prefix: str = "") -> Iterable[ArtifactInfo]:  # noqa: A003
+        """Yield metadata for every key under *prefix*."""
+        ...
+
+    def stat(self, key: str) -> ArtifactInfo:
+        """Return metadata for *key*, raising if it does not exist."""
+        ...
+
+    def url(self, key: str, *, expires_in: int = 3600) -> Optional[str]:
+        """Return a public/pre-signed URL for *key*, or None if unsupported."""
+        ...
+
+
+# ── Key handling ───────────────────────────────────────────
+
+
+def normalize_key(key: str) -> str:
+    """Validate *key* and return it as a clean relative POSIX path.
+
+    The rules mirror the REST API's long-standing download guard:
+    absolute paths, drive letters, ``..`` segments and empty keys are
+    all refused. ``.`` segments and redundant separators are collapsed.
+
+    Args:
+        key: Candidate store key. Both ``/`` and ``\\`` are accepted as
+            separators so Windows-style input is handled consistently.
+
+    Returns:
+        The normalized key, e.g. ``"clips/001.mp4"``.
+
+    Raises:
+        UnsafeKeyError: if the key is empty, absolute, or escapes the root.
+    """
+    if not isinstance(key, str) or not key.strip():
+        raise UnsafeKeyError("Artifact key must be a non-empty string")
+
+    candidate = key.replace("\\", "/").strip()
+    if candidate.startswith("/"):
+        raise UnsafeKeyError(f"Absolute artifact keys are not allowed: {key!r}")
+    # Windows drive letters ("C:/x") and UNC-ish forms are absolute too.
+    if len(candidate) >= 2 and candidate[1] == ":":
+        raise UnsafeKeyError(f"Absolute artifact keys are not allowed: {key!r}")
+
+    parts: List[str] = []
+    for part in PurePosixPath(candidate).parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            raise UnsafeKeyError(f"Artifact key escapes the store root: {key!r}")
+        parts.append(part)
+
+    if not parts:
+        raise UnsafeKeyError(f"Artifact key resolves to the store root: {key!r}")
+    return "/".join(parts)
+
+
+def join_prefix(prefix: str, key: str) -> str:
+    """Join a store prefix and a key into a single POSIX key."""
+    clean_prefix = prefix.replace("\\", "/").strip("/")
+    clean_key = key.replace("\\", "/").strip("/")
+    if not clean_prefix:
+        return clean_key
+    if not clean_key:
+        return clean_prefix
+    return f"{clean_prefix}/{clean_key}"
+
+
+# ── Local backend ──────────────────────────────────────────
+
+
+class LocalArtifactStore:
+    """Filesystem-backed :class:`StorageBackend` (the default).
+
+    Every key is resolved beneath *root*; a key that resolves outside of
+    it raises :class:`UnsafeKeyError` even when symlinks are involved,
+    because the check is performed on the *resolved* paths.
+
+    Args:
+        root: Directory that holds the artifacts. Created on demand.
+    """
+
+    def __init__(self, root: PathLike) -> None:
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._resolved_root = self._root.resolve()
+
+    # ── Introspection ───────────────────────────────────────
+
+    @property
+    def root(self) -> Path:
+        """The store root exactly as configured (not resolved)."""
+        return self._root
+
+    def local_path(self, key: str) -> Path:
+        """Return the on-disk path for *key* (validated, not resolved).
+
+        Keeping the unresolved form means callers see the same paths the
+        pipeline reported in ``TaskResult.output_dir``.
+
+        Raises:
+            UnsafeKeyError: if *key* escapes the store root.
+        """
+        return self._root / normalize_key(key)
+
+    # ── StorageBackend ──────────────────────────────────────
+
+    def put(self, key: str, src_path: PathLike) -> ArtifactInfo:
+        """Copy *src_path* into the store under *key*."""
+        target = self._safe_path(key)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(os.fspath(src_path), target)
+        return self._info(normalize_key(key), target)
+
+    def get(self, key: str, dest_path: PathLike) -> Path:
+        """Copy *key* out of the store to *dest_path*."""
+        source = self._existing_path(key)
+        dest = Path(dest_path)
+        if dest.parent and not dest.parent.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, dest)
+        return dest
+
+    def open(self, key: str) -> IO[bytes]:  # noqa: A003
+        """Open *key* for binary reading."""
+        return self._existing_path(key).open("rb")
+
+    def exists(self, key: str) -> bool:
+        """Return True when *key* is an existing regular file."""
+        try:
+            return self._safe_path(key).is_file()
+        except UnsafeKeyError:
+            return False
+
+    def delete(self, key: str) -> bool:
+        """Remove *key*; return True when a file was removed."""
+        path = self._safe_path(key)
+        if not path.is_file():
+            return False
+        path.unlink()
+        return True
+
+    def list(self, prefix: str = "") -> Iterator[ArtifactInfo]:  # noqa: A003
+        """Yield every file under *prefix*, recursively, sorted by key."""
+        clean_prefix = prefix.replace("\\", "/").strip("/")
+        base = self._root
+        if clean_prefix:
+            try:
+                base = self._safe_path(clean_prefix)
+            except UnsafeKeyError:
+                return
+        if not base.is_dir():
+            return
+
+        for path in sorted(p for p in base.rglob("*") if p.is_file()):
+            try:
+                key = path.relative_to(self._root).as_posix()
+            except ValueError:  # pragma: no cover - defensive
+                continue
+            yield self._info(key, path)
+
+    def stat(self, key: str) -> ArtifactInfo:
+        """Return metadata for *key*."""
+        path = self._existing_path(key)
+        return self._info(normalize_key(key), path)
+
+    def url(self, key: str, *, expires_in: int = 3600) -> Optional[str]:
+        """Local files have no shareable URL — always None."""
+        return None
+
+    # ── Internals ───────────────────────────────────────────
+
+    def _safe_path(self, key: str) -> Path:
+        """Resolve *key* under the root, refusing anything that escapes."""
+        candidate = self._root / normalize_key(key)
+        if not _is_within(candidate.resolve(), self._resolved_root):
+            raise UnsafeKeyError(f"Artifact key escapes the store root: {key!r}")
+        return candidate
+
+    def _existing_path(self, key: str) -> Path:
+        path = self._safe_path(key)
+        if not path.is_file():
+            raise ArtifactNotFoundError(f"Artifact not found: {key!r}")
+        return path
+
+    @staticmethod
+    def _info(key: str, path: Path) -> ArtifactInfo:
+        stat = path.stat()
+        return ArtifactInfo(key=key, size=stat.st_size, modified_at=stat.st_mtime)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True when *path* is inside *root* (both already resolved)."""
+    try:
+        return path.is_relative_to(root)
+    except (AttributeError, ValueError):  # pragma: no cover - py<3.9 / mixed drives
+        return False
+
+
+# ── S3 backend ─────────────────────────────────────────────
+
+
+_S3_MISSING_HINT = (
+    "The S3 artifact backend requires boto3, which is not installed.\n"
+    "Install it with:  pip install 'movie-narrator[s3]'\n"
+    "Or switch back to the local backend:  MN_STORAGE_BACKEND=local"
+)
+
+
+class S3ArtifactStore:
+    """S3-compatible :class:`StorageBackend` (AWS S3, MinIO, R2).
+
+    ``boto3`` is imported lazily inside ``__init__`` so that merely
+    importing this module — or running the default local backend — never
+    requires the optional dependency.
+
+    The client is injectable, which makes the class testable without
+    boto3 or network access::
+
+        store = S3ArtifactStore(bucket="b", client=FakeS3Client())
+
+    Args:
+        bucket: Target bucket name.
+        prefix: Key prefix inside the bucket (optional).
+        client: Pre-built boto3 S3 client. When provided, boto3 is not
+            imported at all.
+        endpoint_url: Custom endpoint for MinIO / R2 compatibility.
+        region_name: AWS region name.
+
+    Raises:
+        ArtifactStoreError: if *bucket* is empty, or if boto3 is missing
+            and no *client* was injected.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str = "",
+        *,
+        client: Any = None,
+        endpoint_url: Optional[str] = None,
+        region_name: Optional[str] = None,
+    ) -> None:
+        if not bucket:
+            raise ArtifactStoreError(
+                "S3 artifact backend requires a bucket name (set MN_S3_BUCKET)."
+            )
+        self.bucket = bucket
+        self.prefix = prefix.replace("\\", "/").strip("/")
+
+        if client is None:
+            try:
+                # Imported lazily: boto3 is an optional extra, and the
+                # default local backend must never require it.
+                import boto3
+            except ImportError as exc:  # pragma: no cover - boto3 absent in CI
+                raise ArtifactStoreError(_S3_MISSING_HINT) from exc
+            client = boto3.client(
+                "s3",
+                endpoint_url=endpoint_url,
+                region_name=region_name,
+            )
+        self._client = client
+
+    # ── Introspection ───────────────────────────────────────
+
+    @property
+    def client(self) -> Any:
+        """The underlying S3 client (boto3 or an injected double)."""
+        return self._client
+
+    def object_key(self, key: str) -> str:
+        """Return the fully-qualified bucket key for a store *key*."""
+        return join_prefix(self.prefix, normalize_key(key))
+
+    # ── StorageBackend ──────────────────────────────────────
+
+    def put(self, key: str, src_path: PathLike) -> ArtifactInfo:
+        """Upload the local file *src_path* to *key*."""
+        clean = normalize_key(key)
+        self._client.upload_file(os.fspath(src_path), self.bucket, self.object_key(clean))
+        return self.stat(clean)
+
+    def get(self, key: str, dest_path: PathLike) -> Path:
+        """Download *key* to the local file *dest_path*."""
+        dest = Path(dest_path)
+        if dest.parent and not dest.parent.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._client.download_file(self.bucket, self.object_key(key), os.fspath(dest))
+        except UnsafeKeyError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - botocore raises client-specific errors
+            raise _translate_s3_error(exc, key) from exc
+        return dest
+
+    def open(self, key: str) -> IO[bytes]:  # noqa: A003
+        """Return the streaming body of *key*."""
+        try:
+            response = self._client.get_object(
+                Bucket=self.bucket, Key=self.object_key(key)
+            )
+        except UnsafeKeyError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise _translate_s3_error(exc, key) from exc
+        body: IO[bytes] = response["Body"]
+        return body
+
+    def exists(self, key: str) -> bool:
+        """Return True when *key* exists in the bucket."""
+        try:
+            self.stat(key)
+        except ArtifactStoreError:
+            return False
+        return True
+
+    def delete(self, key: str) -> bool:
+        """Delete *key*; returns False when it did not exist."""
+        if not self.exists(key):
+            return False
+        self._client.delete_object(Bucket=self.bucket, Key=self.object_key(key))
+        return True
+
+    def list(self, prefix: str = "") -> Iterator[ArtifactInfo]:  # noqa: A003
+        """Yield metadata for every object under *prefix*."""
+        search_prefix = join_prefix(self.prefix, prefix.replace("\\", "/").strip("/"))
+        for page in self._paginate(search_prefix):
+            for obj in page.get("Contents", []) or []:
+                raw_key = str(obj.get("Key", ""))
+                key = self._strip_prefix(raw_key)
+                if not key or raw_key.endswith("/"):
+                    continue
+                yield ArtifactInfo(
+                    key=key,
+                    size=int(obj.get("Size", 0)),
+                    modified_at=_as_timestamp(obj.get("LastModified")),
+                    etag=_clean_etag(obj.get("ETag")),
+                )
+
+    def stat(self, key: str) -> ArtifactInfo:
+        """Return metadata for *key* via ``head_object``."""
+        clean = normalize_key(key)
+        try:
+            head = self._client.head_object(Bucket=self.bucket, Key=self.object_key(clean))
+        except Exception as exc:  # noqa: BLE001
+            raise _translate_s3_error(exc, key) from exc
+        return ArtifactInfo(
+            key=clean,
+            size=int(head.get("ContentLength", 0)),
+            modified_at=_as_timestamp(head.get("LastModified")),
+            etag=_clean_etag(head.get("ETag")),
+        )
+
+    def url(self, key: str, *, expires_in: int = 3600) -> Optional[str]:
+        """Return a pre-signed GET URL, or None when unsupported."""
+        generate = getattr(self._client, "generate_presigned_url", None)
+        if generate is None:
+            return None
+        try:
+            signed = generate(
+                "get_object",
+                Params={"Bucket": self.bucket, "Key": self.object_key(key)},
+                ExpiresIn=expires_in,
+            )
+        except Exception as exc:  # noqa: BLE001 - URL signing is best-effort
+            logger.debug("Failed to pre-sign URL for %r: %s", key, exc)
+            return None
+        return str(signed) if signed else None
+
+    # ── Internals ───────────────────────────────────────────
+
+    def _paginate(self, prefix: str) -> Iterator[Mapping[str, Any]]:
+        """Yield ``list_objects_v2`` pages, using a paginator when available."""
+        get_paginator = getattr(self._client, "get_paginator", None)
+        if get_paginator is not None:
+            try:
+                paginator = get_paginator("list_objects_v2")
+            except Exception:  # noqa: BLE001 - fall back to the plain call
+                paginator = None
+            if paginator is not None:
+                yield from paginator.paginate(Bucket=self.bucket, Prefix=prefix)
+                return
+
+        token: Optional[str] = None
+        while True:
+            kwargs: dict[str, Any] = {"Bucket": self.bucket, "Prefix": prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            page = self._client.list_objects_v2(**kwargs)
+            yield page
+            if not page.get("IsTruncated"):
+                return
+            token = page.get("NextContinuationToken")
+            if not token:
+                return
+
+    def _strip_prefix(self, raw_key: str) -> str:
+        if not self.prefix:
+            return raw_key.lstrip("/")
+        marker = self.prefix + "/"
+        if raw_key.startswith(marker):
+            return raw_key[len(marker):]
+        if raw_key == self.prefix:
+            return ""
+        return raw_key.lstrip("/")
+
+
+#: Error codes/markers that mean "the object is simply not there".
+_S3_MISSING_MARKERS = ("NoSuchKey", "NoSuchBucket", "NotFound", "404")
+
+
+def _translate_s3_error(exc: Exception, key: str) -> ArtifactStoreError:
+    """Map a botocore/client exception onto an artifact-store error.
+
+    ``botocore.exceptions.ClientError`` carries the S3 error code in its
+    ``response`` payload; anything else is matched on the exception name
+    and message so that MinIO/R2 clients and test doubles behave the
+    same way.
+    """
+    if isinstance(exc, (FileNotFoundError, ArtifactNotFoundError)):
+        return ArtifactNotFoundError(f"Artifact not found: {key!r}")
+
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error", {})
+        code = str(error.get("Code", "")) if isinstance(error, dict) else ""
+        status = str(
+            response.get("ResponseMetadata", {}).get("HTTPStatusCode", "")
+        )
+        if code in _S3_MISSING_MARKERS or status == "404":
+            return ArtifactNotFoundError(f"Artifact not found: {key!r}")
+
+    haystack = f"{type(exc).__name__} {exc}"
+    if any(marker in haystack for marker in _S3_MISSING_MARKERS):
+        return ArtifactNotFoundError(f"Artifact not found: {key!r}")
+    return ArtifactStoreError(f"S3 operation failed for {key!r}: {exc}")
+
+
+def _as_timestamp(value: Any) -> float:
+    """Convert an S3 ``LastModified`` value to a POSIX timestamp."""
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    timestamp = getattr(value, "timestamp", None)
+    if callable(timestamp):
+        return float(timestamp())
+    return 0.0
+
+
+def _clean_etag(value: Any) -> Optional[str]:
+    """Strip the quotes S3 wraps around ETags."""
+    if not value:
+        return None
+    return str(value).strip('"')
+
+
+# ── Factory ────────────────────────────────────────────────
+
+
+def get_artifact_store(
+    *,
+    backend: Optional[str] = None,
+    root: Optional[PathLike] = None,
+    sub_prefix: str = "",
+    env: Optional[Mapping[str, str]] = None,
+) -> StorageBackend:
+    """Build the configured artifact store.
+
+    Resolution order for every setting is *explicit argument* →
+    *environment variable* → *default*.
+
+    Args:
+        backend: ``"local"`` or ``"s3"``. Defaults to
+            ``MN_STORAGE_BACKEND`` and ultimately ``"local"``.
+        root: Local root directory (local backend only). Defaults to
+            ``MN_STORAGE_ROOT`` and ultimately ``"output"``.
+        sub_prefix: Extra prefix appended to the store scope — used to
+            scope a store to a single task (``sub_prefix=task_id``).
+        env: Environment mapping to read from (defaults to ``os.environ``;
+            injectable for tests).
+
+    Returns:
+        A ready-to-use :class:`StorageBackend`.
+
+    Raises:
+        ArtifactStoreError: for an unknown backend name, a missing bucket,
+            or a missing boto3 install.
+    """
+    environ: Mapping[str, str] = os.environ if env is None else env
+    name = (backend or environ.get("MN_STORAGE_BACKEND") or "local").strip().lower()
+
+    if name == "local":
+        base = Path(root) if root is not None else Path(
+            environ.get("MN_STORAGE_ROOT") or DEFAULT_LOCAL_ROOT
+        )
+        if sub_prefix:
+            base = base / normalize_key(sub_prefix)
+        return LocalArtifactStore(base)
+
+    if name == "s3":
+        bucket = environ.get("MN_S3_BUCKET", "")
+        if not bucket:
+            raise ArtifactStoreError(
+                "MN_STORAGE_BACKEND=s3 requires MN_S3_BUCKET to be set."
+            )
+        prefix = join_prefix(environ.get("MN_S3_PREFIX", ""), sub_prefix)
+        return S3ArtifactStore(
+            bucket=bucket,
+            prefix=prefix,
+            endpoint_url=environ.get("MN_S3_ENDPOINT_URL") or None,
+            region_name=environ.get("MN_S3_REGION") or None,
+        )
+
+    raise ArtifactStoreError(
+        f"Unknown storage backend {name!r}. Supported backends: 'local', 's3'."
+    )
+
+
+def get_task_artifact_store(
+    task_id: str,
+    output_dir: Optional[PathLike] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[StorageBackend]:
+    """Return a store scoped to a single task's artifacts.
+
+    For the default local backend the scope is the task's own output
+    directory, so behaviour is byte-for-byte identical to the direct
+    filesystem access the REST API used before v0.8.3. For remote
+    backends the scope is the ``<prefix>/<task_id>/`` key namespace.
+
+    Args:
+        task_id: The task whose artifacts should be exposed.
+        output_dir: The task's local output directory (from
+            ``TaskResult.output_dir``).
+        env: Environment mapping to read from (defaults to ``os.environ``).
+
+    Returns:
+        A task-scoped :class:`StorageBackend`, or None when the task has
+        no usable artifact location (e.g. the output directory is gone).
+    """
+    environ: Mapping[str, str] = os.environ if env is None else env
+    name = (environ.get("MN_STORAGE_BACKEND") or "local").strip().lower()
+
+    if name == "local":
+        if output_dir is None:
+            return None
+        base = Path(output_dir)
+        if not base.is_dir():
+            return None
+        return LocalArtifactStore(base)
+
+    try:
+        return get_artifact_store(sub_prefix=task_id, env=environ)
+    except ArtifactStoreError as exc:
+        logger.warning("Artifact store unavailable for task %s: %s", task_id, exc)
+        return None
+
+
+def artifact_location(store: StorageBackend, key: str) -> str:
+    """Return a consumer-facing location string for *key*.
+
+    Local stores report the on-disk path (unchanged from v0.6.1);
+    remote stores report a pre-signed URL when they can produce one,
+    falling back to the bare key.
+    """
+    if isinstance(store, LocalArtifactStore):
+        return str(store.local_path(key))
+    return store.url(key) or key
+
+
+__all__ = [
+    "DEFAULT_LOCAL_ROOT",
+    "ArtifactInfo",
+    "ArtifactNotFoundError",
+    "ArtifactStoreError",
+    "LocalArtifactStore",
+    "S3ArtifactStore",
+    "StorageBackend",
+    "UnsafeKeyError",
+    "artifact_location",
+    "get_artifact_store",
+    "get_task_artifact_store",
+    "join_prefix",
+    "normalize_key",
+]

--- a/src/movie_narrator/cloud/lifecycle.py
+++ b/src/movie_narrator/cloud/lifecycle.py
@@ -1,0 +1,480 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Artifact lifecycle — TTL-based cleanup and retention (v0.8.3).
+
+Rendered artifacts (``final.mp4``, narration audio, subtitles, clips)
+are large and pile up quickly on a long-running worker. This module
+adds a retention policy on top of the :class:`~movie_narrator.cloud.
+artifact_store.StorageBackend` abstraction:
+
+- **TTL** — delete artifacts older than ``ttl_seconds``.
+- **Size cap** — evict oldest-first until the store fits in
+  ``max_total_bytes``.
+- **keep_last_n** — always retain the N most recent artifacts, no
+  matter what the two rules above say.
+- **Protection** — never touch artifacts belonging to a task that is
+  still pending/running; callers pass ``protected_keys`` or an
+  ``is_protected`` predicate.
+- **dry_run** — report what *would* be deleted without deleting.
+
+Everything is expressed as a pure function, :func:`cleanup_artifacts`,
+so it can be unit-tested with a frozen clock. :class:`ArtifactSweeper`
+wraps it in a daemon thread for the API server, and ``mn artifacts
+cleanup`` exposes it on the CLI.
+
+Environment variables:
+    ``MN_ARTIFACT_TTL``             TTL in seconds (0 = keep forever, default)
+    ``MN_ARTIFACT_MAX_BYTES``       total size cap in bytes (0 = unlimited)
+    ``MN_ARTIFACT_KEEP_LAST``       always keep the N newest (0 = disabled)
+    ``MN_ARTIFACT_SWEEP_INTERVAL``  sweeper period in seconds (default 3600)
+
+Typical usage::
+
+    from movie_narrator.cloud.artifact_store import get_artifact_store
+    from movie_narrator.cloud.lifecycle import (
+        ArtifactLifecyclePolicy, cleanup_artifacts,
+    )
+
+    policy = ArtifactLifecyclePolicy(ttl_seconds=7 * 86400, keep_last_n=5)
+    report = cleanup_artifacts(get_artifact_store(), policy)
+    print(report.summary())
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+from .artifact_store import ArtifactInfo, ArtifactStoreError, StorageBackend
+
+logger = logging.getLogger(__name__)
+
+#: Default sweeper period when ``MN_ARTIFACT_SWEEP_INTERVAL`` is unset.
+DEFAULT_SWEEP_INTERVAL = 3600.0
+
+#: Predicate deciding whether an artifact must be preserved.
+ProtectionPredicate = Callable[[ArtifactInfo], bool]
+
+
+# ── Policy ─────────────────────────────────────────────────
+
+
+def _env_int(env: Mapping[str, str], name: str, default: int) -> int:
+    """Read a non-negative integer env var, falling back to *default*."""
+    raw = env.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = int(str(raw).strip())
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r (expected an integer)", name, raw)
+        return default
+    if value < 0:
+        logger.warning("Ignoring negative %s=%r", name, raw)
+        return default
+    return value
+
+
+@dataclass
+class ArtifactLifecyclePolicy:
+    """Retention rules for stored artifacts.
+
+    Attributes:
+        ttl_seconds: Delete artifacts at least this old. ``0`` disables
+            TTL expiry (keep forever) — the default, so existing
+            deployments never lose data by upgrading.
+        max_total_bytes: Cap on the total size of the store. ``0``
+            means unlimited. Enforced oldest-first after TTL expiry.
+        keep_last_n: Always retain the N newest artifacts. ``0``
+            disables the guarantee.
+        dry_run: When True nothing is deleted; the report lists what
+            *would* have been removed.
+    """
+
+    ttl_seconds: int = 0
+    max_total_bytes: int = 0
+    keep_last_n: int = 0
+    dry_run: bool = False
+
+    @property
+    def enabled(self) -> bool:
+        """True when at least one reclaiming rule is active."""
+        return self.ttl_seconds > 0 or self.max_total_bytes > 0
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Optional[Mapping[str, str]] = None,
+        *,
+        dry_run: bool = False,
+    ) -> "ArtifactLifecyclePolicy":
+        """Build a policy from ``MN_ARTIFACT_*`` environment variables."""
+        environ: Mapping[str, str] = os.environ if env is None else env
+        return cls(
+            ttl_seconds=_env_int(environ, "MN_ARTIFACT_TTL", 0),
+            max_total_bytes=_env_int(environ, "MN_ARTIFACT_MAX_BYTES", 0),
+            keep_last_n=_env_int(environ, "MN_ARTIFACT_KEEP_LAST", 0),
+            dry_run=dry_run,
+        )
+
+
+def sweep_interval_from_env(env: Optional[Mapping[str, str]] = None) -> float:
+    """Return the sweeper period from ``MN_ARTIFACT_SWEEP_INTERVAL``."""
+    environ: Mapping[str, str] = os.environ if env is None else env
+    raw = environ.get("MN_ARTIFACT_SWEEP_INTERVAL")
+    if raw is None or not str(raw).strip():
+        return DEFAULT_SWEEP_INTERVAL
+    try:
+        value = float(str(raw).strip())
+    except ValueError:
+        logger.warning("Ignoring invalid MN_ARTIFACT_SWEEP_INTERVAL=%r", raw)
+        return DEFAULT_SWEEP_INTERVAL
+    if value <= 0:
+        logger.warning("Ignoring non-positive MN_ARTIFACT_SWEEP_INTERVAL=%r", raw)
+        return DEFAULT_SWEEP_INTERVAL
+    return value
+
+
+# ── Report ─────────────────────────────────────────────────
+
+
+def format_bytes(size: float) -> str:
+    """Render a byte count in human-readable form (1 KB = 1024 B)."""
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(value) < 1024.0 or unit == "TB":
+            if unit == "B":
+                return f"{int(value)} B"
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} TB"  # pragma: no cover - unreachable
+
+
+@dataclass
+class CleanupReport:
+    """Outcome of a :func:`cleanup_artifacts` run.
+
+    Attributes:
+        deleted: Keys removed (or, in dry-run mode, that would be).
+        freed_bytes: Bytes reclaimed by those deletions.
+        skipped: Keys deliberately preserved (protected or kept by
+            ``keep_last_n``) that a rule would otherwise have removed.
+        errors: ``(key, message)`` pairs for deletions that failed. A
+            failure never aborts the sweep.
+        scanned: Number of artifacts examined.
+        dry_run: Whether this was a preview.
+    """
+
+    deleted: List[str] = field(default_factory=list)
+    freed_bytes: int = 0
+    skipped: List[str] = field(default_factory=list)
+    errors: List[Tuple[str, str]] = field(default_factory=list)
+    scanned: int = 0
+    dry_run: bool = False
+
+    @property
+    def deleted_count(self) -> int:
+        """Number of artifacts deleted."""
+        return len(self.deleted)
+
+    def summary(self) -> str:
+        """Return a one-line human-readable summary."""
+        prefix = "[dry-run] would delete" if self.dry_run else "deleted"
+        return (
+            f"{prefix} {len(self.deleted)} artifact(s), "
+            f"{format_bytes(self.freed_bytes)} freed, "
+            f"{len(self.skipped)} kept, {len(self.errors)} error(s) "
+            f"({self.scanned} scanned)"
+        )
+
+
+# ── Cleanup ────────────────────────────────────────────────
+
+
+def make_task_protection(active_task_ids: Iterable[str]) -> ProtectionPredicate:
+    """Protect artifacts owned by still-running tasks.
+
+    Assumes the task-scoped key layout ``<task_id>/<filename>`` used by
+    :func:`~movie_narrator.cloud.artifact_store.get_task_artifact_store`
+    for remote backends, and also matches a bare ``<task_id>`` key.
+
+    Args:
+        active_task_ids: IDs of tasks that are pending/running/retrying.
+
+    Returns:
+        A predicate suitable for ``cleanup_artifacts(is_protected=...)``.
+    """
+    ids: Set[str] = {tid for tid in active_task_ids if tid}
+
+    def _protected(info: ArtifactInfo) -> bool:
+        head = info.key.split("/", 1)[0]
+        return head in ids
+
+    return _protected
+
+
+def cleanup_artifacts(
+    store: StorageBackend,
+    policy: ArtifactLifecyclePolicy,
+    *,
+    now: Optional[float] = None,
+    prefix: str = "",
+    protected_keys: Optional[Iterable[str]] = None,
+    is_protected: Optional[ProtectionPredicate] = None,
+) -> CleanupReport:
+    """Apply *policy* to the artifacts in *store*.
+
+    The passes run in this order:
+
+    1. **TTL** — every artifact whose age is ``>= policy.ttl_seconds``
+       is deleted (skipped when ``ttl_seconds == 0``).
+    2. **Size cap** — while the surviving artifacts exceed
+       ``policy.max_total_bytes``, the oldest is evicted.
+
+    Both passes refuse to touch a protected artifact or one of the
+    ``keep_last_n`` newest artifacts; such candidates are recorded in
+    ``report.skipped`` instead.
+
+    Args:
+        store: Backend to clean.
+        policy: Retention rules to apply.
+        now: POSIX timestamp treated as "current time". Defaults to
+            :func:`time.time`; injectable so tests can freeze the clock.
+        prefix: Restrict the sweep to keys under this prefix.
+        protected_keys: Exact keys that must never be deleted — the
+            simple way for a caller to guard in-flight work.
+        is_protected: Predicate for the same purpose, evaluated per
+            artifact (e.g. :func:`make_task_protection`).
+
+    Returns:
+        A :class:`CleanupReport`. Deletion failures are collected in
+        ``report.errors`` rather than raised, so one bad file cannot
+        abort a sweep.
+    """
+    current = time.time() if now is None else now
+    guarded: Set[str] = set(protected_keys or ())
+
+    try:
+        artifacts: List[ArtifactInfo] = list(store.list(prefix))
+    except ArtifactStoreError as exc:
+        report = CleanupReport(dry_run=policy.dry_run)
+        report.errors.append((prefix or "<all>", str(exc)))
+        return report
+
+    # Oldest first — both passes evict from the front.
+    artifacts.sort(key=lambda info: (info.modified_at, info.key))
+    report = CleanupReport(scanned=len(artifacts), dry_run=policy.dry_run)
+
+    # The ``keep_last_n`` newest artifacts are exempt from every rule.
+    kept_recent: Set[str] = set()
+    if policy.keep_last_n > 0:
+        kept_recent = {info.key for info in artifacts[-policy.keep_last_n:]}
+
+    def _exempt(info: ArtifactInfo) -> bool:
+        if info.key in guarded:
+            return True
+        if info.key in kept_recent:
+            return True
+        return bool(is_protected and is_protected(info))
+
+    def _remove(info: ArtifactInfo) -> bool:
+        """Delete *info* honouring dry-run; returns True on success."""
+        if policy.dry_run:
+            report.deleted.append(info.key)
+            report.freed_bytes += info.size
+            return True
+        try:
+            store.delete(info.key)
+        except Exception as exc:  # noqa: BLE001 - one bad key must not abort the sweep
+            logger.warning("Failed to delete artifact %r: %s", info.key, exc)
+            report.errors.append((info.key, str(exc)))
+            return False
+        report.deleted.append(info.key)
+        report.freed_bytes += info.size
+        return True
+
+    survivors: List[ArtifactInfo] = []
+
+    # ── Pass 1: TTL expiry ─────────────────────────────────
+    for info in artifacts:
+        expired = policy.ttl_seconds > 0 and (current - info.modified_at) >= policy.ttl_seconds
+        if not expired:
+            survivors.append(info)
+            continue
+        if _exempt(info):
+            report.skipped.append(info.key)
+            survivors.append(info)
+            continue
+        if not _remove(info):
+            survivors.append(info)
+
+    # ── Pass 2: total size cap ─────────────────────────────
+    if policy.max_total_bytes > 0:
+        total = sum(info.size for info in survivors)
+        for info in list(survivors):
+            if total <= policy.max_total_bytes:
+                break
+            if _exempt(info):
+                if info.key not in report.skipped:
+                    report.skipped.append(info.key)
+                continue
+            if _remove(info):
+                total -= info.size
+                survivors.remove(info)
+
+    return report
+
+
+# ── Background sweeper ─────────────────────────────────────
+
+
+class ArtifactSweeper:
+    """Daemon thread that periodically runs :func:`cleanup_artifacts`.
+
+    Started by :class:`~movie_narrator.cloud.api.TaskAPIServer` when a
+    retention rule is configured. The loop is deliberately defensive: a
+    failing sweep is logged and retried on the next tick, never
+    propagated, so artifact housekeeping can not take the API server
+    down.
+
+    Args:
+        store: Backend to sweep.
+        policy: Retention rules.
+        interval: Seconds between sweeps.
+        protected_ids: Callable returning the IDs of tasks that are
+            currently in flight; their artifacts are preserved.
+        prefix: Restrict sweeping to keys under this prefix.
+        name: Thread name.
+    """
+
+    def __init__(
+        self,
+        store: StorageBackend,
+        policy: ArtifactLifecyclePolicy,
+        *,
+        interval: float = DEFAULT_SWEEP_INTERVAL,
+        protected_ids: Optional[Callable[[], Iterable[str]]] = None,
+        prefix: str = "",
+        name: str = "mn-artifact-sweeper",
+    ) -> None:
+        self._store = store
+        self._policy = policy
+        self._interval = max(float(interval), 1.0)
+        self._protected_ids = protected_ids
+        self._prefix = prefix
+        self._name = name
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._last_report: Optional[CleanupReport] = None
+
+    # ── Introspection ───────────────────────────────────────
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the sweeper thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def interval(self) -> float:
+        """Seconds between sweeps."""
+        return self._interval
+
+    @property
+    def last_report(self) -> Optional[CleanupReport]:
+        """Report from the most recent sweep (None before the first)."""
+        return self._last_report
+
+    # ── Lifecycle ───────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start the background thread (no-op when already running)."""
+        if self.is_running:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, name=self._name, daemon=True)
+        self._thread.start()
+        logger.info(
+            "Artifact sweeper started (interval=%.0fs, ttl=%ds, max_bytes=%d, keep_last=%d)",
+            self._interval,
+            self._policy.ttl_seconds,
+            self._policy.max_total_bytes,
+            self._policy.keep_last_n,
+        )
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Signal the thread to exit and wait up to *timeout* seconds."""
+        self._stop.set()
+        thread, self._thread = self._thread, None
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    def sweep_once(self) -> Optional[CleanupReport]:
+        """Run a single sweep; returns None when the sweep failed."""
+        protection: Optional[ProtectionPredicate] = None
+        if self._protected_ids is not None:
+            try:
+                protection = make_task_protection(self._protected_ids())
+            except Exception as exc:  # noqa: BLE001 - never trust the callback
+                logger.warning("Artifact sweeper could not resolve active tasks: %s", exc)
+                return None
+        try:
+            report = cleanup_artifacts(
+                self._store,
+                self._policy,
+                prefix=self._prefix,
+                is_protected=protection,
+            )
+        except Exception as exc:  # noqa: BLE001 - housekeeping must never crash the server
+            logger.warning("Artifact sweep failed: %s", exc)
+            return None
+        self._last_report = report
+        if report.deleted or report.errors:
+            logger.info("Artifact sweep: %s", report.summary())
+        return report
+
+    # ── Internals ───────────────────────────────────────────
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            self.sweep_once()
+            if self._stop.wait(self._interval):
+                break
+        logger.debug("Artifact sweeper stopped")
+
+    def __enter__(self) -> "ArtifactSweeper":
+        self.start()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.stop()
+
+
+def describe_policy(policy: ArtifactLifecyclePolicy) -> Sequence[str]:
+    """Return human-readable lines describing *policy* (used by the CLI)."""
+    lines = [
+        f"ttl_seconds     : {policy.ttl_seconds or 'disabled'}",
+        f"max_total_bytes : "
+        f"{format_bytes(policy.max_total_bytes) if policy.max_total_bytes else 'unlimited'}",
+        f"keep_last_n     : {policy.keep_last_n or 'disabled'}",
+        f"dry_run         : {policy.dry_run}",
+    ]
+    return lines
+
+
+__all__ = [
+    "DEFAULT_SWEEP_INTERVAL",
+    "ArtifactLifecyclePolicy",
+    "ArtifactSweeper",
+    "CleanupReport",
+    "ProtectionPredicate",
+    "cleanup_artifacts",
+    "describe_policy",
+    "format_bytes",
+    "make_task_protection",
+    "sweep_interval_from_env",
+]

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -50,7 +50,7 @@ from typing import Callable, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 2)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 3)
 
 
 def check_version(required: tuple[int, int, int]) -> None:
@@ -339,6 +339,16 @@ __all__ = [
     "build_health_payload",
     "build_readiness_payload",
     "build_openapi_spec",
+    # Cloud / Artifact storage & lifecycle (v0.8.3)
+    "ArtifactInfo",
+    "ArtifactLifecyclePolicy",
+    "ArtifactSweeper",
+    "CleanupReport",
+    "LocalArtifactStore",
+    "S3ArtifactStore",
+    "StorageBackend",
+    "cleanup_artifacts",
+    "get_artifact_store",
 ]
 
 
@@ -403,4 +413,19 @@ from .cloud import (  # noqa: E402
     build_health_payload,
     build_openapi_spec,
     build_readiness_payload,
+)
+
+# Cloud / artifact storage & lifecycle (v0.8.3) — new exports, backward
+# compatible. The artifact store is the blob/media counterpart to
+# ``TaskStorage`` (which persists task *state*, not artifacts).
+from .cloud import (  # noqa: E402
+    ArtifactInfo,
+    ArtifactLifecyclePolicy,
+    ArtifactSweeper,
+    CleanupReport,
+    LocalArtifactStore,
+    S3ArtifactStore,
+    StorageBackend,
+    cleanup_artifacts,
+    get_artifact_store,
 )

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 8, 2) — bumped for v0.8.1 observability exports."""
-        assert CONTRACT_VERSION == (0, 8, 2)
+        """CONTRACT_VERSION is (0, 8, 3) — bumped for v0.8.1 observability exports."""
+        assert CONTRACT_VERSION == (0, 8, 3)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 2)
+        assert CONTRACT_VERSION == (0, 8, 3)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 8, 2)."""
+        """CONTRACT_VERSION is (0, 8, 3)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 2)
+        assert CONTRACT_VERSION == (0, 8, 3)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""

--- a/tests/test_v080_format_rename.py
+++ b/tests/test_v080_format_rename.py
@@ -73,5 +73,5 @@ class TestContractVersionBump:
     """Tests for CONTRACT_VERSION bump."""
 
     def test_contract_version_is_0_8_0(self):
-        """CONTRACT_VERSION is (0, 8, 2)."""
-        assert CONTRACT_VERSION == (0, 8, 2)
+        """CONTRACT_VERSION is (0, 8, 3)."""
+        assert CONTRACT_VERSION == (0, 8, 3)

--- a/tests/test_v083_artifact_store.py
+++ b/tests/test_v083_artifact_store.py
@@ -1,0 +1,781 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for v0.8.3: storage backend abstraction (``artifact_store``).
+
+Covers:
+- ``normalize_key`` traversal rejection (absolute, ``..``, drive letters)
+- ``LocalArtifactStore`` round-trip put/get/open/list/stat/delete/exists
+- traversal rejection through the store surface (incl. symlink escape)
+- ``StorageBackend`` protocol conformance for both backends
+- ``S3ArtifactStore`` against an injected fake boto3 client
+- ``get_artifact_store`` / ``get_task_artifact_store`` env resolution
+- REST API artifact endpoints still behave exactly as in v0.6.1
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from movie_narrator.cloud import TaskAPIServer
+from movie_narrator.cloud.artifact_store import (
+    ArtifactInfo,
+    ArtifactNotFoundError,
+    ArtifactStoreError,
+    LocalArtifactStore,
+    S3ArtifactStore,
+    StorageBackend,
+    UnsafeKeyError,
+    artifact_location,
+    get_artifact_store,
+    get_task_artifact_store,
+    join_prefix,
+    normalize_key,
+)
+from movie_narrator.cloud.models import Task, TaskRequest, TaskResult, TaskStatus
+
+_HAS_BOTO3 = importlib.util.find_spec("boto3") is not None
+
+
+# ── Fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path) -> LocalArtifactStore:
+    """A local artifact store rooted in a temp directory."""
+    return LocalArtifactStore(tmp_path / "artifacts")
+
+
+@pytest.fixture
+def source_file(tmp_path) -> Path:
+    """A small local file to upload."""
+    path = tmp_path / "src" / "final.mp4"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"fake video content")
+    return path
+
+
+# ── Fake boto3 client ─────────────────────────────────────
+
+
+class FakeS3Client:
+    """In-memory stand-in for ``boto3.client('s3')``.
+
+    Only the handful of operations ``S3ArtifactStore`` uses are
+    implemented. Keeping the double here means the S3 backend is fully
+    exercised without boto3, credentials, or network access.
+    """
+
+    def __init__(self) -> None:
+        self.objects: Dict[str, bytes] = {}
+        self.times: Dict[str, datetime] = {}
+        self.calls: List[str] = []
+
+    # ── helpers ────────────────────────────────────────────
+
+    def _require(self, key: str) -> bytes:
+        if key not in self.objects:
+            raise FakeClientError(f"An error occurred (404) NoSuchKey: {key}")
+        return self.objects[key]
+
+    def seed(self, key: str, data: bytes, modified: Optional[datetime] = None) -> None:
+        self.objects[key] = data
+        self.times[key] = modified or datetime.now(timezone.utc)
+
+    # ── boto3 surface ──────────────────────────────────────
+
+    def upload_file(self, filename: str, bucket: str, key: str) -> None:
+        self.calls.append(f"upload_file:{key}")
+        self.seed(key, Path(filename).read_bytes())
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        self.calls.append(f"download_file:{key}")
+        Path(filename).write_bytes(self._require(key))
+
+    def get_object(self, Bucket: str, Key: str) -> Dict[str, Any]:  # noqa: N803
+        self.calls.append(f"get_object:{Key}")
+        import io
+
+        return {"Body": io.BytesIO(self._require(Key))}
+
+    def head_object(self, Bucket: str, Key: str) -> Dict[str, Any]:  # noqa: N803
+        self.calls.append(f"head_object:{Key}")
+        data = self._require(Key)
+        return {
+            "ContentLength": len(data),
+            "LastModified": self.times[Key],
+            "ETag": '"deadbeef"',
+        }
+
+    def delete_object(self, Bucket: str, Key: str) -> Dict[str, Any]:  # noqa: N803
+        self.calls.append(f"delete_object:{Key}")
+        self.objects.pop(Key, None)
+        self.times.pop(Key, None)
+        return {}
+
+    def list_objects_v2(self, **kwargs: Any) -> Dict[str, Any]:
+        prefix = kwargs.get("Prefix", "")
+        self.calls.append(f"list_objects_v2:{prefix}")
+        contents = [
+            {
+                "Key": key,
+                "Size": len(data),
+                "LastModified": self.times[key],
+                "ETag": '"deadbeef"',
+            }
+            for key, data in sorted(self.objects.items())
+            if key.startswith(prefix)
+        ]
+        return {"Contents": contents, "IsTruncated": False}
+
+    def generate_presigned_url(  # noqa: N803
+        self, op: str, Params: Dict[str, Any], ExpiresIn: int
+    ) -> str:
+        return f"https://example.invalid/{Params['Key']}?exp={ExpiresIn}"
+
+
+class FakeClientError(Exception):
+    """Stands in for ``botocore.exceptions.ClientError``."""
+
+
+# ════════════════════════════════════════════════════════════
+#  Key normalization / traversal
+# ════════════════════════════════════════════════════════════
+
+
+class TestKeyNormalization:
+    """Tests for ``normalize_key`` — the shared traversal guard."""
+
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("final.mp4", "final.mp4"),
+            ("clips/001.mp4", "clips/001.mp4"),
+            ("./final.mp4", "final.mp4"),
+            ("clips//001.mp4", "clips/001.mp4"),
+            ("clips\\001.mp4", "clips/001.mp4"),
+            ("  final.mp4  ", "final.mp4"),
+        ],
+    )
+    def test_accepts_relative_keys(self, key, expected):
+        """Relative keys are normalized to POSIX form."""
+        assert normalize_key(key) == expected
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "",
+            "   ",
+            "..",
+            "../secrets",
+            "../../../etc/passwd",
+            "clips/../../etc/passwd",
+            "/etc/passwd",
+            "/",
+            "\\windows\\system32",
+            "C:/Windows/system32",
+            "c:\\Windows",
+            ".",
+        ],
+    )
+    def test_rejects_unsafe_keys(self, key):
+        """Absolute paths, drive letters and ``..`` segments are refused."""
+        with pytest.raises(UnsafeKeyError):
+            normalize_key(key)
+
+    def test_rejects_non_string(self):
+        """A non-string key is refused rather than coerced."""
+        with pytest.raises(UnsafeKeyError):
+            normalize_key(None)  # type: ignore[arg-type]
+
+    def test_join_prefix(self):
+        """join_prefix concatenates cleanly in both directions."""
+        assert join_prefix("", "a.mp4") == "a.mp4"
+        assert join_prefix("runs", "a.mp4") == "runs/a.mp4"
+        assert join_prefix("runs/", "/a.mp4") == "runs/a.mp4"
+        assert join_prefix("runs", "") == "runs"
+
+
+# ════════════════════════════════════════════════════════════
+#  LocalArtifactStore
+# ════════════════════════════════════════════════════════════
+
+
+class TestLocalArtifactStore:
+    """Round-trip and semantics of the default filesystem backend."""
+
+    def test_satisfies_protocol(self, store):
+        """LocalArtifactStore structurally implements StorageBackend."""
+        assert isinstance(store, StorageBackend)
+
+    def test_root_created(self, tmp_path):
+        """The root directory is created on construction."""
+        root = tmp_path / "nested" / "artifacts"
+        assert not root.exists()
+        LocalArtifactStore(root)
+        assert root.is_dir()
+
+    def test_put_get_round_trip(self, store, source_file, tmp_path):
+        """put() stores a file and get() copies it back byte-identically."""
+        info = store.put("final.mp4", source_file)
+        assert info.key == "final.mp4"
+        assert info.size == len(b"fake video content")
+        assert info.etag is None
+
+        dest = tmp_path / "out" / "copy.mp4"
+        returned = store.get("final.mp4", dest)
+        assert returned == dest
+        assert dest.read_bytes() == b"fake video content"
+
+    def test_put_nested_key(self, store, source_file):
+        """put() creates intermediate directories for nested keys."""
+        store.put("clips/001.mp4", source_file)
+        assert store.exists("clips/001.mp4")
+        assert (store.root / "clips" / "001.mp4").is_file()
+
+    def test_open_returns_binary_stream(self, store, source_file):
+        """open() yields a readable binary stream."""
+        store.put("final.mp4", source_file)
+        with store.open("final.mp4") as fh:
+            assert fh.read() == b"fake video content"
+
+    def test_exists_and_delete(self, store, source_file):
+        """exists()/delete() report accurately and delete is idempotent."""
+        store.put("final.mp4", source_file)
+        assert store.exists("final.mp4") is True
+        assert store.delete("final.mp4") is True
+        assert store.exists("final.mp4") is False
+        assert store.delete("final.mp4") is False
+
+    def test_list_recurses_and_sorts(self, store, source_file):
+        """list() yields every file, recursively, sorted by key."""
+        store.put("b.mp4", source_file)
+        store.put("a.mp4", source_file)
+        store.put("clips/001.mp4", source_file)
+        keys = [i.key for i in store.list()]
+        assert keys == ["a.mp4", "b.mp4", "clips/001.mp4"]
+
+    def test_list_with_prefix(self, store, source_file):
+        """list(prefix) restricts results to that subtree."""
+        store.put("a.mp4", source_file)
+        store.put("clips/001.mp4", source_file)
+        assert [i.key for i in store.list("clips")] == ["clips/001.mp4"]
+
+    def test_list_unknown_prefix_is_empty(self, store):
+        """Listing a missing prefix yields nothing rather than raising."""
+        assert list(store.list("nope")) == []
+
+    def test_list_unsafe_prefix_is_empty(self, store):
+        """A traversal prefix yields nothing rather than escaping."""
+        assert list(store.list("../..")) == []
+
+    def test_stat_reports_metadata(self, store, source_file):
+        """stat() returns size and mtime for an existing key."""
+        store.put("final.mp4", source_file)
+        info = store.stat("final.mp4")
+        assert isinstance(info, ArtifactInfo)
+        assert info.size == 18
+        assert info.modified_at > 0
+
+    def test_stat_missing_raises(self, store):
+        """stat() on a missing key raises ArtifactNotFoundError."""
+        with pytest.raises(ArtifactNotFoundError):
+            store.stat("missing.mp4")
+
+    def test_stat_directory_is_not_found(self, store, source_file):
+        """A directory is not an artifact."""
+        store.put("clips/001.mp4", source_file)
+        with pytest.raises(ArtifactNotFoundError):
+            store.stat("clips")
+
+    def test_open_missing_raises(self, store):
+        """open() on a missing key raises ArtifactNotFoundError."""
+        with pytest.raises(ArtifactNotFoundError):
+            store.open("missing.mp4")
+
+    def test_url_is_none(self, store, source_file):
+        """The local backend has no shareable URL."""
+        store.put("final.mp4", source_file)
+        assert store.url("final.mp4") is None
+
+    @pytest.mark.parametrize(
+        "key", ["../escape.txt", "/etc/passwd", "clips/../../escape.txt"]
+    )
+    def test_traversal_rejected(self, store, source_file, key):
+        """Every mutating/reading entry point refuses traversal keys."""
+        with pytest.raises(UnsafeKeyError):
+            store.stat(key)
+        with pytest.raises(UnsafeKeyError):
+            store.open(key)
+        with pytest.raises(UnsafeKeyError):
+            store.delete(key)
+        with pytest.raises(UnsafeKeyError):
+            store.put(key, source_file)
+        assert store.exists(key) is False
+
+    def test_traversal_cannot_read_sibling_file(self, tmp_path):
+        """A key escaping the root cannot read a neighbouring file."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("classified", encoding="utf-8")
+        inner = LocalArtifactStore(tmp_path / "artifacts")
+        with pytest.raises(UnsafeKeyError):
+            inner.open("../secret.txt")
+
+    def test_symlink_escape_rejected(self, tmp_path, store):
+        """A symlink pointing outside the root is refused on resolution."""
+        outside = tmp_path / "outside.txt"
+        outside.write_text("nope", encoding="utf-8")
+        link = store.root / "link.txt"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):  # pragma: no cover - needs privileges
+            pytest.skip("symlink creation not permitted on this platform")
+        if not link.is_symlink():  # pragma: no cover - Windows without privileges
+            pytest.skip("symlinks are unavailable on this platform")
+        with pytest.raises(UnsafeKeyError):
+            store.stat("link.txt")
+
+    def test_local_path_matches_root_layout(self, store, source_file):
+        """local_path() reports the unresolved on-disk path."""
+        store.put("final.mp4", source_file)
+        assert store.local_path("final.mp4") == store.root / "final.mp4"
+        assert artifact_location(store, "final.mp4") == str(store.root / "final.mp4")
+
+
+# ════════════════════════════════════════════════════════════
+#  S3ArtifactStore (injected fake client)
+# ════════════════════════════════════════════════════════════
+
+
+class TestS3ArtifactStore:
+    """The S3 backend, exercised against an injected fake boto3 client."""
+
+    @pytest.fixture
+    def client(self) -> FakeS3Client:
+        return FakeS3Client()
+
+    @pytest.fixture
+    def s3(self, client) -> S3ArtifactStore:
+        return S3ArtifactStore(bucket="mn-bucket", prefix="runs", client=client)
+
+    def test_satisfies_protocol(self, s3):
+        """S3ArtifactStore structurally implements StorageBackend."""
+        assert isinstance(s3, StorageBackend)
+
+    def test_requires_bucket(self):
+        """An empty bucket name is rejected with an actionable message."""
+        with pytest.raises(ArtifactStoreError, match="MN_S3_BUCKET"):
+            S3ArtifactStore(bucket="", client=FakeS3Client())
+
+    def test_object_key_applies_prefix(self, s3):
+        """Store keys are prefixed before hitting the bucket."""
+        assert s3.object_key("final.mp4") == "runs/final.mp4"
+
+    def test_object_key_rejects_traversal(self, s3):
+        """The traversal guard applies to the S3 backend too."""
+        with pytest.raises(UnsafeKeyError):
+            s3.object_key("../../etc/passwd")
+
+    def test_put_and_stat(self, s3, client, source_file):
+        """put() uploads under the prefix; stat() reads it back."""
+        info = s3.put("final.mp4", source_file)
+        assert "runs/final.mp4" in client.objects
+        assert info.key == "final.mp4"
+        assert info.size == 18
+        assert info.etag == "deadbeef"
+
+    def test_get_round_trip(self, s3, source_file, tmp_path):
+        """get() downloads to a local path, creating parent dirs."""
+        s3.put("final.mp4", source_file)
+        dest = tmp_path / "dl" / "final.mp4"
+        assert s3.get("final.mp4", dest) == dest
+        assert dest.read_bytes() == b"fake video content"
+
+    def test_open_streams_body(self, s3, source_file):
+        """open() returns the object body stream."""
+        s3.put("final.mp4", source_file)
+        with s3.open("final.mp4") as body:
+            assert body.read() == b"fake video content"
+
+    def test_exists_and_delete(self, s3, source_file):
+        """exists()/delete() behave like the local backend."""
+        assert s3.exists("final.mp4") is False
+        s3.put("final.mp4", source_file)
+        assert s3.exists("final.mp4") is True
+        assert s3.delete("final.mp4") is True
+        assert s3.delete("final.mp4") is False
+
+    def test_list_strips_prefix(self, s3, client):
+        """Listed keys are store-relative, not bucket-absolute."""
+        client.seed("runs/a.mp4", b"a")
+        client.seed("runs/clips/b.mp4", b"bb")
+        client.seed("other/c.mp4", b"ccc")
+        infos = sorted(s3.list(), key=lambda i: i.key)
+        assert [i.key for i in infos] == ["a.mp4", "clips/b.mp4"]
+        assert [i.size for i in infos] == [1, 2]
+
+    def test_list_skips_directory_markers(self, s3, client):
+        """Zero-byte ``dir/`` marker objects are not reported."""
+        client.seed("runs/clips/", b"")
+        client.seed("runs/a.mp4", b"a")
+        assert [i.key for i in s3.list()] == ["a.mp4"]
+
+    def test_list_modified_at_is_timestamp(self, s3, client):
+        """LastModified datetimes are converted to POSIX timestamps."""
+        when = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        client.seed("runs/a.mp4", b"a", modified=when)
+        info = next(iter(s3.list()))
+        assert info.modified_at == pytest.approx(when.timestamp())
+
+    def test_stat_missing_raises_not_found(self, s3):
+        """A 404 from the client maps to ArtifactNotFoundError."""
+        with pytest.raises(ArtifactNotFoundError):
+            s3.stat("missing.mp4")
+
+    def test_url_is_presigned(self, s3, source_file):
+        """url() delegates to generate_presigned_url."""
+        s3.put("final.mp4", source_file)
+        assert s3.url("final.mp4", expires_in=60) == (
+            "https://example.invalid/runs/final.mp4?exp=60"
+        )
+
+    def test_url_none_without_signing_support(self, source_file):
+        """A client that cannot pre-sign yields None instead of raising."""
+
+        class NoSignClient(FakeS3Client):
+            generate_presigned_url = None  # type: ignore[assignment]
+
+        s3 = S3ArtifactStore(bucket="b", client=NoSignClient())
+        assert s3.url("final.mp4") is None
+
+    def test_pagination_without_paginator(self, client, source_file):
+        """The manual ContinuationToken loop is used when no paginator exists."""
+
+        class PagedClient(FakeS3Client):
+            def list_objects_v2(self, **kwargs):
+                if "ContinuationToken" not in kwargs:
+                    return {
+                        "Contents": [
+                            {"Key": "a.mp4", "Size": 1, "LastModified": None, "ETag": '"x"'}
+                        ],
+                        "IsTruncated": True,
+                        "NextContinuationToken": "tok",
+                    }
+                return {
+                    "Contents": [
+                        {"Key": "b.mp4", "Size": 2, "LastModified": None, "ETag": '"y"'}
+                    ],
+                    "IsTruncated": False,
+                }
+
+        s3 = S3ArtifactStore(bucket="b", client=PagedClient())
+        assert [i.key for i in s3.list()] == ["a.mp4", "b.mp4"]
+
+    @pytest.mark.skipif(
+        _HAS_BOTO3, reason="boto3 is installed, so the missing-dependency path cannot run"
+    )
+    def test_missing_boto3_error_is_actionable(self):
+        """Without boto3 and without an injected client, the error explains the fix."""
+        with pytest.raises(ArtifactStoreError, match=r"movie-narrator\[s3\]"):
+            S3ArtifactStore(bucket="mn-bucket")
+
+    @pytest.mark.skipif(not _HAS_BOTO3, reason="requires the real boto3 library")
+    def test_real_boto3_client_is_built(self):  # pragma: no cover - boto3 absent in CI
+        """With boto3 available, a real client is constructed lazily."""
+        s3 = S3ArtifactStore(bucket="mn-bucket", endpoint_url="http://localhost:9000")
+        assert s3.client is not None
+
+
+# ════════════════════════════════════════════════════════════
+#  Factory / env resolution
+# ════════════════════════════════════════════════════════════
+
+
+class TestArtifactStoreFactory:
+    """Tests for get_artifact_store / get_task_artifact_store."""
+
+    def test_default_backend_is_local(self, tmp_path):
+        """With no env configured the local backend is used."""
+        s = get_artifact_store(env={"MN_STORAGE_ROOT": str(tmp_path / "root")})
+        assert isinstance(s, LocalArtifactStore)
+        assert s.root == tmp_path / "root"
+
+    def test_local_root_from_env(self, tmp_path):
+        """MN_STORAGE_ROOT selects the local root."""
+        env = {"MN_STORAGE_BACKEND": "local", "MN_STORAGE_ROOT": str(tmp_path / "a")}
+        s = get_artifact_store(env=env)
+        assert isinstance(s, LocalArtifactStore)
+        assert s.root == tmp_path / "a"
+
+    def test_sub_prefix_scopes_local_root(self, tmp_path):
+        """sub_prefix nests the local root (task-scoped store)."""
+        env = {"MN_STORAGE_ROOT": str(tmp_path / "a")}
+        s = get_artifact_store(env=env, sub_prefix="task123")
+        assert isinstance(s, LocalArtifactStore)
+        assert s.root == tmp_path / "a" / "task123"
+
+    def test_explicit_root_wins_over_env(self, tmp_path):
+        """An explicit root argument overrides MN_STORAGE_ROOT."""
+        env = {"MN_STORAGE_ROOT": str(tmp_path / "env")}
+        s = get_artifact_store(root=tmp_path / "explicit", env=env)
+        assert isinstance(s, LocalArtifactStore)
+        assert s.root == tmp_path / "explicit"
+
+    def test_s3_requires_bucket(self):
+        """MN_STORAGE_BACKEND=s3 without MN_S3_BUCKET is an actionable error."""
+        with pytest.raises(ArtifactStoreError, match="MN_S3_BUCKET"):
+            get_artifact_store(env={"MN_STORAGE_BACKEND": "s3"})
+
+    def test_unknown_backend_rejected(self):
+        """An unsupported backend name is rejected."""
+        with pytest.raises(ArtifactStoreError, match="Unknown storage backend"):
+            get_artifact_store(env={"MN_STORAGE_BACKEND": "gcs"})
+
+    def test_backend_name_is_case_insensitive(self, tmp_path):
+        """Backend resolution tolerates casing/whitespace."""
+        env = {"MN_STORAGE_BACKEND": " Local ", "MN_STORAGE_ROOT": str(tmp_path)}
+        assert isinstance(get_artifact_store(env=env), LocalArtifactStore)
+
+    def test_task_store_local_uses_output_dir(self, tmp_path):
+        """The task-scoped local store is rooted at the task output dir."""
+        output = tmp_path / "output" / "Movie"
+        output.mkdir(parents=True)
+        s = get_task_artifact_store("abc123", output, env={})
+        assert isinstance(s, LocalArtifactStore)
+        assert s.root == output
+
+    def test_task_store_none_without_output_dir(self):
+        """No output directory means no task store."""
+        assert get_task_artifact_store("abc123", None, env={}) is None
+
+    def test_task_store_none_when_dir_missing(self, tmp_path):
+        """A vanished output directory yields None (API then reports 404)."""
+        assert get_task_artifact_store("abc", tmp_path / "gone", env={}) is None
+
+    def test_task_store_s3_scopes_by_task_id(self):
+        """For remote backends the task id becomes the key prefix."""
+        env = {
+            "MN_STORAGE_BACKEND": "s3",
+            "MN_S3_BUCKET": "mn",
+            "MN_S3_PREFIX": "runs",
+        }
+        # boto3 is unavailable in CI, so the factory surfaces the install hint.
+        if _HAS_BOTO3:  # pragma: no cover - depends on the environment
+            s = get_task_artifact_store("abc123", None, env=env)
+            assert isinstance(s, S3ArtifactStore)
+            assert s.prefix == "runs/abc123"
+        else:
+            assert get_task_artifact_store("abc123", None, env=env) is None
+
+
+# ════════════════════════════════════════════════════════════
+#  REST API wiring (behaviour must be unchanged)
+# ════════════════════════════════════════════════════════════
+
+
+def _mock_pipeline(ctx, **kwargs):
+    """Mock pipeline that doesn't do any actual work."""
+    Path(ctx.output_dir).mkdir(parents=True, exist_ok=True)
+    ctx.video_path = str(Path(ctx.output_dir) / "final.mp4")
+    Path(ctx.video_path).write_bytes(b"mock video")
+    return ctx
+
+
+@pytest.fixture(autouse=True)
+def mock_pipeline(monkeypatch):
+    """Prevent any real pipeline execution in this module."""
+    monkeypatch.setattr(
+        "movie_narrator.cloud.worker.run_pipeline",
+        _mock_pipeline,
+    )
+
+
+@pytest.fixture
+def api_server(tmp_path, monkeypatch):
+    """A running API server with the default (local) artifact backend."""
+    monkeypatch.delenv("MN_STORAGE_BACKEND", raising=False)
+    monkeypatch.delenv("MN_ARTIFACT_TTL", raising=False)
+    monkeypatch.delenv("MN_ARTIFACT_MAX_BYTES", raising=False)
+    server = TaskAPIServer(
+        host="127.0.0.1",
+        port=0,
+        storage_dir=tmp_path / "tasks",
+        max_workers=1,
+    )
+    server.start(blocking=False)
+    time.sleep(0.1)
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def task_with_files(api_server, tmp_path) -> Task:
+    """A completed task whose output directory holds four artifacts."""
+    output_dir = tmp_path / "output" / "v083_task"
+    output_dir.mkdir(parents=True)
+    (output_dir / "final.mp4").write_bytes(b"fake video content")
+    (output_dir / "narration.mp3").write_bytes(b"fake audio")
+    (output_dir / "subtitle.srt").write_text("1\n", encoding="utf-8")
+    (output_dir / "metadata.json").write_text('{"v": "0.8.3"}', encoding="utf-8")
+    (output_dir / ".hidden").write_text("x", encoding="utf-8")
+    (output_dir / "clips").mkdir()
+    (output_dir / "clips" / "001.mp4").write_bytes(b"nested")
+
+    task = Task(
+        request=TaskRequest(movie_name="V083", max_retries=0),
+        status=TaskStatus.COMPLETED,
+        result=TaskResult(
+            video_path=str(output_dir / "final.mp4"),
+            output_dir=str(output_dir),
+        ),
+    )
+    api_server.queue._storage.save(task)
+    return task
+
+
+def _get(url: str):
+    return urllib.request.urlopen(url, timeout=5)
+
+
+def _status(url: str) -> int:
+    try:
+        with _get(url) as resp:
+            return resp.getcode()
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+class TestApiArtifactEndpoints:
+    """The REST endpoints now go through the store but behave identically."""
+
+    def test_list_artifacts_top_level_only(self, api_server, task_with_files):
+        """Listing reports top-level files, skips dotfiles and subdirectories."""
+        url = f"{api_server.base_url}/tasks/{task_with_files.id}/artifacts"
+        with _get(url) as resp:
+            body = json.loads(resp.read())
+        names = [a["filename"] for a in body["artifacts"]]
+        assert names == ["final.mp4", "metadata.json", "narration.mp3", "subtitle.srt"]
+        assert body["count"] == 4
+        assert ".hidden" not in names
+        assert all("/" not in n for n in names)
+
+    def test_list_artifacts_reports_size_and_path(self, api_server, task_with_files):
+        """Each entry keeps the v0.6.1 filename/size/path shape."""
+        url = f"{api_server.base_url}/tasks/{task_with_files.id}/artifacts"
+        with _get(url) as resp:
+            body = json.loads(resp.read())
+        entry = next(a for a in body["artifacts"] if a["filename"] == "final.mp4")
+        assert entry["size"] == len(b"fake video content")
+        assert Path(entry["path"]).name == "final.mp4"
+        assert Path(entry["path"]).is_file()
+
+    def test_list_artifacts_missing_output_dir(self, api_server):
+        """A task without output still returns an empty list."""
+        task = Task(
+            request=TaskRequest(movie_name="NoOutput", max_retries=0),
+            status=TaskStatus.PENDING,
+        )
+        api_server.queue._storage.save(task)
+        with _get(f"{api_server.base_url}/tasks/{task.id}/artifacts") as resp:
+            body = json.loads(resp.read())
+        assert body["artifacts"] == []
+
+    def test_download_artifact(self, api_server, task_with_files):
+        """Downloading returns the exact bytes with the right content type."""
+        url = f"{api_server.base_url}/tasks/{task_with_files.id}/download/final.mp4"
+        with _get(url) as resp:
+            assert resp.getcode() == 200
+            assert resp.headers["Content-Type"] == "video/mp4"
+            assert resp.headers["Content-Length"] == "18"
+            assert resp.read() == b"fake video content"
+
+    def test_download_nested_key(self, api_server, task_with_files):
+        """Nested keys remain reachable for direct download."""
+        url = f"{api_server.base_url}/tasks/{task_with_files.id}/download/clips/001.mp4"
+        with _get(url) as resp:
+            assert resp.read() == b"nested"
+
+    def test_download_missing_file_404(self, api_server, task_with_files):
+        """A missing file is a 404."""
+        url = f"{api_server.base_url}/tasks/{task_with_files.id}/download/nope.mp4"
+        assert _status(url) == 404
+
+    def test_download_directory_404(self, api_server, task_with_files):
+        """A directory key is not downloadable."""
+        url = f"{api_server.base_url}/tasks/{task_with_files.id}/download/clips"
+        assert _status(url) == 404
+
+    def test_download_traversal_forbidden(self, api_server, task_with_files):
+        """Encoded traversal attempts are rejected with 403."""
+        url = (
+            f"{api_server.base_url}/tasks/{task_with_files.id}"
+            f"/download/..%2f..%2f..%2fetc%2fpasswd"
+        )
+        assert _status(url) == 403
+
+    def test_download_absolute_path_forbidden(self, api_server, task_with_files):
+        """An absolute path in the filename segment is rejected with 403."""
+        url = (
+            f"{api_server.base_url}/tasks/{task_with_files.id}"
+            f"/download/C%3A%2FWindows%2Fsystem32%2Fdrivers%2Fetc%2Fhosts"
+        )
+        assert _status(url) == 403
+
+    def test_download_no_output_dir_404(self, api_server):
+        """A task with no output directory reports 404."""
+        task = Task(
+            request=TaskRequest(movie_name="NoOutput", max_retries=0),
+            status=TaskStatus.COMPLETED,
+            result=TaskResult(),
+        )
+        api_server.queue._storage.save(task)
+        assert _status(f"{api_server.base_url}/tasks/{task.id}/download/final.mp4") == 404
+
+
+class TestApiSweeperLifecycle:
+    """The API server starts/stops the TTL sweeper only when configured."""
+
+    def test_no_sweeper_by_default(self, api_server):
+        """Without MN_ARTIFACT_* configured no sweeper thread runs."""
+        assert api_server.sweeper is None
+
+    def test_sweeper_started_when_ttl_enabled(self, tmp_path):
+        """A TTL policy starts a daemon sweeper that stops with the server."""
+        from movie_narrator.cloud.lifecycle import ArtifactLifecyclePolicy
+
+        store = LocalArtifactStore(tmp_path / "artifacts")
+        server = TaskAPIServer(
+            host="127.0.0.1",
+            port=0,
+            storage_dir=tmp_path / "tasks",
+            max_workers=1,
+            artifact_store=store,
+            artifact_policy=ArtifactLifecyclePolicy(ttl_seconds=3600),
+        )
+        server.start(blocking=False)
+        try:
+            assert server.sweeper is not None
+            assert server.sweeper.is_running
+        finally:
+            server.stop()
+        assert server.sweeper is None
+
+    def test_active_task_ids_exclude_terminal(self, api_server, task_with_files):
+        """Only pending/running tasks are reported as protected."""
+        pending = Task(
+            request=TaskRequest(movie_name="Pending", max_retries=0),
+            status=TaskStatus.PENDING,
+        )
+        api_server.queue._storage.save(pending)
+        ids = api_server._active_task_ids()
+        assert pending.id in ids
+        assert task_with_files.id not in ids

--- a/tests/test_v083_lifecycle.py
+++ b/tests/test_v083_lifecycle.py
@@ -1,0 +1,724 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for v0.8.3: artifact lifecycle / TTL cleanup (``lifecycle``).
+
+Covers:
+- ``ArtifactLifecyclePolicy`` defaults and ``MN_ARTIFACT_*`` env parsing
+- TTL expiry boundaries with a frozen clock
+- ``keep_last_n`` retention
+- size-cap eviction order (oldest first)
+- ``dry_run`` previews
+- protected in-flight keys (``protected_keys`` and ``is_protected``)
+- deletion errors are reported, never raised
+- the background ``ArtifactSweeper`` thread
+- the ``mn artifacts`` CLI commands
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional
+
+import pytest
+from typer.testing import CliRunner
+
+from movie_narrator.cli import app
+from movie_narrator.cloud.artifact_store import (
+    ArtifactInfo,
+    ArtifactStoreError,
+    LocalArtifactStore,
+    StorageBackend,
+)
+from movie_narrator.cloud.lifecycle import (
+    DEFAULT_SWEEP_INTERVAL,
+    ArtifactLifecyclePolicy,
+    ArtifactSweeper,
+    CleanupReport,
+    cleanup_artifacts,
+    describe_policy,
+    format_bytes,
+    make_task_protection,
+    sweep_interval_from_env,
+)
+
+DAY = 86400.0
+NOW = 1_800_000_000.0
+
+
+# ── Test doubles ──────────────────────────────────────────
+
+
+class MemoryStore:
+    """Minimal in-memory :class:`StorageBackend` with a controllable clock."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, ArtifactInfo] = {}
+        self.deleted: List[str] = []
+        self.fail_on: set[str] = set()
+
+    # ── seeding ────────────────────────────────────────────
+
+    def seed(self, key: str, size: int, age_seconds: float, *, now: float = NOW) -> None:
+        """Add an artifact of *size* bytes that is *age_seconds* old."""
+        self._items[key] = ArtifactInfo(key=key, size=size, modified_at=now - age_seconds)
+
+    @property
+    def keys(self) -> List[str]:
+        return sorted(self._items)
+
+    # ── StorageBackend ─────────────────────────────────────
+
+    def put(self, key: str, src_path) -> ArtifactInfo:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def get(self, key: str, dest_path) -> Path:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def open(self, key: str):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def exists(self, key: str) -> bool:
+        return key in self._items
+
+    def delete(self, key: str) -> bool:
+        if key in self.fail_on:
+            raise OSError(f"disk on fire: {key}")
+        self.deleted.append(key)
+        return self._items.pop(key, None) is not None
+
+    def list(self, prefix: str = "") -> Iterator[ArtifactInfo]:
+        for key in sorted(self._items):
+            if key.startswith(prefix):
+                yield self._items[key]
+
+    def stat(self, key: str) -> ArtifactInfo:
+        return self._items[key]
+
+    def url(self, key: str, *, expires_in: int = 3600) -> Optional[str]:
+        return None
+
+
+@pytest.fixture
+def store() -> MemoryStore:
+    return MemoryStore()
+
+
+# ════════════════════════════════════════════════════════════
+#  Policy
+# ════════════════════════════════════════════════════════════
+
+
+class TestPolicy:
+    """Defaults, env parsing and the ``enabled`` predicate."""
+
+    def test_defaults_keep_everything(self):
+        """Out of the box nothing is ever deleted."""
+        policy = ArtifactLifecyclePolicy()
+        assert policy.ttl_seconds == 0
+        assert policy.max_total_bytes == 0
+        assert policy.keep_last_n == 0
+        assert policy.dry_run is False
+        assert policy.enabled is False
+
+    def test_enabled_with_ttl_or_size(self):
+        """Either rule flips the policy on; keep_last alone does not."""
+        assert ArtifactLifecyclePolicy(ttl_seconds=1).enabled is True
+        assert ArtifactLifecyclePolicy(max_total_bytes=1).enabled is True
+        assert ArtifactLifecyclePolicy(keep_last_n=5).enabled is False
+
+    def test_from_env_reads_all_vars(self):
+        """MN_ARTIFACT_* variables populate the policy."""
+        policy = ArtifactLifecyclePolicy.from_env(
+            {
+                "MN_ARTIFACT_TTL": "604800",
+                "MN_ARTIFACT_MAX_BYTES": "1024",
+                "MN_ARTIFACT_KEEP_LAST": "3",
+            }
+        )
+        assert policy.ttl_seconds == 604800
+        assert policy.max_total_bytes == 1024
+        assert policy.keep_last_n == 3
+        assert policy.dry_run is False
+
+    def test_from_env_defaults_when_unset(self):
+        """An empty environment yields the keep-forever defaults."""
+        policy = ArtifactLifecyclePolicy.from_env({})
+        assert (policy.ttl_seconds, policy.max_total_bytes, policy.keep_last_n) == (0, 0, 0)
+
+    @pytest.mark.parametrize("raw", ["", "   ", "abc", "-5", "1.5"])
+    def test_from_env_ignores_invalid(self, raw):
+        """Malformed values fall back to the default instead of crashing."""
+        policy = ArtifactLifecyclePolicy.from_env({"MN_ARTIFACT_TTL": raw})
+        assert policy.ttl_seconds == 0
+
+    def test_from_env_dry_run_flag(self):
+        """dry_run is passed through, not read from the environment."""
+        assert ArtifactLifecyclePolicy.from_env({}, dry_run=True).dry_run is True
+
+    def test_sweep_interval_default(self):
+        """The sweep interval defaults to one hour."""
+        assert sweep_interval_from_env({}) == DEFAULT_SWEEP_INTERVAL
+        assert DEFAULT_SWEEP_INTERVAL == 3600.0
+
+    @pytest.mark.parametrize("raw", ["abc", "0", "-1", ""])
+    def test_sweep_interval_invalid(self, raw):
+        """Invalid or non-positive intervals fall back to the default."""
+        assert sweep_interval_from_env({"MN_ARTIFACT_SWEEP_INTERVAL": raw}) == (
+            DEFAULT_SWEEP_INTERVAL
+        )
+
+    def test_sweep_interval_from_env(self):
+        """A valid interval is honoured."""
+        assert sweep_interval_from_env({"MN_ARTIFACT_SWEEP_INTERVAL": "90"}) == 90.0
+
+    def test_describe_policy_lines(self):
+        """describe_policy renders every knob for the CLI."""
+        lines = "\n".join(describe_policy(ArtifactLifecyclePolicy(ttl_seconds=60)))
+        assert "ttl_seconds" in lines
+        assert "unlimited" in lines
+        assert "disabled" in lines
+
+
+class TestFormatBytes:
+    """Human-readable byte rendering."""
+
+    @pytest.mark.parametrize(
+        "size,expected",
+        [(0, "0 B"), (512, "512 B"), (2048, "2.0 KB"), (5 * 1024**2, "5.0 MB")],
+    )
+    def test_format(self, size, expected):
+        assert format_bytes(size) == expected
+
+
+# ════════════════════════════════════════════════════════════
+#  TTL expiry
+# ════════════════════════════════════════════════════════════
+
+
+class TestTtlExpiry:
+    """TTL pass with a frozen clock."""
+
+    def test_disabled_ttl_deletes_nothing(self, store):
+        """ttl_seconds=0 keeps everything, however old."""
+        store.seed("old.mp4", 10, age_seconds=365 * DAY)
+        report = cleanup_artifacts(store, ArtifactLifecyclePolicy(), now=NOW)
+        assert report.deleted == []
+        assert store.keys == ["old.mp4"]
+
+    def test_expired_artifact_deleted(self, store):
+        """An artifact older than the TTL is removed."""
+        store.seed("old.mp4", 100, age_seconds=8 * DAY)
+        store.seed("new.mp4", 100, age_seconds=1 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=int(7 * DAY))
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == ["old.mp4"]
+        assert report.freed_bytes == 100
+        assert store.keys == ["new.mp4"]
+
+    def test_boundary_exactly_at_ttl_is_expired(self, store):
+        """Age == TTL counts as expired (inclusive boundary)."""
+        store.seed("edge.mp4", 1, age_seconds=100)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=100)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == ["edge.mp4"]
+
+    def test_boundary_one_second_below_ttl_survives(self, store):
+        """Age == TTL-1 survives."""
+        store.seed("edge.mp4", 1, age_seconds=99)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=100)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == []
+        assert store.keys == ["edge.mp4"]
+
+    def test_boundary_one_second_above_ttl_expires(self, store):
+        """Age == TTL+1 is deleted."""
+        store.seed("edge.mp4", 1, age_seconds=101)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=100)
+        assert cleanup_artifacts(store, policy, now=NOW).deleted == ["edge.mp4"]
+
+    def test_now_defaults_to_wall_clock(self, store):
+        """Omitting ``now`` uses the real clock."""
+        store.seed("old.mp4", 1, age_seconds=10, now=time.time())
+        policy = ArtifactLifecyclePolicy(ttl_seconds=5)
+        assert cleanup_artifacts(store, policy).deleted == ["old.mp4"]
+
+    def test_report_counts_scanned(self, store):
+        """The report tracks how many artifacts were examined."""
+        store.seed("a", 1, age_seconds=1)
+        store.seed("b", 1, age_seconds=1)
+        report = cleanup_artifacts(store, ArtifactLifecyclePolicy(ttl_seconds=10), now=NOW)
+        assert report.scanned == 2
+
+    def test_prefix_limits_scope(self, store):
+        """A prefix restricts the sweep."""
+        store.seed("keep/old.mp4", 1, age_seconds=999)
+        store.seed("sweep/old.mp4", 1, age_seconds=999)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=10)
+        report = cleanup_artifacts(store, policy, now=NOW, prefix="sweep/")
+        assert report.deleted == ["sweep/old.mp4"]
+        assert "keep/old.mp4" in store.keys
+
+
+# ════════════════════════════════════════════════════════════
+#  keep_last_n
+# ════════════════════════════════════════════════════════════
+
+
+class TestKeepLastN:
+    """The N newest artifacts survive every rule."""
+
+    def test_keep_last_protects_newest(self, store):
+        """Even fully expired artifacts survive when in the newest N."""
+        for i, age in enumerate([10 * DAY, 9 * DAY, 8 * DAY]):
+            store.seed(f"a{i}.mp4", 10, age_seconds=age)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=int(DAY), keep_last_n=2)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        # a0 is the oldest, a1/a2 are the two newest and therefore kept.
+        assert report.deleted == ["a0.mp4"]
+        assert sorted(report.skipped) == ["a1.mp4", "a2.mp4"]
+        assert store.keys == ["a1.mp4", "a2.mp4"]
+
+    def test_keep_last_larger_than_store(self, store):
+        """keep_last_n >= artifact count keeps everything."""
+        store.seed("a.mp4", 10, age_seconds=99 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=1, keep_last_n=5)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == []
+        assert report.skipped == ["a.mp4"]
+
+    def test_keep_last_zero_disables(self, store):
+        """keep_last_n=0 offers no protection."""
+        store.seed("a.mp4", 10, age_seconds=99 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=1, keep_last_n=0)
+        assert cleanup_artifacts(store, policy, now=NOW).deleted == ["a.mp4"]
+
+    def test_keep_last_survives_size_cap(self, store):
+        """keep_last_n also wins against the size cap."""
+        store.seed("old.mp4", 100, age_seconds=3 * DAY)
+        store.seed("new.mp4", 100, age_seconds=1 * DAY)
+        policy = ArtifactLifecyclePolicy(max_total_bytes=50, keep_last_n=2)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == []
+        assert sorted(report.skipped) == ["new.mp4", "old.mp4"]
+
+
+# ════════════════════════════════════════════════════════════
+#  Size cap
+# ════════════════════════════════════════════════════════════
+
+
+class TestSizeCap:
+    """Oldest-first eviction until the store fits the cap."""
+
+    def test_evicts_oldest_first(self, store):
+        """Eviction order follows modification time, oldest first."""
+        store.seed("oldest.mp4", 100, age_seconds=3 * DAY)
+        store.seed("middle.mp4", 100, age_seconds=2 * DAY)
+        store.seed("newest.mp4", 100, age_seconds=1 * DAY)
+        policy = ArtifactLifecyclePolicy(max_total_bytes=150)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == ["oldest.mp4", "middle.mp4"]
+        assert report.freed_bytes == 200
+        assert store.keys == ["newest.mp4"]
+
+    def test_stops_as_soon_as_it_fits(self, store):
+        """Eviction stops at the first size that satisfies the cap."""
+        store.seed("a.mp4", 100, age_seconds=3 * DAY)
+        store.seed("b.mp4", 100, age_seconds=2 * DAY)
+        policy = ArtifactLifecyclePolicy(max_total_bytes=100)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == ["a.mp4"]
+        assert store.keys == ["b.mp4"]
+
+    def test_under_cap_deletes_nothing(self, store):
+        """A store already within the cap is untouched."""
+        store.seed("a.mp4", 10, age_seconds=DAY)
+        policy = ArtifactLifecyclePolicy(max_total_bytes=1000)
+        assert cleanup_artifacts(store, policy, now=NOW).deleted == []
+
+    def test_zero_cap_means_unlimited(self, store):
+        """max_total_bytes=0 disables the cap entirely."""
+        store.seed("a.mp4", 10_000, age_seconds=DAY)
+        assert cleanup_artifacts(store, ArtifactLifecyclePolicy(), now=NOW).deleted == []
+
+    def test_ttl_runs_before_size_cap(self, store):
+        """TTL frees space first, so the cap may need no further eviction."""
+        store.seed("expired.mp4", 100, age_seconds=10 * DAY)
+        store.seed("fresh.mp4", 100, age_seconds=1 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=int(2 * DAY), max_total_bytes=150)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == ["expired.mp4"]
+        assert store.keys == ["fresh.mp4"]
+
+
+# ════════════════════════════════════════════════════════════
+#  Protection & dry-run
+# ════════════════════════════════════════════════════════════
+
+
+class TestProtection:
+    """In-flight work must never be swept."""
+
+    def test_protected_keys_are_skipped(self, store):
+        """Exact protected keys survive TTL expiry."""
+        store.seed("running.mp4", 10, age_seconds=99 * DAY)
+        store.seed("done.mp4", 10, age_seconds=99 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=1)
+        report = cleanup_artifacts(
+            store, policy, now=NOW, protected_keys=["running.mp4"]
+        )
+        assert report.deleted == ["done.mp4"]
+        assert report.skipped == ["running.mp4"]
+        assert "running.mp4" in store.keys
+
+    def test_protected_keys_survive_size_cap(self, store):
+        """Protection also applies to size-cap eviction."""
+        store.seed("running.mp4", 100, age_seconds=9 * DAY)
+        store.seed("done.mp4", 100, age_seconds=1 * DAY)
+        policy = ArtifactLifecyclePolicy(max_total_bytes=50)
+        report = cleanup_artifacts(
+            store, policy, now=NOW, protected_keys={"running.mp4"}
+        )
+        assert report.deleted == ["done.mp4"]
+        assert "running.mp4" in store.keys
+
+    def test_is_protected_predicate(self, store):
+        """A predicate can protect artifacts by any rule."""
+        store.seed("keepme.mp4", 10, age_seconds=99 * DAY)
+        store.seed("other.mp4", 10, age_seconds=99 * DAY)
+        report = cleanup_artifacts(
+            store,
+            ArtifactLifecyclePolicy(ttl_seconds=1),
+            now=NOW,
+            is_protected=lambda info: info.key.startswith("keep"),
+        )
+        assert report.deleted == ["other.mp4"]
+
+    def test_task_protection_by_key_prefix(self, store):
+        """make_task_protection guards the ``<task_id>/`` namespace."""
+        store.seed("task-a/final.mp4", 10, age_seconds=99 * DAY)
+        store.seed("task-b/final.mp4", 10, age_seconds=99 * DAY)
+        report = cleanup_artifacts(
+            store,
+            ArtifactLifecyclePolicy(ttl_seconds=1),
+            now=NOW,
+            is_protected=make_task_protection(["task-a"]),
+        )
+        assert report.deleted == ["task-b/final.mp4"]
+        assert report.skipped == ["task-a/final.mp4"]
+
+    def test_task_protection_matches_bare_key(self):
+        """A bare ``<task_id>`` key is also protected."""
+        guard = make_task_protection(["abc"])
+        assert guard(ArtifactInfo(key="abc", size=1, modified_at=0)) is True
+        assert guard(ArtifactInfo(key="abcdef/x", size=1, modified_at=0)) is False
+
+    def test_task_protection_ignores_empty_ids(self):
+        """Empty IDs never match anything."""
+        guard = make_task_protection(["", None])  # type: ignore[list-item]
+        assert guard(ArtifactInfo(key="x", size=1, modified_at=0)) is False
+
+
+class TestDryRun:
+    """Preview mode reports without mutating."""
+
+    def test_dry_run_reports_but_keeps(self, store):
+        """dry_run lists deletions and frees nothing on disk."""
+        store.seed("old.mp4", 100, age_seconds=9 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=1, dry_run=True)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.dry_run is True
+        assert report.deleted == ["old.mp4"]
+        assert report.freed_bytes == 100
+        assert store.deleted == []
+        assert store.keys == ["old.mp4"]
+
+    def test_dry_run_size_cap(self, store):
+        """The size-cap pass is previewed too, without deleting."""
+        store.seed("a.mp4", 100, age_seconds=3 * DAY)
+        store.seed("b.mp4", 100, age_seconds=1 * DAY)
+        policy = ArtifactLifecyclePolicy(max_total_bytes=100, dry_run=True)
+        report = cleanup_artifacts(store, policy, now=NOW)
+        assert report.deleted == ["a.mp4"]
+        assert store.keys == ["a.mp4", "b.mp4"]
+
+    def test_summary_mentions_dry_run(self, store):
+        """The one-line summary flags preview mode."""
+        store.seed("a.mp4", 100, age_seconds=9 * DAY)
+        policy = ArtifactLifecyclePolicy(ttl_seconds=1, dry_run=True)
+        summary = cleanup_artifacts(store, policy, now=NOW).summary()
+        assert "dry-run" in summary
+        assert "100 B" in summary
+
+
+class TestErrorHandling:
+    """A failing delete is reported, never raised."""
+
+    def test_delete_error_is_collected(self, store):
+        """One unusable file does not abort the sweep."""
+        store.seed("bad.mp4", 10, age_seconds=9 * DAY)
+        store.seed("good.mp4", 10, age_seconds=9 * DAY)
+        store.fail_on.add("bad.mp4")
+        report = cleanup_artifacts(store, ArtifactLifecyclePolicy(ttl_seconds=1), now=NOW)
+        assert report.deleted == ["good.mp4"]
+        assert [k for k, _ in report.errors] == ["bad.mp4"]
+        assert "disk on fire" in report.errors[0][1]
+
+    def test_list_error_is_reported(self):
+        """A store that cannot be listed yields an error report, not a crash."""
+
+        class BrokenStore(MemoryStore):
+            def list(self, prefix: str = "") -> Iterator[ArtifactInfo]:
+                raise ArtifactStoreError("bucket unreachable")
+
+        report = cleanup_artifacts(
+            BrokenStore(), ArtifactLifecyclePolicy(ttl_seconds=1), now=NOW
+        )
+        assert report.deleted == []
+        assert report.errors and "bucket unreachable" in report.errors[0][1]
+
+    def test_empty_report_summary(self):
+        """A default report renders a sensible summary."""
+        assert "0 artifact(s)" in CleanupReport().summary()
+        assert CleanupReport().deleted_count == 0
+
+
+# ════════════════════════════════════════════════════════════
+#  Real filesystem end-to-end
+# ════════════════════════════════════════════════════════════
+
+
+class TestLocalStoreCleanup:
+    """cleanup_artifacts against a real LocalArtifactStore."""
+
+    def test_deletes_expired_files_on_disk(self, tmp_path):
+        """Expired files are actually unlinked."""
+        root = tmp_path / "artifacts"
+        store = LocalArtifactStore(root)
+        old = root / "old.mp4"
+        new = root / "new.mp4"
+        old.write_bytes(b"x" * 100)
+        new.write_bytes(b"y" * 100)
+        stale = time.time() - 10 * DAY
+        import os
+
+        os.utime(old, (stale, stale))
+
+        policy = ArtifactLifecyclePolicy(ttl_seconds=int(DAY))
+        report = cleanup_artifacts(store, policy)
+        assert report.deleted == ["old.mp4"]
+        assert not old.exists()
+        assert new.exists()
+
+    def test_protocol_conformance(self, tmp_path):
+        """MemoryStore and LocalArtifactStore both satisfy the protocol."""
+        assert isinstance(LocalArtifactStore(tmp_path), StorageBackend)
+        assert isinstance(MemoryStore(), StorageBackend)
+
+
+# ════════════════════════════════════════════════════════════
+#  Background sweeper
+# ════════════════════════════════════════════════════════════
+
+
+class TestArtifactSweeper:
+    """The daemon thread that periodically runs cleanup_artifacts."""
+
+    def test_sweep_once_deletes(self, store):
+        """A manual sweep applies the policy."""
+        store.seed("old.mp4", 10, age_seconds=99 * DAY, now=time.time())
+        sweeper = ArtifactSweeper(store, ArtifactLifecyclePolicy(ttl_seconds=1))
+        report = sweeper.sweep_once()
+        assert report is not None
+        assert report.deleted == ["old.mp4"]
+        assert sweeper.last_report is report
+
+    def test_sweep_once_honours_protected_ids(self, store):
+        """Active task IDs protect their key namespace."""
+        store.seed("live/final.mp4", 10, age_seconds=99 * DAY, now=time.time())
+        store.seed("dead/final.mp4", 10, age_seconds=99 * DAY, now=time.time())
+        sweeper = ArtifactSweeper(
+            store,
+            ArtifactLifecyclePolicy(ttl_seconds=1),
+            protected_ids=lambda: ["live"],
+        )
+        report = sweeper.sweep_once()
+        assert report is not None
+        assert report.deleted == ["dead/final.mp4"]
+
+    def test_sweep_survives_callback_failure(self, store):
+        """A broken protected-ids callback aborts the sweep, not the process."""
+
+        def _boom() -> Iterable[str]:
+            raise RuntimeError("queue is down")
+
+        sweeper = ArtifactSweeper(
+            store, ArtifactLifecyclePolicy(ttl_seconds=1), protected_ids=_boom
+        )
+        assert sweeper.sweep_once() is None
+
+    def test_sweep_survives_store_failure(self):
+        """A store that raises a non-store error is caught and logged."""
+
+        class ExplodingStore(MemoryStore):
+            def list(self, prefix: str = "") -> Iterator[ArtifactInfo]:
+                raise RuntimeError("boom")
+
+        sweeper = ArtifactSweeper(ExplodingStore(), ArtifactLifecyclePolicy(ttl_seconds=1))
+        assert sweeper.sweep_once() is None
+
+    def test_thread_lifecycle(self, store):
+        """start()/stop() manage a daemon thread cleanly."""
+        store.seed("old.mp4", 10, age_seconds=99 * DAY, now=time.time())
+        sweeper = ArtifactSweeper(
+            store, ArtifactLifecyclePolicy(ttl_seconds=1), interval=1.0
+        )
+        assert sweeper.is_running is False
+        sweeper.start()
+        try:
+            assert sweeper.is_running is True
+            deadline = time.time() + 5
+            while sweeper.last_report is None and time.time() < deadline:
+                time.sleep(0.05)
+            assert sweeper.last_report is not None
+            assert store.keys == []
+        finally:
+            sweeper.stop()
+        assert sweeper.is_running is False
+
+    def test_start_is_idempotent(self, store):
+        """Calling start() twice does not spawn a second thread."""
+        sweeper = ArtifactSweeper(store, ArtifactLifecyclePolicy(ttl_seconds=1))
+        sweeper.start()
+        try:
+            first = sweeper._thread
+            sweeper.start()
+            assert sweeper._thread is first
+        finally:
+            sweeper.stop()
+
+    def test_stop_before_start_is_safe(self, store):
+        """stop() on a never-started sweeper is a no-op."""
+        ArtifactSweeper(store, ArtifactLifecyclePolicy()).stop()
+
+    def test_context_manager(self, store):
+        """The sweeper works as a context manager."""
+        with ArtifactSweeper(store, ArtifactLifecyclePolicy(ttl_seconds=1)) as sweeper:
+            assert sweeper.is_running
+        assert sweeper.is_running is False
+
+    def test_interval_floor(self, store):
+        """A sub-second interval is clamped to avoid a hot loop."""
+        sweeper = ArtifactSweeper(store, ArtifactLifecyclePolicy(), interval=0.01)
+        assert sweeper.interval == 1.0
+
+
+# ════════════════════════════════════════════════════════════
+#  CLI
+# ════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def cli_root(tmp_path) -> Path:
+    """A populated artifact root: one stale file, one fresh file."""
+    root = tmp_path / "store"
+    root.mkdir()
+    (root / "old.mp4").write_bytes(b"x" * 100)
+    (root / "new.mp4").write_bytes(b"y" * 50)
+    stale = time.time() - 30 * DAY
+    import os
+
+    os.utime(root / "old.mp4", (stale, stale))
+    return root
+
+
+class TestArtifactsCli:
+    """``mn artifacts list`` / ``mn artifacts cleanup``."""
+
+    def test_list_reports_files(self, cli_root):
+        """`mn artifacts list` prints every key and a total."""
+        result = CliRunner().invoke(app, ["artifacts", "list", "--root", str(cli_root)])
+        assert result.exit_code == 0
+        assert "old.mp4" in result.output
+        assert "new.mp4" in result.output
+        assert "2 artifact(s)" in result.output
+
+    def test_list_empty_store(self, tmp_path):
+        """An empty store says so instead of printing a bare total."""
+        result = CliRunner().invoke(
+            app, ["artifacts", "list", "--root", str(tmp_path / "empty")]
+        )
+        assert result.exit_code == 0
+        assert "No artifacts found." in result.output
+
+    def test_cleanup_dry_run_keeps_files(self, cli_root):
+        """--dry-run previews the deletion without touching the disk."""
+        result = CliRunner().invoke(
+            app,
+            [
+                "artifacts", "cleanup",
+                "--root", str(cli_root),
+                "--ttl", str(int(7 * DAY)),
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Would delete:" in result.output
+        assert "old.mp4" in result.output
+        assert "dry-run" in result.output
+        assert (cli_root / "old.mp4").exists()
+
+    def test_cleanup_deletes_expired(self, cli_root):
+        """Without --dry-run the expired artifact is removed."""
+        result = CliRunner().invoke(
+            app,
+            ["artifacts", "cleanup", "--root", str(cli_root), "--ttl", str(int(7 * DAY))],
+        )
+        assert result.exit_code == 0
+        assert "Deleted:" in result.output
+        assert not (cli_root / "old.mp4").exists()
+        assert (cli_root / "new.mp4").exists()
+
+    def test_cleanup_keep_last_protects(self, cli_root):
+        """--keep-last shields the newest artifacts."""
+        result = CliRunner().invoke(
+            app,
+            [
+                "artifacts", "cleanup",
+                "--root", str(cli_root),
+                "--ttl", "1",
+                "--keep-last", "2",
+            ],
+        )
+        assert result.exit_code == 0
+        assert (cli_root / "old.mp4").exists()
+        assert (cli_root / "new.mp4").exists()
+
+    def test_cleanup_max_bytes(self, cli_root):
+        """--max-bytes evicts oldest-first until the cap is met."""
+        result = CliRunner().invoke(
+            app, ["artifacts", "cleanup", "--root", str(cli_root), "--max-bytes", "60"]
+        )
+        assert result.exit_code == 0
+        assert not (cli_root / "old.mp4").exists()
+        assert (cli_root / "new.mp4").exists()
+
+    def test_cleanup_no_rule_is_noop(self, cli_root):
+        """With no rule active the command explains and exits cleanly."""
+        result = CliRunner().invoke(
+            app, ["artifacts", "cleanup", "--root", str(cli_root), "--ttl", "0"]
+        )
+        assert result.exit_code == 0
+        assert "No retention rule active" in result.output
+        assert (cli_root / "old.mp4").exists()
+
+    def test_cleanup_unknown_backend_exits_1(self, cli_root):
+        """An unsupported backend is a clean error, not a traceback."""
+        result = CliRunner().invoke(
+            app,
+            ["artifacts", "cleanup", "--backend", "gcs", "--ttl", "1"],
+        )
+        assert result.exit_code == 1
+        assert "Artifact store unavailable" in result.output


### PR DESCRIPTION
## v0.8.3 — Storage backend & artifact lifecycle

### Added
- **Artifact storage abstraction** — new `cloud.artifact_store` module: `StorageBackend` protocol (put/get/open/exists/delete/list/stat/url), `ArtifactInfo` value object, `LocalArtifactStore` (default) and `S3ArtifactStore` (S3 / MinIO / R2). Factory `get_artifact_store()` resolves from `MN_STORAGE_BACKEND` / `MN_STORAGE_ROOT` / `MN_S3_*` env.
- **Optional `s3` extra** — `pip install 'movie-narrator[s3]'` (`boto3>=1.34`, lazy import, injectable client).
- **Artifact lifecycle / TTL cleanup** — new `cloud.lifecycle` module: `ArtifactLifecyclePolicy` (TTL / size cap / keep-last-N / dry-run), `cleanup_artifacts()` returning `CleanupReport`, daemonised `ArtifactSweeper` thread. In-flight task artifacts are never deleted.
- **`mn artifacts` CLI group** — `list` and `cleanup --ttl/--max-bytes/--keep-last/--dry-run`.
- Background sweeper in `mn serve` when a retention rule is configured (`MN_ARTIFACT_TTL` / `MN_ARTIFACT_MAX_BYTES`, sweep every `MN_ARTIFACT_SWEEP_INTERVAL`s).
- Exports: `ArtifactInfo`, `ArtifactLifecyclePolicy`, `ArtifactSweeper`, `CleanupReport`, `LocalArtifactStore`, `S3ArtifactStore`, `StorageBackend`, `cleanup_artifacts`, `get_artifact_store`.
- 151 new tests.

### Changed
- `GET /tasks/{id}/artifacts` and `GET /tasks/{id}/download/{file}` now go through the artifact-store abstraction; behaviour and the path-traversal guard are unchanged (local backend default).
- `CONTRACT_VERSION` → (0, 8, 3); package version 0.8.3.

### Verification
- Local full suite after merge: 1697 passed / 0 failed / 5 skipped.