### PR TITLE
release: v0.8.4 — containerization (multi-stage Dockerfile + compose cluster)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build-context exclusions for the movie-narrator image (v0.8.4).
+#
+# The builder stage only needs: pyproject.toml, README.md and src/.
+# Everything else is excluded to keep the context small and to avoid
+# invalidating the dependency cache layer on unrelated edits.
+#
+# NOTE: pyproject.toml and README.md must stay in the context —
+# `readme = "README.md"` in pyproject.toml makes the build fail without it.
+
+# ── VCS ──────────────────────────────────────────────────────
+.git
+.gitignore
+.gitattributes
+.github
+
+# ── Python build / cache artifacts ───────────────────────────
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+.eggs/
+build/
+dist/
+wheels/
+.Python
+
+# ── Virtual environments ─────────────────────────────────────
+.venv
+venv/
+env/
+
+# ── Test / tooling caches ────────────────────────────────────
+tests/
+conftest.py
+benchmarks/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.pytools/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# ── Secrets and local config ─────────────────────────────────
+# .env must never be baked into an image layer — it is injected at
+# runtime via `env_file` / `-e` instead.
+.env
+.env.local
+.env.*.local
+
+# ── Generated output and media ───────────────────────────────
+output/
+*.mp4
+*.mp3
+*.wav
+*.srt
+!src/movie_narrator/assets/**
+
+# ── Documentation (not needed at runtime) ────────────────────
+docs/
+docs-nocommit/
+examples/
+mkdocs.yml
+site/
+CHANGELOG.md
+INTEGRATION_NOTES.md
+README.zh-CN.md
+SECURITY.md
+
+# ── Container files themselves ───────────────────────────────
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker-compose.*.yml
+
+# ── Editor / OS cruft ────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# ── AI tooling leftovers ─────────────────────────────────────
+.claude/
+.mimocode/
+CLAUDE.md
+superpowers/

--- a/.env.example
+++ b/.env.example
@@ -139,3 +139,32 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # MN_ARTIFACT_MAX_BYTES=0           # evict oldest-first above this total size (0 = unlimited)
 # MN_ARTIFACT_KEEP_LAST=0           # always keep the N newest artifacts (0 = disabled)
 # MN_ARTIFACT_SWEEP_INTERVAL=3600   # seconds between background sweeps (mn serve)
+
+# ============================================================
+# Containerized deployment (v0.8.4)
+# ============================================================
+# Only read by Dockerfile build args and docker-compose.yml — the
+# application itself ignores them (Settings uses extra="ignore").
+# Every one has a compose-side default, so this whole block is optional.
+# See docs/DEPLOYMENT.md for the full guide.
+#
+# NOTE: containers bind 0.0.0.0, so MN_API_KEY above is effectively
+# REQUIRED — `mn serve` refuses to start on a public interface without
+# it (append --insecure to the compose command to override).
+
+# ---- Image build ----
+# MN_EXTRAS=media                  # CPU image extras: "" | media | ml | full
+# MN_GPU_EXTRAS=full               # CUDA image extras (target: runtime-gpu)
+# MN_IMAGE_TAG=local               # tag for movie-narrator:<tag>
+
+# ---- Cluster topology ----
+# MN_API_PORT=8765                 # host port published by the api service
+# MN_MAX_WORKERS=2                 # --max-workers per container (concurrent tasks)
+# MN_WORKER_REPLICAS=2             # worker container count (docker compose --scale)
+
+# ---- MinIO (compose profile: s3, experimental) ----
+# Used by `docker compose --profile s3 up`. Pair with the v0.8.3
+# StorageBackend: set MN_STORAGE_BACKEND=s3, MN_S3_ENDPOINT_URL=http://minio:9000
+# in the api/worker services to store artifacts in MinIO.
+# MINIO_ROOT_USER=minioadmin
+# MINIO_ROOT_PASSWORD=minioadmin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-08-03
+
+### Added
+
+- **Dockerfile** — multi-stage build (`builder` → `runtime`), based on `python:3.12-slim`. The runtime stage installs `ffmpeg`, runs as a non-root `app` user (UID/GID 10001), declares volumes for `/app/output` and `/app/.mn_tasks`, exposes 8765, and ships a `HEALTHCHECK` against `/health`. `ENTRYPOINT` is `mn`, so the image doubles as the CLI.
+- **GPU image** — `runtime-gpu` build target based on `nvidia/cuda:12.4.1-runtime-ubuntu22.04`, intended for `docker run --gpus all` / the compose `gpu` profile. The CPU image remains the default build target.
+- **`MN_EXTRAS` / `MN_GPU_EXTRAS` / `PYTHON_VERSION` build args** — select the optional-dependency set (`""` / `media` / `ml` / `full`) at build time.
+- **`.dockerignore`** — trims the build context and keeps `.env` out of image layers.
+- **docker-compose.yml** — local cluster with an `api` service (publishes 8765, health-gated), a scalable `worker` service, a `gpu` profile (`worker-gpu`, NVIDIA device reservation) and an `s3` profile (MinIO, paired with the v0.8.3 S3 `StorageBackend`). Storage is modelled as named volumes; no database or broker was invented.
+- **`docs/DEPLOYMENT.md` / `docs/DEPLOYMENT.zh-CN.md`** — bilingual deployment guide covering build, run, scale, GPU, environment variables, volumes and backup, plus the queue-architecture caveats.
+- **`tests/test_v084_container.py`** — 74 static validation tests for the container artifacts, including a check that every subcommand and flag referenced from `docker-compose.yml` resolves against the real CLI app.
+
 ## [0.8.3] - 2026-08-03
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# movie-narrator — multi-stage container image (v0.8.4)
+#
+# Targets
+#   builder      internal — resolves dependencies and builds the wheel
+#   runtime-gpu  CUDA-enabled image, intended for `docker run --gpus all`
+#   runtime      DEFAULT — slim CPU image
+#
+# Stage ordering note: `runtime` is deliberately the LAST stage so that a
+# plain `docker build .` (no --target) produces the lightweight CPU image.
+# BuildKit (default since Docker 23) skips stages the target does not
+# depend on, so the CUDA layers are never pulled for a CPU build.
+#
+# Usage
+#   docker build -t movie-narrator:0.8.4 .
+#   docker build -t movie-narrator:0.8.4-full --build-arg MN_EXTRAS=full .
+#   docker build -t movie-narrator:0.8.4-gpu --target runtime-gpu .
+
+# Python 3.12 is chosen deliberately: the `ml` extras (whisperx,
+# faster-whisper, sentence-transformers) are pinned `python_version < "3.14"`,
+# and 3.12 is the best-supported target across the PyTorch / CTranslate2
+# wheel matrix. 3.13 still has patchy binary-wheel coverage for those
+# packages, and 3.14 is excluded by the pins outright.
+ARG PYTHON_VERSION=3.12
+
+# Extras selection for the CPU image. Empty string installs the base
+# package only. `media` (scenedetect) is the sensible default; `full`
+# adds the heavy ml stack.
+ARG MN_EXTRAS=media
+
+# Extras for the GPU image — defaults to `full` because the whole point
+# of the CUDA image is to run the ml stack on a device.
+ARG MN_GPU_EXTRAS=full
+
+
+# ─────────────────────────────────────────────────────────────
+# Stage 1: builder — build the wheel and a self-contained venv
+# ─────────────────────────────────────────────────────────────
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+ARG MN_EXTRAS
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Build toolchain lives only in this stage — it never reaches runtime.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+WORKDIR /build
+
+# ── Dependency layer ─────────────────────────────────────────
+# Copy only the metadata needed to resolve dependencies, then install
+# against a stub package. This layer is cached and only invalidated when
+# pyproject.toml changes — editing source code does not re-resolve deps.
+COPY pyproject.toml README.md ./
+RUN mkdir -p src/movie_narrator \
+    && : > src/movie_narrator/__init__.py \
+    && pip install --upgrade pip setuptools wheel \
+    && if [ -n "${MN_EXTRAS}" ]; then \
+           pip install ".[${MN_EXTRAS}]"; \
+       else \
+           pip install "."; \
+       fi
+
+# ── Source layer ─────────────────────────────────────────────
+# Real sources arrive last so that the expensive dependency layer above
+# stays warm across ordinary code changes.
+COPY src/ ./src/
+RUN pip wheel --no-deps --wheel-dir /wheels . \
+    && pip install --no-deps --force-reinstall /wheels/movie_narrator-*.whl
+
+
+# ─────────────────────────────────────────────────────────────
+# Stage 2: runtime-gpu — CUDA runtime for `--gpus all`
+# ─────────────────────────────────────────────────────────────
+# Built from the wheel produced above rather than from the 3.12 venv:
+# the CUDA base ships Ubuntu's own Python, and copying a venv across
+# interpreter versions would not work. Dependencies are resolved fresh
+# for that interpreter (>=3.10 satisfies requires-python, and the `ml`
+# pins `< 3.14` still hold).
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS runtime-gpu
+
+ARG MN_GPU_EXTRAS
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# ffmpeg is a hard runtime requirement — moviepy and pydub shell out to it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /wheels /tmp/wheels
+RUN WHEEL="$(ls /tmp/wheels/movie_narrator-*.whl)" \
+    && python3 -m pip install --upgrade pip setuptools wheel \
+    && if [ -n "${MN_GPU_EXTRAS}" ]; then \
+           python3 -m pip install "${WHEEL}[${MN_GPU_EXTRAS}]"; \
+       else \
+           python3 -m pip install "${WHEEL}"; \
+       fi \
+    && rm -rf /tmp/wheels
+
+# Non-root user with an explicit, stable UID/GID so that bind-mounted
+# host directories get predictable ownership.
+RUN groupadd --gid 10001 app \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash app
+
+WORKDIR /app
+RUN mkdir -p /app/output /app/.mn_tasks && chown -R app:app /app
+
+# Artifacts and task state must outlive the container.
+VOLUME ["/app/output", "/app/.mn_tasks"]
+
+USER app:app
+
+EXPOSE 8765
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD ["python3", "-c", "import sys,urllib.request as u; sys.exit(0 if u.urlopen('http://127.0.0.1:8765/health', timeout=4).status == 200 else 1)"]
+
+ENTRYPOINT ["mn"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "8765", "--storage-dir", "/app/.mn_tasks"]
+
+
+# ─────────────────────────────────────────────────────────────
+# Stage 3: runtime — DEFAULT slim CPU image
+# ─────────────────────────────────────────────────────────────
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/opt/venv/bin:${PATH}"
+
+# ffmpeg is a hard runtime requirement — moviepy and pydub shell out to it.
+# No build toolchain is installed here; only the prebuilt venv is copied in.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 10001 app \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash app
+
+COPY --from=builder --chown=10001:10001 /opt/venv /opt/venv
+
+WORKDIR /app
+RUN mkdir -p /app/output /app/.mn_tasks && chown -R app:app /app
+
+# Artifacts and task state must outlive the container.
+VOLUME ["/app/output", "/app/.mn_tasks"]
+
+USER app:app
+
+EXPOSE 8765
+
+# Uses the stdlib rather than curl so the runtime image stays free of
+# extra apt packages. /health is exempt from X-API-Key auth (v0.6.1).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD ["python", "-c", "import sys,urllib.request as u; sys.exit(0 if u.urlopen('http://127.0.0.1:8765/health', timeout=4).status == 200 else 1)"]
+
+ENTRYPOINT ["mn"]
+# Binding 0.0.0.0 is required for the port to be reachable from outside the
+# container. `mn serve` refuses to start on a public interface without an
+# API key, so set MN_API_KEY (or append --insecure at your own risk).
+CMD ["serve", "--host", "0.0.0.0", "--port", "8765", "--storage-dir", "/app/.mn_tasks"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# movie-narrator — local cluster (v0.8.4)
+#
+#   docker compose up -d                     # api + workers (CPU)
+#   docker compose up -d --scale worker=4    # more capacity
+#   docker compose --profile s3 up -d        # + MinIO (experimental)
+#   docker compose --profile gpu up -d       # + CUDA worker (needs nvidia-ctk)
+#
+# Requires Docker Compose v2.24+ (for the `env_file: [{path, required}]`
+# long syntax). No top-level `version:` key — it is obsolete in the
+# Compose Spec.
+#
+# ── Storage model ────────────────────────────────────────────
+# The project has no database and no external broker, so "storage" here
+# is modelled with named volumes rather than an invented service:
+#
+#   mn-output   artifacts (rendered video/audio/subtitles) — SHARED by
+#               the api and every worker replica.
+#   mn-tasks    the api's authoritative task index (tasks.json).
+#
+# IMPORTANT: `LocalTaskQueue` is an in-process ThreadPoolExecutor and
+# `TaskStorage` keeps the whole index cached in memory, rewriting the
+# file on every save. Two processes pointing at the same --storage-dir
+# would clobber each other. Worker replicas therefore get a PRIVATE
+# anonymous volume for /app/.mn_tasks and act as independent inference
+# endpoints reached via `--remote http://worker:8765`, not as consumers
+# of the api's queue. See docs/DEPLOYMENT.md for the consequences.
+
+name: movie-narrator
+
+# ── Reusable fragments ───────────────────────────────────────
+x-mn-build: &mn-build
+  context: .
+  dockerfile: Dockerfile
+  target: runtime
+  args:
+    MN_EXTRAS: ${MN_EXTRAS:-media}
+
+x-mn-env: &mn-env
+  # Loads MN_LLM_*, MN_TTS_*, MN_TMDB_* … from the local .env.
+  # Optional so that `docker compose config` works on a fresh clone.
+  - path: .env
+    required: false
+
+x-mn-healthcheck: &mn-healthcheck
+  # /health is exempt from X-API-Key authentication (v0.6.1), so the
+  # probe needs no credentials. Uses the stdlib to avoid shipping curl.
+  test:
+    - CMD
+    - python
+    - -c
+    - "import sys,urllib.request as u; sys.exit(0 if u.urlopen('http://127.0.0.1:8765/health', timeout=4).status == 200 else 1)"
+  interval: 30s
+  timeout: 5s
+  retries: 3
+  start_period: 20s
+
+services:
+
+  # ── REST API — the front door ──────────────────────────────
+  api:
+    build: *mn-build
+    image: movie-narrator:${MN_IMAGE_TAG:-local}
+    # ENTRYPOINT is ["mn"], so `command` supplies the subcommand + flags.
+    command:
+      - serve
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8765"
+      - --storage-dir
+      - /app/.mn_tasks
+      - --max-workers
+      - "${MN_MAX_WORKERS:-2}"
+    env_file: *mn-env
+    environment:
+      # Never hardcode the key — it is read from .env / the host env.
+      # `mn serve` refuses to bind 0.0.0.0 without it (add --insecure to
+      # override, at your own risk).
+      MN_API_KEY: ${MN_API_KEY:-}
+    ports:
+      - "${MN_API_PORT:-8765}:8765"
+    volumes:
+      - mn-tasks:/app/.mn_tasks
+      - mn-output:/app/output
+    healthcheck: *mn-healthcheck
+    restart: unless-stopped
+
+  # ── Worker pool — extra inference capacity ─────────────────
+  # Scale with `--scale worker=N` or MN_WORKER_REPLICAS.
+  # Compose's internal DNS round-robins `worker` across replicas.
+  worker:
+    build: *mn-build
+    image: movie-narrator:${MN_IMAGE_TAG:-local}
+    command:
+      - serve
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8765"
+      - --storage-dir
+      - /app/.mn_tasks
+      - --max-workers
+      - "${MN_MAX_WORKERS:-2}"
+    env_file: *mn-env
+    environment:
+      MN_API_KEY: ${MN_API_KEY:-}
+    # No published ports — replicas would collide on the host port.
+    expose:
+      - "8765"
+    volumes:
+      # Anonymous per-replica volume: task state must NOT be shared.
+      - /app/.mn_tasks
+      # Artifacts, on the other hand, are shared with the api.
+      - mn-output:/app/output
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck: *mn-healthcheck
+    deploy:
+      replicas: ${MN_WORKER_REPLICAS:-2}
+    restart: unless-stopped
+
+  # ── GPU worker (profile: gpu) ──────────────────────────────
+  # Requires the NVIDIA Container Toolkit on the host.
+  # Equivalent to `docker run --gpus all`.
+  worker-gpu:
+    profiles:
+      - gpu
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime-gpu
+      args:
+        MN_GPU_EXTRAS: ${MN_GPU_EXTRAS:-full}
+    image: movie-narrator:${MN_IMAGE_TAG:-local}-gpu
+    command:
+      - serve
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8765"
+      - --storage-dir
+      - /app/.mn_tasks
+      - --max-workers
+      - "${MN_MAX_WORKERS:-2}"
+    env_file: *mn-env
+    environment:
+      MN_API_KEY: ${MN_API_KEY:-}
+    expose:
+      - "8765"
+    volumes:
+      - /app/.mn_tasks
+      - mn-output:/app/output
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      # The CUDA image exposes Ubuntu's interpreter as `python3`.
+      test:
+        - CMD
+        - python3
+        - -c
+        - "import sys,urllib.request as u; sys.exit(0 if u.urlopen('http://127.0.0.1:8765/health', timeout=4).status == 200 else 1)"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu
+    restart: unless-stopped
+
+  # ── MinIO (profile: s3) — EXPERIMENTAL ─────────────────────
+  # movie-narrator does NOT speak S3 yet; artifacts still land on the
+  # mn-output volume. This service exists so the storage-backend work
+  # (`StorageBackend` protocol, deferred to a later v0.8.x point
+  # release) has an S3-compatible endpoint to develop against.
+  minio:
+    profiles:
+      - s3
+    # Pin a dated RELEASE tag before using this for anything real.
+    image: minio/minio:latest
+    command:
+      - server
+      - /data
+      - --console-address
+      - ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - mn-minio:/data
+    healthcheck:
+      test:
+        - CMD
+        - mc
+        - ready
+        - local
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  # Rendered artifacts — shared by api + workers. Back this up.
+  mn-output:
+  # api task index (tasks.json). Small but not reproducible.
+  mn-tasks:
+  # MinIO object store (profile: s3 only).
+  mn-minio:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,374 @@
+# Deployment
+
+> 中文版本：[DEPLOYMENT.zh-CN.md](DEPLOYMENT.zh-CN.md)
+
+Container images and a local cluster for `movie-narrator` (v0.8.4).
+
+- [Requirements](#requirements)
+- [Building the image](#building-the-image)
+- [Running a single container](#running-a-single-container)
+- [The local cluster](#the-local-cluster)
+- [Scaling](#scaling)
+- [GPU](#gpu)
+- [Object storage (experimental)](#object-storage-experimental)
+- [Environment variables](#environment-variables)
+- [Volumes and backup](#volumes-and-backup)
+- [Architecture notes and limitations](#architecture-notes-and-limitations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Requirements
+
+| Component | Minimum | Notes |
+|---|---|---|
+| Docker Engine | 23.0 | BuildKit is the default builder |
+| Docker Compose | v2.24 | needed for the `env_file: [{path, required}]` long syntax |
+| NVIDIA Container Toolkit | any current | GPU profile only |
+
+No Python installation is needed on the host — `ffmpeg` ships inside the image.
+
+---
+
+## Building the image
+
+The `Dockerfile` has three stages:
+
+| Stage | Base | Purpose |
+|---|---|---|
+| `builder` | `python:3.12-slim` | resolves dependencies, builds the wheel |
+| `runtime-gpu` | `nvidia/cuda:12.4.1-runtime-ubuntu22.04` | CUDA image for `--gpus all` |
+| `runtime` | `python:3.12-slim` | **default** — slim CPU image |
+
+`runtime` is the last stage on purpose, so a plain build gives you the small
+CPU image and never pulls the multi-gigabyte CUDA layers:
+
+```bash
+docker build -t movie-narrator:local .
+```
+
+### Why Python 3.12
+
+The `ml` extras (`whisperx`, `faster-whisper`, `sentence-transformers`) are
+pinned `python_version < "3.14"`, and 3.12 has the most complete binary-wheel
+coverage across the PyTorch / CTranslate2 matrix. 3.13 wheels are still patchy
+for those packages, and 3.14 is excluded by the pins outright.
+
+### Build arguments
+
+| Arg | Default | Effect |
+|---|---|---|
+| `PYTHON_VERSION` | `3.12` | base interpreter for the CPU stages |
+| `MN_EXTRAS` | `media` | extras for the CPU image — `""`, `media`, `ml`, `full` |
+| `MN_GPU_EXTRAS` | `full` | extras for the CUDA image |
+
+```bash
+# Minimal image — base dependencies only, no scenedetect
+docker build --build-arg MN_EXTRAS= -t movie-narrator:slim .
+
+# Everything, including the ml stack
+docker build --build-arg MN_EXTRAS=full -t movie-narrator:full .
+
+# CUDA image
+docker build --target runtime-gpu -t movie-narrator:gpu .
+```
+
+### Layer caching
+
+The builder copies `pyproject.toml` + `README.md` and installs dependencies
+**before** copying `src/`. Editing source code therefore reuses the cached
+dependency layer; only a `pyproject.toml` change forces a re-resolve.
+
+---
+
+## Running a single container
+
+The image's `ENTRYPOINT` is `mn`, so anything you can do with the CLI works:
+
+```bash
+# Start the API server (the default CMD)
+docker run --rm -p 8765:8765 \
+  -e MN_API_KEY=your-secret \
+  -v mn-output:/app/output \
+  -v mn-tasks:/app/.mn_tasks \
+  movie-narrator:local
+
+# Any other subcommand
+docker run --rm movie-narrator:local version
+docker run --rm movie-narrator:local --help
+```
+
+> **The API key is effectively mandatory.** Containers must bind `0.0.0.0` to be
+> reachable, and `mn serve` refuses to start on a public interface without a key.
+> Either set `MN_API_KEY`, or append `--insecure` to accept the risk:
+>
+> ```bash
+> docker run --rm -p 8765:8765 movie-narrator:local \
+>   serve --host 0.0.0.0 --port 8765 --storage-dir /app/.mn_tasks --insecure
+> ```
+
+Verify:
+
+```bash
+curl http://localhost:8765/health          # {"status": "ok"} — no auth required
+curl -H "X-API-Key: your-secret" http://localhost:8765/info
+```
+
+---
+
+## The local cluster
+
+```bash
+cp .env.example .env
+# edit .env — at minimum set MN_API_KEY and your MN_LLM_* values
+docker compose up -d
+docker compose ps
+docker compose logs -f api
+```
+
+Services:
+
+| Service | Profile | Published | Role |
+|---|---|---|---|
+| `api` | default | `${MN_API_PORT:-8765}` → 8765 | REST front door, owns the task index |
+| `worker` | default | — | additional inference capacity |
+| `worker-gpu` | `gpu` | — | CUDA worker |
+| `minio` | `s3` | 9000, 9001 | S3-compatible sandbox (experimental) |
+
+Workers wait for the API to report healthy (`depends_on: condition:
+service_healthy`) before they start.
+
+Submit work:
+
+```bash
+docker compose exec api mn submit -m "飞驰人生" --wait
+# or from the host
+mn submit -m "飞驰人生" --remote http://localhost:8765 --wait
+mn tasks --remote http://localhost:8765
+mn download <task-id> --remote http://localhost:8765 -o ./output
+```
+
+Tear down:
+
+```bash
+docker compose down            # keep volumes
+docker compose down -v         # delete artifacts and task state too
+```
+
+---
+
+## Scaling
+
+```bash
+docker compose up -d --scale worker=4
+# or persist it
+echo "MN_WORKER_REPLICAS=4" >> .env && docker compose up -d
+```
+
+Two independent knobs:
+
+- **`MN_WORKER_REPLICAS`** — how many worker *containers* run.
+- **`MN_MAX_WORKERS`** — `--max-workers`, how many tasks run concurrently
+  *inside* one container.
+
+Total concurrency is roughly `replicas × MN_MAX_WORKERS`. Rendering is
+CPU- and memory-hungry; start at `MN_MAX_WORKERS=2` and watch memory before
+raising it.
+
+Read [Architecture notes and limitations](#architecture-notes-and-limitations)
+before relying on worker replicas — they are **not** consumers of the API's
+queue.
+
+---
+
+## GPU
+
+Requires the NVIDIA Container Toolkit on the host.
+
+```bash
+docker compose --profile gpu up -d
+docker compose exec worker-gpu nvidia-smi
+```
+
+The compose service uses the standard reservation stanza, equivalent to
+`docker run --gpus all`:
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+The CUDA image is built from the wheel produced by the `builder` stage rather
+than from the 3.12 virtualenv: the CUDA base ships Ubuntu's own interpreter, and
+a venv cannot be copied across interpreter versions. Dependencies are resolved
+fresh for that interpreter — `requires-python >= 3.10` is satisfied and the
+`ml` pins (`< 3.14`) still hold.
+
+Without a GPU, `whisperx` / `faster-whisper` fall back to CPU, which is slow but
+correct.
+
+---
+
+## Object storage (experimental)
+
+```bash
+docker compose --profile s3 up -d
+# console at http://localhost:9001 (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD)
+```
+
+> **movie-narrator does not speak S3 yet.** Artifacts still land on the
+> `mn-output` volume. This service exists so that the `StorageBackend`
+> abstraction (deferred to a later v0.8.x point release) has an S3-compatible
+> endpoint to develop against. Pin a dated `RELEASE.*` tag instead of `latest`
+> before using it for anything real.
+
+---
+
+## Environment variables
+
+Configuration is env-driven and read from `.env` (see `.env.example`). The
+container never bakes secrets into a layer — `.env` is excluded by
+`.dockerignore` and injected at runtime.
+
+### Container-specific
+
+| Variable | Default | Scope | Meaning |
+|---|---|---|---|
+| `MN_API_KEY` | *(unset)* | runtime | `X-API-Key` credential; effectively required |
+| `MN_API_PORT` | `8765` | compose | host port published by `api` |
+| `MN_MAX_WORKERS` | `2` | compose | `--max-workers` per container |
+| `MN_WORKER_REPLICAS` | `2` | compose | number of worker containers |
+| `MN_IMAGE_TAG` | `local` | compose | tag for `movie-narrator:<tag>` |
+| `MN_EXTRAS` | `media` | build | extras for the CPU image |
+| `MN_GPU_EXTRAS` | `full` | build | extras for the CUDA image |
+| `MINIO_ROOT_USER` | `minioadmin` | compose | `s3` profile only |
+| `MINIO_ROOT_PASSWORD` | `minioadmin` | compose | `s3` profile only |
+
+### Application
+
+All existing `MN_*` settings (`MN_LLM_BASE_URL`, `MN_LLM_API_KEY`,
+`MN_LLM_MODEL`, `MN_DEFAULT_VOICE`, `MN_TTS_PROVIDER`, `MN_TMDB_API_KEY`, …)
+pass straight through from `.env`. See `.env.example` for the full list.
+
+If your LLM runs on the host (e.g. Ollama), point the containers at
+`host.docker.internal` rather than `localhost`:
+
+```dotenv
+MN_LLM_BASE_URL=http://host.docker.internal:11434/v1
+```
+
+---
+
+## Volumes and backup
+
+| Volume | Mount | Contents | Back up? |
+|---|---|---|---|
+| `mn-output` | `/app/output` | rendered video, audio, subtitles, scripts | **yes** |
+| `mn-tasks` | `/app/.mn_tasks` | the API's `tasks.json` index | yes — small, not reproducible |
+| *(anonymous)* | `/app/.mn_tasks` on workers | per-replica task state | no — disposable |
+| `mn-minio` | `/data` | MinIO objects (`s3` profile) | if you use it |
+
+Both runtime stages declare `VOLUME ["/app/output", "/app/.mn_tasks"]`, so those
+paths stay writable and persistent even with a plain `docker run`.
+
+Backup:
+
+```bash
+docker run --rm -v movie-narrator_mn-output:/data:ro -v "$PWD":/backup \
+  alpine tar czf /backup/mn-output-$(date +%F).tar.gz -C /data .
+```
+
+Restore:
+
+```bash
+docker run --rm -v movie-narrator_mn-output:/data -v "$PWD":/backup \
+  alpine tar xzf /backup/mn-output-2026-01-01.tar.gz -C /data
+```
+
+> Volumes are prefixed with the compose project name (`movie-narrator`, set via
+> the top-level `name:` key). Confirm with `docker volume ls`.
+
+Containers run as UID/GID `10001:10001`. If you swap a named volume for a bind
+mount, chown the host directory to match:
+
+```bash
+mkdir -p ./output && sudo chown -R 10001:10001 ./output
+```
+
+---
+
+## Architecture notes and limitations
+
+Read this before scaling out.
+
+**Workers are independent endpoints, not queue consumers.**
+`LocalTaskQueue` is an in-process `ThreadPoolExecutor`, and `TaskStorage` keeps
+the whole task index cached in memory, rewriting `tasks.json` on every save.
+There is no broker and no shared queue. Consequences:
+
+1. **Task state is never shared.** Two processes pointing at the same
+   `--storage-dir` would clobber each other's index, so worker replicas get a
+   *private anonymous volume* for `/app/.mn_tasks`. Only the `api` service uses
+   the named `mn-tasks` volume.
+2. **A task submitted to `api` runs on `api`.** Workers do not pick it up.
+   To use worker capacity, address them directly — Compose's DNS round-robins
+   `worker` across replicas:
+   ```bash
+   mn submit -m "..." --remote http://worker:8765
+   ```
+3. **Task IDs are not portable across replicas.** Because DNS round-robins,
+   a follow-up `mn status <id> --remote http://worker:8765` may hit a different
+   replica that has never heard of that ID. For `--wait` workflows either keep
+   `MN_WORKER_REPLICAS=1`, or target one replica by its container name
+   (`docker compose ps` → `movie-narrator-worker-2`).
+4. **Artifacts *are* shared.** Every service mounts `mn-output` at
+   `/app/output`, so rendered files land in one place regardless of which
+   container produced them.
+
+A real shared broker (Redis / Celery / SQS) is roadmap work, not part of v0.8.4.
+
+**Other notes**
+
+- The healthcheck probes `http://127.0.0.1:8765/health` with the Python stdlib,
+  so the image ships no `curl`. If you change the listen port, override the
+  healthcheck too — the port is hardcoded in the image's `HEALTHCHECK`.
+- `/health` is exempt from `X-API-Key` auth (v0.6.1), so probes need no
+  credentials. Every other route is authenticated when `MN_API_KEY` is set.
+- Running tasks are lost if a container is killed mid-render; they stay
+  `RUNNING` in the index. Clear them with `mn cleanup --all`.
+
+---
+
+## Troubleshooting
+
+**The `api` container exits immediately with code 1**
+`mn serve` refused to bind `0.0.0.0` without an API key. Set `MN_API_KEY` in
+`.env`, or add `--insecure` to the service's `command`.
+
+**`docker compose up` fails on `env_file`**
+You are on Compose < 2.24. Upgrade, or replace the long syntax with
+`env_file: [.env]` and make sure the file exists.
+
+**Workers never start**
+They wait for `api` to be healthy. Check `docker compose ps` and
+`docker compose logs api`. A wedged API means the healthcheck never passes.
+
+**`ffmpeg not found`**
+You are not using this image — the runtime stages install it explicitly.
+Confirm with `docker compose exec api ffmpeg -version`.
+
+**Renders are killed with exit code 137**
+Out of memory. Lower `MN_MAX_WORKERS`, or raise the Docker memory limit.
+
+**`nvidia-smi` fails inside `worker-gpu`**
+The NVIDIA Container Toolkit is missing or unconfigured on the host. Verify
+with `docker run --rm --gpus all nvidia/cuda:12.4.1-runtime-ubuntu22.04
+nvidia-smi`.
+
+**Permission denied writing to a bind-mounted `./output`**
+Chown it to `10001:10001` (see [Volumes and backup](#volumes-and-backup)).

--- a/docs/DEPLOYMENT.zh-CN.md
+++ b/docs/DEPLOYMENT.zh-CN.md
@@ -1,0 +1,359 @@
+# 部署指南
+
+> English version: [DEPLOYMENT.md](DEPLOYMENT.md)
+
+`movie-narrator` 的容器镜像与本地集群（v0.8.4）。
+
+- [环境要求](#环境要求)
+- [构建镜像](#构建镜像)
+- [运行单个容器](#运行单个容器)
+- [本地集群](#本地集群)
+- [扩缩容](#扩缩容)
+- [GPU](#gpu)
+- [对象存储（实验性）](#对象存储实验性)
+- [环境变量](#环境变量)
+- [数据卷与备份](#数据卷与备份)
+- [架构说明与限制](#架构说明与限制)
+- [故障排查](#故障排查)
+
+---
+
+## 环境要求
+
+| 组件 | 最低版本 | 说明 |
+|---|---|---|
+| Docker Engine | 23.0 | BuildKit 为默认构建器 |
+| Docker Compose | v2.24 | `env_file: [{path, required}]` 长语法所需 |
+| NVIDIA Container Toolkit | 当前版本即可 | 仅 GPU profile 需要 |
+
+宿主机无需安装 Python——`ffmpeg` 已内置于镜像中。
+
+---
+
+## 构建镜像
+
+`Dockerfile` 包含三个阶段：
+
+| 阶段 | 基础镜像 | 用途 |
+|---|---|---|
+| `builder` | `python:3.12-slim` | 解析依赖、构建 wheel |
+| `runtime-gpu` | `nvidia/cuda:12.4.1-runtime-ubuntu22.04` | 用于 `--gpus all` 的 CUDA 镜像 |
+| `runtime` | `python:3.12-slim` | **默认**——轻量 CPU 镜像 |
+
+`runtime` 被刻意放在最后一个阶段，因此直接构建得到的是小体积 CPU 镜像，
+不会拉取数 GB 的 CUDA 层：
+
+```bash
+docker build -t movie-narrator:local .
+```
+
+### 为什么选 Python 3.12
+
+`ml` 附加依赖（`whisperx`、`faster-whisper`、`sentence-transformers`）被固定为
+`python_version < "3.14"`，而 3.12 在 PyTorch / CTranslate2 的二进制 wheel
+矩阵中覆盖最完整。这些包对 3.13 的 wheel 支持仍不齐全，3.14 则被版本约束直接排除。
+
+### 构建参数
+
+| 参数 | 默认值 | 作用 |
+|---|---|---|
+| `PYTHON_VERSION` | `3.12` | CPU 阶段的基础解释器 |
+| `MN_EXTRAS` | `media` | CPU 镜像的附加依赖——`""`、`media`、`ml`、`full` |
+| `MN_GPU_EXTRAS` | `full` | CUDA 镜像的附加依赖 |
+
+```bash
+# 最小镜像——仅基础依赖，不含 scenedetect
+docker build --build-arg MN_EXTRAS= -t movie-narrator:slim .
+
+# 完整镜像，包含 ml 技术栈
+docker build --build-arg MN_EXTRAS=full -t movie-narrator:full .
+
+# CUDA 镜像
+docker build --target runtime-gpu -t movie-narrator:gpu .
+```
+
+### 层缓存
+
+builder 阶段先复制 `pyproject.toml` + `README.md` 并安装依赖，**之后**才复制
+`src/`。因此修改源码可复用缓存的依赖层，只有改动 `pyproject.toml` 才会触发重新解析依赖。
+
+---
+
+## 运行单个容器
+
+镜像的 `ENTRYPOINT` 是 `mn`，所以 CLI 能做的事容器都能做：
+
+```bash
+# 启动 API 服务（默认 CMD）
+docker run --rm -p 8765:8765 \
+  -e MN_API_KEY=your-secret \
+  -v mn-output:/app/output \
+  -v mn-tasks:/app/.mn_tasks \
+  movie-narrator:local
+
+# 任意其它子命令
+docker run --rm movie-narrator:local version
+docker run --rm movie-narrator:local --help
+```
+
+> **API key 实际上是必填项。** 容器必须绑定 `0.0.0.0` 才可被访问，而 `mn serve`
+> 在无 key 的情况下会拒绝监听公网接口。请设置 `MN_API_KEY`，或追加 `--insecure`
+> 自行承担风险：
+>
+> ```bash
+> docker run --rm -p 8765:8765 movie-narrator:local \
+>   serve --host 0.0.0.0 --port 8765 --storage-dir /app/.mn_tasks --insecure
+> ```
+
+验证：
+
+```bash
+curl http://localhost:8765/health          # {"status": "ok"} —— 无需鉴权
+curl -H "X-API-Key: your-secret" http://localhost:8765/info
+```
+
+---
+
+## 本地集群
+
+```bash
+cp .env.example .env
+# 编辑 .env —— 至少设置 MN_API_KEY 以及各项 MN_LLM_* 配置
+docker compose up -d
+docker compose ps
+docker compose logs -f api
+```
+
+服务列表：
+
+| 服务 | Profile | 端口发布 | 角色 |
+|---|---|---|---|
+| `api` | 默认 | `${MN_API_PORT:-8765}` → 8765 | REST 入口，持有任务索引 |
+| `worker` | 默认 | — | 额外推理容量 |
+| `worker-gpu` | `gpu` | — | CUDA worker |
+| `minio` | `s3` | 9000、9001 | S3 兼容沙箱（实验性） |
+
+worker 会等待 api 健康检查通过（`depends_on: condition: service_healthy`）后再启动。
+
+提交任务：
+
+```bash
+docker compose exec api mn submit -m "飞驰人生" --wait
+# 或从宿主机提交
+mn submit -m "飞驰人生" --remote http://localhost:8765 --wait
+mn tasks --remote http://localhost:8765
+mn download <task-id> --remote http://localhost:8765 -o ./output
+```
+
+停止：
+
+```bash
+docker compose down            # 保留数据卷
+docker compose down -v         # 同时删除产物与任务状态
+```
+
+---
+
+## 扩缩容
+
+```bash
+docker compose up -d --scale worker=4
+# 或写入配置持久化
+echo "MN_WORKER_REPLICAS=4" >> .env && docker compose up -d
+```
+
+两个相互独立的调节项：
+
+- **`MN_WORKER_REPLICAS`** —— 运行多少个 worker *容器*。
+- **`MN_MAX_WORKERS`** —— 即 `--max-workers`，单个容器*内部*并发执行多少个任务。
+
+总并发量约为 `replicas × MN_MAX_WORKERS`。渲染对 CPU 和内存消耗很大，
+建议从 `MN_MAX_WORKERS=2` 起步，观察内存占用后再调高。
+
+在依赖 worker 副本之前，请先阅读[架构说明与限制](#架构说明与限制)——
+它们**并非** api 队列的消费者。
+
+---
+
+## GPU
+
+需要宿主机安装 NVIDIA Container Toolkit。
+
+```bash
+docker compose --profile gpu up -d
+docker compose exec worker-gpu nvidia-smi
+```
+
+compose 服务使用标准的设备预留写法，等价于 `docker run --gpus all`：
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+CUDA 镜像基于 `builder` 阶段产出的 wheel 构建，而非复制 3.12 的虚拟环境：
+CUDA 基础镜像自带 Ubuntu 的解释器，虚拟环境无法跨解释器版本复制。
+依赖会针对该解释器重新解析——`requires-python >= 3.10` 满足，
+`ml` 的 `< 3.14` 约束同样成立。
+
+没有 GPU 时，`whisperx` / `faster-whisper` 会回退到 CPU，速度慢但结果正确。
+
+---
+
+## 对象存储（实验性）
+
+```bash
+docker compose --profile s3 up -d
+# 控制台 http://localhost:9001（MINIO_ROOT_USER / MINIO_ROOT_PASSWORD）
+```
+
+> **movie-narrator 目前尚不支持 S3。** 产物仍然落在 `mn-output` 数据卷上。
+> 该服务的存在是为了给 `StorageBackend` 抽象（延后到后续 v0.8.x 补丁版本）
+> 提供一个 S3 兼容端点用于开发。正式使用前请把 `latest` 换成带日期的
+> `RELEASE.*` 标签。
+
+---
+
+## 环境变量
+
+配置由环境变量驱动，从 `.env` 读取（参见 `.env.example`）。容器不会把密钥
+烘焙进镜像层——`.env` 已被 `.dockerignore` 排除，改为运行时注入。
+
+### 容器相关
+
+| 变量 | 默认值 | 作用域 | 含义 |
+|---|---|---|---|
+| `MN_API_KEY` | *(未设置)* | 运行时 | `X-API-Key` 凭据；实际上必填 |
+| `MN_API_PORT` | `8765` | compose | `api` 在宿主机发布的端口 |
+| `MN_MAX_WORKERS` | `2` | compose | 每个容器的 `--max-workers` |
+| `MN_WORKER_REPLICAS` | `2` | compose | worker 容器数量 |
+| `MN_IMAGE_TAG` | `local` | compose | `movie-narrator:<tag>` 的标签 |
+| `MN_EXTRAS` | `media` | 构建 | CPU 镜像的附加依赖 |
+| `MN_GPU_EXTRAS` | `full` | 构建 | CUDA 镜像的附加依赖 |
+| `MINIO_ROOT_USER` | `minioadmin` | compose | 仅 `s3` profile |
+| `MINIO_ROOT_PASSWORD` | `minioadmin` | compose | 仅 `s3` profile |
+
+### 应用配置
+
+现有的全部 `MN_*` 设置（`MN_LLM_BASE_URL`、`MN_LLM_API_KEY`、`MN_LLM_MODEL`、
+`MN_DEFAULT_VOICE`、`MN_TTS_PROVIDER`、`MN_TMDB_API_KEY` 等）会从 `.env`
+直接透传。完整列表见 `.env.example`。
+
+如果 LLM 运行在宿主机上（例如 Ollama），容器内应指向 `host.docker.internal`
+而不是 `localhost`：
+
+```dotenv
+MN_LLM_BASE_URL=http://host.docker.internal:11434/v1
+```
+
+---
+
+## 数据卷与备份
+
+| 数据卷 | 挂载点 | 内容 | 是否需备份 |
+|---|---|---|---|
+| `mn-output` | `/app/output` | 渲染视频、音频、字幕、文稿 | **是** |
+| `mn-tasks` | `/app/.mn_tasks` | api 的 `tasks.json` 索引 | 是——体积小且不可重建 |
+| *(匿名卷)* | worker 的 `/app/.mn_tasks` | 各副本私有任务状态 | 否——可丢弃 |
+| `mn-minio` | `/data` | MinIO 对象（`s3` profile） | 若启用则需要 |
+
+两个 runtime 阶段都声明了 `VOLUME ["/app/output", "/app/.mn_tasks"]`，
+即使使用普通的 `docker run`，这些路径也保持可写且持久。
+
+备份：
+
+```bash
+docker run --rm -v movie-narrator_mn-output:/data:ro -v "$PWD":/backup \
+  alpine tar czf /backup/mn-output-$(date +%F).tar.gz -C /data .
+```
+
+恢复：
+
+```bash
+docker run --rm -v movie-narrator_mn-output:/data -v "$PWD":/backup \
+  alpine tar xzf /backup/mn-output-2026-01-01.tar.gz -C /data
+```
+
+> 数据卷会带上 compose 项目名前缀（`movie-narrator`，由顶层 `name:` 指定）。
+> 可用 `docker volume ls` 确认。
+
+容器以 UID/GID `10001:10001` 运行。如果把命名卷换成绑定挂载，
+请相应修改宿主机目录属主：
+
+```bash
+mkdir -p ./output && sudo chown -R 10001:10001 ./output
+```
+
+---
+
+## 架构说明与限制
+
+在扩容之前请务必阅读本节。
+
+**worker 是独立端点，而非队列消费者。**
+`LocalTaskQueue` 是进程内的 `ThreadPoolExecutor`，`TaskStorage` 把整个任务索引
+缓存在内存中，每次保存都重写 `tasks.json`。系统中不存在消息代理，也没有共享队列。
+由此带来以下后果：
+
+1. **任务状态绝不共享。** 两个进程指向同一个 `--storage-dir` 会互相覆盖索引，
+   因此 worker 副本的 `/app/.mn_tasks` 使用*私有匿名卷*。
+   只有 `api` 服务使用命名卷 `mn-tasks`。
+2. **提交到 `api` 的任务就在 `api` 上执行。** worker 不会接管。
+   要使用 worker 的算力需直接访问它们——Compose 的内部 DNS 会在副本间轮询：
+   ```bash
+   mn submit -m "..." --remote http://worker:8765
+   ```
+3. **任务 ID 在副本之间不通用。** 由于 DNS 轮询，后续的
+   `mn status <id> --remote http://worker:8765` 可能落到另一个从未见过该 ID
+   的副本上。使用 `--wait` 流程时，要么保持 `MN_WORKER_REPLICAS=1`，
+   要么通过容器名定位单个副本（`docker compose ps` → `movie-narrator-worker-2`）。
+4. **产物是共享的。** 所有服务都把 `mn-output` 挂载到 `/app/output`，
+   因此无论由哪个容器生成，渲染文件都汇集在同一处。
+
+真正的共享消息代理（Redis / Celery / SQS）属于路线图工作，不在 v0.8.4 范围内。
+
+**其它说明**
+
+- 健康检查使用 Python 标准库探测 `http://127.0.0.1:8765/health`，
+  因此镜像中不含 `curl`。若改变监听端口，需同时覆盖健康检查——
+  端口在镜像的 `HEALTHCHECK` 中是硬编码的。
+- `/health` 不受 `X-API-Key` 鉴权约束（v0.6.1），因此探针无需凭据。
+  设置 `MN_API_KEY` 后，其余所有路由均需鉴权。
+- 渲染过程中容器被强杀会丢失运行中的任务，它们会在索引里停留在 `RUNNING`
+  状态。用 `mn cleanup --all` 清理。
+
+---
+
+## 故障排查
+
+**`api` 容器立即以退出码 1 结束**
+`mn serve` 拒绝在无 API key 的情况下绑定 `0.0.0.0`。请在 `.env` 中设置
+`MN_API_KEY`，或在该服务的 `command` 中加上 `--insecure`。
+
+**`docker compose up` 在 `env_file` 处报错**
+你的 Compose 版本低于 2.24。请升级，或把长语法改为 `env_file: [.env]`
+并确保该文件存在。
+
+**worker 一直不启动**
+它们在等待 `api` 变为健康状态。检查 `docker compose ps` 与
+`docker compose logs api`。API 卡死会导致健康检查始终不通过。
+
+**提示 `ffmpeg not found`**
+说明你用的不是本镜像——两个 runtime 阶段都显式安装了 ffmpeg。
+可用 `docker compose exec api ffmpeg -version` 确认。
+
+**渲染被以退出码 137 终止**
+内存不足。调低 `MN_MAX_WORKERS`，或提高 Docker 的内存上限。
+
+**`worker-gpu` 中 `nvidia-smi` 执行失败**
+宿主机缺少 NVIDIA Container Toolkit 或未正确配置。可用
+`docker run --rm --gpus all nvidia/cuda:12.4.1-runtime-ubuntu22.04 nvidia-smi`
+验证。
+
+**绑定挂载的 `./output` 报权限拒绝**
+将其属主改为 `10001:10001`（参见[数据卷与备份](#数据卷与备份)）。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,8 +49,8 @@ The original v0.6.2–v0.6.4 plan (distributed rendering, API gateway & auth, cl
 
 **Deferred to v0.8.x point releases:**
 
-- [ ] Dockerfile — multi-stage build (builder + runtime), GPU support
-- [ ] docker-compose.yml — local cluster (API + N workers + storage)
+- [x] Dockerfile — multi-stage build (builder + runtime), GPU support (v0.8.4)
+- [x] docker-compose.yml — local cluster (API + N workers + storage) (v0.8.4)
 - [x] Storage backend abstraction — `StorageBackend` protocol (local / S3) (v0.8.3)
 - [x] Artifact lifecycle — TTL-based cleanup (v0.8.3)
 - [x] Structured logging — JSON format with correlation IDs (v0.8.1)

--- a/docs/ROADMAP.zh-CN.md
+++ b/docs/ROADMAP.zh-CN.md
@@ -49,8 +49,8 @@
 
 **推迟到 v0.8.x 点版本：**
 
-- [ ] Dockerfile — 多阶段构建（builder + runtime），支持 GPU
-- [ ] docker-compose.yml — 本地集群（API + N workers + 存储）
+- [x] Dockerfile — 多阶段构建（builder + runtime），支持 GPU（v0.8.4）
+- [x] docker-compose.yml — 本地集群（API + N workers + 存储）（v0.8.4）
 - [ ] 存储后端抽象 — `StorageBackend` 协议（local / S3）
 - [ ] 产物生命周期 — 基于 TTL 的清理
 - [x] 结构化日志 — JSON 格式，带关联 ID（v0.8.1）

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Use the navigation on the left, or start here:
 - [Architecture](ARCHITECTURE.md) — system design and component relationships
 - [Roadmap](ROADMAP.md) — version planning
 - [Contributing](CONTRIBUTING.md) — development setup and conventions
+- [Deployment](DEPLOYMENT.md) — Docker image, local cluster, GPU, volumes
 - [Packaging](PACKAGING.md) — versioning and PyPI publishing
 - [LLM Providers](LLM_PROVIDERS.md) — LLM backend setup guides
 - SDK Reference — auto-generated API documentation (Contract, Models,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - Metadata Schema: METADATA_SCHEMA.md
   - Roadmap: ROADMAP.md
   - Contributing: CONTRIBUTING.md
+  - Deployment: DEPLOYMENT.md
   - Packaging: PACKAGING.md
   - LLM Providers: LLM_PROVIDERS.md
   - AI Guide: AI_GUIDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movie-narrator"
-version = "0.8.3"
+version = "0.8.4"
 description = "Generate narrated movie recap videos from a single prompt."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -50,7 +50,7 @@ from typing import Callable, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 3)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 4)
 
 
 def check_version(required: tuple[int, int, int]) -> None:

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,8 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 8, 3) — bumped for v0.8.1 observability exports."""
-        assert CONTRACT_VERSION == (0, 8, 3)
+        """CONTRACT_VERSION is (0, 8, 4) — bumped for v0.8.1 observability exports."""
+        assert CONTRACT_VERSION == (0, 8, 4)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 3)
+        assert CONTRACT_VERSION == (0, 8, 4)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 8, 3)."""
+        """CONTRACT_VERSION is (0, 8, 4)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 3)
+        assert CONTRACT_VERSION == (0, 8, 4)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""

--- a/tests/test_v080_format_rename.py
+++ b/tests/test_v080_format_rename.py
@@ -73,5 +73,5 @@ class TestContractVersionBump:
     """Tests for CONTRACT_VERSION bump."""
 
     def test_contract_version_is_0_8_0(self):
-        """CONTRACT_VERSION is (0, 8, 3)."""
-        assert CONTRACT_VERSION == (0, 8, 3)
+        """CONTRACT_VERSION is (0, 8, 4)."""
+        assert CONTRACT_VERSION == (0, 8, 4)

--- a/tests/test_v084_container.py
+++ b/tests/test_v084_container.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Static validation for the v0.8.4 containerization artifacts.
+
+Docker is not available in CI, so these tests validate the *content* of
+``Dockerfile``, ``.dockerignore`` and ``docker-compose.yml`` rather than
+building or running anything.
+
+The highest-value assertions live in ``TestComposeMatchesCLI``: they
+import the real Typer app and check that every subcommand and every flag
+referenced from a compose ``command:`` actually resolves. That is what
+stops the compose file from silently drifting away from the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+SPDX_COPYRIGHT = "SPDX-FileCopyrightText: 2026 zcbacxc"
+SPDX_LICENSE = "SPDX-License-Identifier: AGPL-3.0-or-later"
+
+# Port the API server listens on (v0.6.1 default, see cli.serve).
+API_PORT = "8765"
+
+
+# ── Fixtures / helpers ───────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def dockerignore_text() -> str:
+    return DOCKERIGNORE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def compose() -> Dict[str, Any]:
+    with COMPOSE_FILE.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, dict), "docker-compose.yml must parse to a mapping"
+    return data
+
+
+@pytest.fixture(scope="module")
+def compose_text() -> str:
+    return COMPOSE_FILE.read_text(encoding="utf-8")
+
+
+def _dockerfile_stages(text: str) -> List[str]:
+    """Return the stage names of every ``FROM ... AS <name>`` in order."""
+    return re.findall(r"^FROM\s+\S+\s+AS\s+(\S+)", text, re.MULTILINE | re.IGNORECASE)
+
+
+def _stage_body(text: str, stage: str) -> str:
+    """Return the Dockerfile text belonging to a single build stage."""
+    stages = list(
+        re.finditer(r"^FROM\s+\S+\s+AS\s+(\S+)", text, re.MULTILINE | re.IGNORECASE)
+    )
+    for i, match in enumerate(stages):
+        if match.group(1) == stage:
+            end = stages[i + 1].start() if i + 1 < len(stages) else len(text)
+            return text[match.start():end]
+    raise AssertionError(f"stage {stage!r} not found in Dockerfile")
+
+
+def _json_arrays_for(directive: str, text: str) -> List[List[str]]:
+    """Parse every exec-form ``DIRECTIVE ["a", "b"]`` into a list."""
+    out: List[List[str]] = []
+    pattern = rf"^{directive}\s+(\[.*?\])\s*$"
+    for raw in re.findall(pattern, text, re.MULTILINE | re.DOTALL):
+        out.append(json.loads(raw))
+    return out
+
+
+def _service_command(service: Dict[str, Any]) -> List[str]:
+    """Normalize a compose ``command:`` into a token list."""
+    cmd = service.get("command")
+    if cmd is None:
+        return []
+    if isinstance(cmd, str):
+        return cmd.split()
+    return [str(token) for token in cmd]
+
+
+def _mn_services(compose: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Services built from this repo's Dockerfile (i.e. running ``mn``)."""
+    return {
+        name: svc
+        for name, svc in compose["services"].items()
+        if "build" in svc
+    }
+
+
+# ── Dockerfile ───────────────────────────────────────────────
+
+
+class TestDockerfile:
+    def test_exists(self) -> None:
+        assert DOCKERFILE.is_file(), "Dockerfile must exist at the repo root"
+
+    def test_spdx_header(self, dockerfile_text: str) -> None:
+        head = dockerfile_text[:400]
+        assert SPDX_COPYRIGHT in head
+        assert SPDX_LICENSE in head
+
+    def test_is_multi_stage(self, dockerfile_text: str) -> None:
+        stages = _dockerfile_stages(dockerfile_text)
+        assert len(stages) >= 2, f"expected a multi-stage build, got stages={stages}"
+        assert "builder" in stages
+        assert "runtime" in stages
+
+    def test_gpu_stage_exists(self, dockerfile_text: str) -> None:
+        stages = _dockerfile_stages(dockerfile_text)
+        assert "runtime-gpu" in stages, f"missing GPU target, got stages={stages}"
+
+    def test_gpu_stage_uses_cuda_base(self, dockerfile_text: str) -> None:
+        gpu = _stage_body(dockerfile_text, "runtime-gpu")
+        from_line = gpu.splitlines()[0]
+        assert "nvidia/cuda" in from_line, from_line
+        assert "runtime" in from_line, "use a CUDA *runtime* base, not devel"
+
+    def test_cpu_runtime_is_the_default_target(self, dockerfile_text: str) -> None:
+        # `docker build .` builds the LAST stage; it must be the slim CPU one.
+        stages = _dockerfile_stages(dockerfile_text)
+        assert stages[-1] == "runtime", (
+            f"last stage must be the CPU runtime so `docker build .` stays "
+            f"lightweight, got {stages[-1]!r}"
+        )
+
+    def test_python_312_base_with_rationale(self, dockerfile_text: str) -> None:
+        assert re.search(r"ARG\s+PYTHON_VERSION=3\.12", dockerfile_text), (
+            "pin the base interpreter to 3.12 (ml extras are pinned < 3.14)"
+        )
+        # The choice must be justified in a comment, not left as a magic number.
+        assert "3.14" in dockerfile_text, "explain the < 3.14 ml pin in a comment"
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_install_ffmpeg(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        assert "ffmpeg" in body, f"{stage}: moviepy/pydub shell out to ffmpeg"
+        assert "--no-install-recommends" in body, f"{stage}: keep the image slim"
+        assert "rm -rf /var/lib/apt/lists/*" in body, f"{stage}: clean the apt cache"
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_run_as_non_root(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        users = re.findall(r"^USER\s+(\S+)", body, re.MULTILINE)
+        assert users, f"{stage}: must declare a USER"
+        final_user = users[-1].split(":")[0]
+        assert final_user not in ("root", "0"), f"{stage}: must not run as root"
+        # Explicit UID/GID keeps bind-mount ownership predictable.
+        assert re.search(r"--uid\s+\d+", body), f"{stage}: pin an explicit UID"
+        assert re.search(r"--gid\s+\d+", body), f"{stage}: pin an explicit GID"
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_expose_api_port(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        assert re.search(rf"^EXPOSE\s+{API_PORT}", body, re.MULTILINE), (
+            f"{stage}: must EXPOSE {API_PORT}"
+        )
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_have_healthcheck_on_health(
+        self, dockerfile_text: str, stage: str
+    ) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        assert "HEALTHCHECK" in body, f"{stage}: must define a HEALTHCHECK"
+        healthcheck = body[body.index("HEALTHCHECK"):]
+        assert "/health" in healthcheck, f"{stage}: probe the /health endpoint"
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_set_workdir_app(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        assert re.search(r"^WORKDIR\s+/app", body, re.MULTILINE), f"{stage}: WORKDIR /app"
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_declare_volumes(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        volumes = _json_arrays_for("VOLUME", body)
+        assert volumes, f"{stage}: declare VOLUME paths for output + task state"
+        declared = set(volumes[0])
+        assert "/app/output" in declared, f"{stage}: artifacts path must be volume-able"
+        assert "/app/.mn_tasks" in declared, f"{stage}: task state must be volume-able"
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_entrypoint_is_mn(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        entrypoints = _json_arrays_for("ENTRYPOINT", body)
+        assert entrypoints == [["mn"]], (
+            f"{stage}: ENTRYPOINT must be the exec-form [\"mn\"], got {entrypoints}"
+        )
+
+    @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
+    def test_runtime_stages_have_cmd(self, dockerfile_text: str, stage: str) -> None:
+        body = _stage_body(dockerfile_text, stage)
+        cmds = _json_arrays_for("CMD", body)
+        # HEALTHCHECK also uses a CMD; the last plain CMD is the default one.
+        assert cmds, f"{stage}: must define a default CMD"
+
+    def test_no_build_toolchain_in_runtime(self, dockerfile_text: str) -> None:
+        body = _stage_body(dockerfile_text, "runtime")
+        assert "build-essential" not in body, (
+            "the build toolchain must stay in the builder stage"
+        )
+        assert "gcc" not in body
+
+    def test_builder_installs_dependencies_before_source(self, dockerfile_text: str) -> None:
+        # Layer ordering: pyproject.toml (deps) must be copied and installed
+        # before src/, otherwise every code edit re-resolves dependencies.
+        body = _stage_body(dockerfile_text, "builder")
+        pyproject_copy = body.index("COPY pyproject.toml")
+        src_copy = body.index("COPY src/")
+        assert pyproject_copy < src_copy, "copy pyproject.toml before src/ for cache reuse"
+        pip_install = body.index("pip install")
+        assert pip_install < src_copy, "install dependencies before copying sources"
+
+    def test_uses_extras_build_arg(self, dockerfile_text: str) -> None:
+        assert re.search(r"ARG\s+MN_EXTRAS=", dockerfile_text), (
+            "expose an MN_EXTRAS build arg for slim/full images"
+        )
+        assert re.search(r"ARG\s+MN_GPU_EXTRAS=", dockerfile_text)
+
+
+# ── .dockerignore ────────────────────────────────────────────
+
+
+class TestDockerignore:
+    def test_exists(self) -> None:
+        assert DOCKERIGNORE.is_file(), ".dockerignore must exist at the repo root"
+
+    def test_spdx_header(self, dockerignore_text: str) -> None:
+        head = dockerignore_text[:400]
+        assert SPDX_COPYRIGHT in head
+        assert SPDX_LICENSE in head
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            ".git",
+            "output/",
+            "__pycache__/",
+            ".venv",
+            "tests/",
+            "docs-nocommit/",
+            ".env",
+            ".mypy_cache/",
+            ".pytest_cache/",
+            "*.egg-info/",
+        ],
+    )
+    def test_covers_critical_pattern(self, dockerignore_text: str, pattern: str) -> None:
+        entries = {
+            line.strip()
+            for line in dockerignore_text.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+        assert pattern in entries, f"{pattern!r} should be excluded from the build context"
+
+    @pytest.mark.parametrize("needed", ["pyproject.toml", "README.md", "src"])
+    def test_does_not_exclude_build_inputs(self, dockerignore_text: str, needed: str) -> None:
+        entries = {
+            line.strip()
+            for line in dockerignore_text.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        }
+        # A bare `src` or `README.md` entry would break the builder stage.
+        assert needed not in entries, f"{needed!r} is required by the builder stage"
+        assert f"{needed}/" not in entries
+
+
+# ── docker-compose.yml ───────────────────────────────────────
+
+
+class TestComposeFile:
+    def test_exists(self) -> None:
+        assert COMPOSE_FILE.is_file(), "docker-compose.yml must exist at the repo root"
+
+    def test_spdx_header(self, compose_text: str) -> None:
+        head = compose_text[:400]
+        assert SPDX_COPYRIGHT in head
+        assert SPDX_LICENSE in head
+
+    def test_parses_as_yaml(self, compose: Dict[str, Any]) -> None:
+        assert "services" in compose
+        assert isinstance(compose["services"], dict)
+
+    def test_no_obsolete_version_key(self, compose: Dict[str, Any]) -> None:
+        assert "version" not in compose, (
+            "the top-level `version:` key is obsolete in the Compose Spec"
+        )
+
+    @pytest.mark.parametrize("service", ["api", "worker", "worker-gpu", "minio"])
+    def test_expected_services_present(self, compose: Dict[str, Any], service: str) -> None:
+        assert service in compose["services"], f"missing service {service!r}"
+
+    def test_api_publishes_the_api_port(self, compose: Dict[str, Any]) -> None:
+        ports = compose["services"]["api"].get("ports", [])
+        assert any(str(p).endswith(f":{API_PORT}") for p in ports), ports
+
+    def test_api_healthcheck_hits_health_endpoint(self, compose: Dict[str, Any]) -> None:
+        hc = compose["services"]["api"].get("healthcheck")
+        assert hc, "the api service needs a healthcheck"
+        assert "/health" in " ".join(str(t) for t in hc["test"])
+
+    def test_worker_waits_for_a_healthy_api(self, compose: Dict[str, Any]) -> None:
+        depends = compose["services"]["worker"].get("depends_on")
+        assert isinstance(depends, dict), "use the long depends_on syntax"
+        assert depends["api"]["condition"] == "service_healthy"
+
+    def test_worker_is_scalable(self, compose: Dict[str, Any]) -> None:
+        deploy = compose["services"]["worker"].get("deploy", {})
+        assert "replicas" in deploy, "worker must declare deploy.replicas"
+
+    def test_worker_publishes_no_host_ports(self, compose: Dict[str, Any]) -> None:
+        # Replicas would collide on a published host port.
+        assert not compose["services"]["worker"].get("ports"), (
+            "worker replicas must not publish host ports"
+        )
+
+    def test_gpu_service_is_behind_a_profile(self, compose: Dict[str, Any]) -> None:
+        assert compose["services"]["worker-gpu"]["profiles"] == ["gpu"]
+
+    def test_gpu_service_reserves_nvidia_devices(self, compose: Dict[str, Any]) -> None:
+        devices = (
+            compose["services"]["worker-gpu"]["deploy"]["resources"]
+            ["reservations"]["devices"]
+        )
+        assert devices, "declare the NVIDIA device reservation stanza"
+        device = devices[0]
+        assert device["driver"] == "nvidia"
+        assert "gpu" in device["capabilities"]
+
+    def test_gpu_service_builds_the_gpu_target(self, compose: Dict[str, Any]) -> None:
+        assert compose["services"]["worker-gpu"]["build"]["target"] == "runtime-gpu"
+
+    def test_minio_is_behind_the_s3_profile(self, compose: Dict[str, Any]) -> None:
+        assert compose["services"]["minio"]["profiles"] == ["s3"]
+
+    def test_default_profile_services_are_not_gated(self, compose: Dict[str, Any]) -> None:
+        for name in ("api", "worker"):
+            assert "profiles" not in compose["services"][name], (
+                f"{name} must start with a plain `docker compose up`"
+            )
+
+    def test_build_targets_exist_in_dockerfile(
+        self, compose: Dict[str, Any], dockerfile_text: str
+    ) -> None:
+        stages = set(_dockerfile_stages(dockerfile_text))
+        for name, svc in _mn_services(compose).items():
+            target = svc["build"]["target"]
+            assert target in stages, f"{name}: build target {target!r} not in Dockerfile"
+
+    def test_build_context_and_dockerfile_resolve(self, compose: Dict[str, Any]) -> None:
+        for name, svc in _mn_services(compose).items():
+            build = svc["build"]
+            context = REPO_ROOT / build["context"]
+            assert context.is_dir(), f"{name}: build context {context} missing"
+            assert (context / build["dockerfile"]).is_file(), (
+                f"{name}: dockerfile {build['dockerfile']} missing"
+            )
+
+    def test_image_references_are_coherent(self, compose: Dict[str, Any]) -> None:
+        for name, svc in compose["services"].items():
+            image = svc.get("image")
+            assert image, f"{name}: every service needs an image reference"
+            if "build" in svc:
+                assert image.startswith("movie-narrator:"), (
+                    f"{name}: locally built services must tag movie-narrator:*, got {image}"
+                )
+            else:
+                # Third-party images must be explicitly qualified with a tag.
+                assert ":" in image, f"{name}: pin a tag on {image}"
+
+    def test_named_volume_mounts_are_declared(self, compose: Dict[str, Any]) -> None:
+        declared = set(compose.get("volumes") or {})
+        for name, svc in compose["services"].items():
+            for mount in svc.get("volumes", []):
+                if not isinstance(mount, str) or ":" not in mount:
+                    continue  # anonymous volume, e.g. "/app/.mn_tasks"
+                source = mount.split(":")[0]
+                if source.startswith((".", "/", "~")):
+                    continue  # bind mount
+                assert source in declared, (
+                    f"{name}: named volume {source!r} is not declared under top-level volumes"
+                )
+
+    def test_task_state_is_not_shared_between_replicas(
+        self, compose: Dict[str, Any]
+    ) -> None:
+        # TaskStorage caches the whole index in memory and rewrites the file
+        # on save, so two processes sharing --storage-dir corrupt each other.
+        for name in ("worker", "worker-gpu"):
+            mounts = compose["services"][name]["volumes"]
+            assert "/app/.mn_tasks" in mounts, (
+                f"{name}: task state must use a private anonymous volume"
+            )
+            named = [m for m in mounts if isinstance(m, str) and m.endswith(":/app/.mn_tasks")]
+            assert not named, f"{name}: must not share a named task-state volume"
+
+    def test_artifacts_volume_is_shared(self, compose: Dict[str, Any]) -> None:
+        for name in ("api", "worker", "worker-gpu"):
+            mounts = compose["services"][name]["volumes"]
+            assert "mn-output:/app/output" in mounts, f"{name}: share the artifact volume"
+
+    def test_api_key_is_passed_through_not_hardcoded(
+        self, compose: Dict[str, Any], compose_text: str
+    ) -> None:
+        for name, svc in _mn_services(compose).items():
+            env = svc.get("environment", {})
+            assert "MN_API_KEY" in env, f"{name}: MN_API_KEY must be passed through"
+            assert env["MN_API_KEY"].startswith("${MN_API_KEY"), (
+                f"{name}: MN_API_KEY must come from the environment, not be hardcoded"
+            )
+        assert "your-secret-api-key" not in compose_text
+
+    def test_env_comes_from_env_file(self, compose: Dict[str, Any]) -> None:
+        for name, svc in _mn_services(compose).items():
+            env_file = svc.get("env_file")
+            assert env_file, f"{name}: wire configuration from .env"
+            paths = [
+                entry["path"] if isinstance(entry, dict) else entry
+                for entry in env_file
+            ]
+            assert ".env" in paths, f"{name}: expected .env in env_file, got {paths}"
+
+    def test_referenced_env_keys_documented_in_env_example(self, compose_text: str) -> None:
+        referenced = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", compose_text))
+        assert referenced, "expected the compose file to use env substitution"
+        env_example = ENV_EXAMPLE.read_text(encoding="utf-8")
+        documented = set(
+            re.findall(r"^#?\s*([A-Z][A-Z0-9_]*)=", env_example, re.MULTILINE)
+        )
+        missing = sorted(referenced - documented)
+        assert not missing, f"undocumented env keys in .env.example: {missing}"
+
+
+# ── The important one: compose must match the real CLI ───────
+
+
+class TestComposeMatchesCLI:
+    """Guards against the compose file drifting away from the Typer app."""
+
+    @staticmethod
+    def _cli_group():
+        import typer.main
+
+        from movie_narrator.cli import app
+
+        return typer.main.get_command(app)
+
+    def test_cli_app_exposes_serve(self) -> None:
+        group = self._cli_group()
+        assert "serve" in group.commands, (
+            "mn serve is the command the containers run; it must exist"
+        )
+
+    def test_every_compose_command_exists_in_the_cli(
+        self, compose: Dict[str, Any]
+    ) -> None:
+        group = self._cli_group()
+        available = set(group.commands)
+        checked = 0
+        for name, svc in _mn_services(compose).items():
+            tokens = _service_command(svc)
+            assert tokens, f"{name}: expected an explicit command"
+            subcommand = tokens[0]
+            assert subcommand in available, (
+                f"{name}: compose runs `mn {subcommand}` but the Typer app only "
+                f"provides {sorted(available)}"
+            )
+            checked += 1
+        assert checked >= 3, "expected api + worker + worker-gpu to be checked"
+
+    def test_every_compose_flag_exists_on_its_command(
+        self, compose: Dict[str, Any]
+    ) -> None:
+        group = self._cli_group()
+        for name, svc in _mn_services(compose).items():
+            tokens = _service_command(svc)
+            command = group.commands.get(tokens[0])
+            if command is None:
+                continue  # unknown subcommand — reported by the test above
+            valid = {opt for param in command.params for opt in param.opts}
+            for token in tokens[1:]:
+                if not token.startswith("--"):
+                    continue
+                assert token in valid, (
+                    f"{name}: `mn {tokens[0]} {token}` is not a valid flag; "
+                    f"available: {sorted(valid)}"
+                )
+
+    def test_dockerfile_cmd_uses_a_real_command(self, dockerfile_text: str) -> None:
+        group = self._cli_group()
+        available = set(group.commands)
+        for stage in ("runtime", "runtime-gpu"):
+            body = _stage_body(dockerfile_text, stage)
+            # The last exec-form CMD is the image default (the earlier one
+            # belongs to HEALTHCHECK).
+            default_cmd = _json_arrays_for("CMD", body)[-1]
+            assert default_cmd[0] in available, (
+                f"{stage}: default CMD runs `mn {default_cmd[0]}`, which does not exist"
+            )
+
+    def test_dockerfile_cmd_flags_exist(self, dockerfile_text: str) -> None:
+        group = self._cli_group()
+        for stage in ("runtime", "runtime-gpu"):
+            body = _stage_body(dockerfile_text, stage)
+            default_cmd = _json_arrays_for("CMD", body)[-1]
+            command = group.commands[default_cmd[0]]
+            valid = {opt for param in command.params for opt in param.opts}
+            for token in default_cmd[1:]:
+                if token.startswith("--"):
+                    assert token in valid, f"{stage}: unknown flag {token}"
+
+    def test_storage_dir_flag_matches_the_declared_volume(
+        self, compose: Dict[str, Any], dockerfile_text: str
+    ) -> None:
+        # The --storage-dir value must be one of the VOLUME paths, otherwise
+        # task state silently lives in the container's writable layer.
+        volumes = set(_json_arrays_for("VOLUME", _stage_body(dockerfile_text, "runtime"))[0])
+        for name, svc in _mn_services(compose).items():
+            tokens = _service_command(svc)
+            if "--storage-dir" not in tokens:
+                continue
+            value = tokens[tokens.index("--storage-dir") + 1]
+            assert value in volumes, (
+                f"{name}: --storage-dir {value} is not a declared VOLUME {sorted(volumes)}"
+            )


### PR DESCRIPTION
## v0.8.4 — Containerization

### Added
- **Dockerfile** — multi-stage build (builder → runtime), python:3.12-slim. Runtime installs ffmpeg, runs as non-root `app` user (UID/GID 10001), volumes for /app/output and /app/.mn_tasks, exposes 8765, HEALTHCHECK against /health, ENTRYPOINT `mn`.
- **GPU image** — `runtime-gpu` target on nvidia/cuda:12.4.1-runtime-ubuntu22.04 (for `docker run --gpus all` / compose `gpu` profile). CPU image stays the default target.
- **Build args** — `MN_EXTRAS` / `MN_GPU_EXTRAS` / `PYTHON_VERSION` select the optional-dependency set at build time.
- **.dockerignore** — trims build context, keeps `.env` out of image layers.
- **docker-compose.yml** — api service (publishes 8765, health-gated), scalable worker service, `gpu` profile (NVIDIA device reservation), `s3` profile (MinIO, paired with the v0.8.3 StorageBackend). Named volumes for storage; no invented DB/broker.
- **docs/DEPLOYMENT.md + .zh-CN.md** — bilingual deployment guide (build, run, scale, GPU, env vars, volumes, backup).
- **tests/test_v084_container.py** — 74 static validation tests incl. CLI-command resolution check against the real Typer app.

### Changed
- `CONTRACT_VERSION` → (0, 8, 4); package version 0.8.4.

### Verification
- Local full suite after merge: 1900 passed / 0 failed / 5 skipped.