### PR TITLE
fix: revert CONTRACT_VERSION to (0,8,3); correct stale MinIO comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,10 +179,15 @@ services:
     restart: unless-stopped
 
   # ── MinIO (profile: s3) — EXPERIMENTAL ─────────────────────
-  # movie-narrator does NOT speak S3 yet; artifacts still land on the
-  # mn-output volume. This service exists so the storage-backend work
-  # (`StorageBackend` protocol, deferred to a later v0.8.x point
-  # release) has an S3-compatible endpoint to develop against.
+  # The v0.8.3 `StorageBackend` (S3ArtifactStore) can target this
+  # endpoint. To route artifacts to MinIO instead of the mn-output
+  # volume, set on the api (and worker, if sharing a store):
+  #   MN_STORAGE_BACKEND=s3
+  #   MN_S3_BUCKET=<bucket>            # create it first: mc mb
+  #   MN_S3_ENDPOINT_URL=http://minio:9000
+  #   MN_S3_REGION=us-east-1
+  # The compose environment intentionally leaves these unset so the
+  # default local backend keeps working out of the box.
   minio:
     profiles:
       - s3

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -50,7 +50,7 @@ from typing import Callable, Optional, Protocol, runtime_checkable
 #   MAJOR — breaking changes to exported symbols or signatures
 #   MINOR — new exports added (backward compatible)
 #   PATCH — bug fixes, doc changes (no API surface change)
-CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 4)
+CONTRACT_VERSION: tuple[int, int, int] = (0, 8, 3)
 
 
 def check_version(required: tuple[int, int, int]) -> None:

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -210,8 +210,12 @@ class TestContractVersion:
     """CONTRACT_VERSION is the stable API boundary for external consumers."""
 
     def test_contract_version_value(self):
-        """CONTRACT_VERSION is (0, 8, 4) — bumped for v0.8.1 observability exports."""
-        assert CONTRACT_VERSION == (0, 8, 4)
+        """CONTRACT_VERSION is (0, 8, 3) — last release with new exports (v0.8.3).
+
+        v0.8.4 (containerization) added no contract exports, so the version
+        was reverted to (0, 8, 3) per the semver policy in contract.py.
+        """
+        assert CONTRACT_VERSION == (0, 8, 3)
 
     def test_contract_version_is_tuple(self):
         """CONTRACT_VERSION is a 3-tuple of ints (semver)."""

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -918,7 +918,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 4)
+        assert CONTRACT_VERSION == (0, 8, 3)
 
     def test_contract_exports_cloud_types(self):
         from movie_narrator.contract import (

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -550,9 +550,9 @@ class TestContractExports:
     """Verify v0.6.1 types are exported from contract."""
 
     def test_contract_version_bumped(self):
-        """CONTRACT_VERSION is (0, 8, 4)."""
+        """CONTRACT_VERSION is (0, 8, 3)."""
         from movie_narrator.contract import CONTRACT_VERSION
-        assert CONTRACT_VERSION == (0, 8, 4)
+        assert CONTRACT_VERSION == (0, 8, 3)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""

--- a/tests/test_v080_format_rename.py
+++ b/tests/test_v080_format_rename.py
@@ -73,5 +73,5 @@ class TestContractVersionBump:
     """Tests for CONTRACT_VERSION bump."""
 
     def test_contract_version_is_0_8_0(self):
-        """CONTRACT_VERSION is (0, 8, 4)."""
-        assert CONTRACT_VERSION == (0, 8, 4)
+        """CONTRACT_VERSION is (0, 8, 3)."""
+        assert CONTRACT_VERSION == (0, 8, 3)


### PR DESCRIPTION
## Fixes found in the v0.8.x code review

### 1. CONTRACT_VERSION reverted to (0, 8, 3)
v0.8.4 (containerization: Dockerfile + compose) added **no contract exports** — its only `contract.py` change was the version value itself. Per the semver policy documented in `contract.py` (`MAJOR=breaking / MINOR=new exports / PATCH=no API change`) and the project rule "API 面未变不升", the bump to (0, 8, 4) was wrong. Reverted to (0, 8, 3); the four `CONTRACT_VERSION` test assertions synced.

### 2. docker-compose.yml stale MinIO comment corrected
The v0.8.4 compose file claimed "movie-narrator does NOT speak S3 yet" and that the `StorageBackend` protocol was "deferred to a later v0.8.x point release" — both false, since v0.8.3 shipped `S3ArtifactStore`. Rewrote the comment to document how to point the v0.8.3 backend at MinIO (`MN_STORAGE_BACKEND=s3`, `MN_S3_ENDPOINT_URL=http://minio:9000`), and note that compose intentionally leaves S3 env unset so the local backend stays the default.

### Verification
- Targeted tests: 273 passed (contract + v060 + v061 + v080 + v084).
