### PR TITLE
fix(v0.7): TTS cache-cost accuracy, real ambient ducking, remove legacy tracking codes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # MN_MIMO_STYLE_PROMPT=            # style description, mimo-v2.5-tts only
 
 # ============================================================
-# VLM — visual scene captioning (Q-M5, optional)
+# VLM — visual scene captioning (optional)
 # ============================================================
 # Enable real visual descriptions via cloud VLM API.
 # Set vision_captioner: vlm in job.yaml params to activate.
@@ -70,7 +70,7 @@ MN_DEFAULT_VOICE=zh-CN-YunxiNeural
 # MN_VLM_LANGUAGE=en               # Caption language (en or zh)
 
 # ============================================================
-# TMDB — external movie database for fact verification (NA-M2-S1+, optional)
+# TMDB — external movie database for fact verification (optional)
 # ============================================================
 # When configured, TMDB cross-checks LLM-generated movie cards against
 # real data (director, cast, year, genres) to reduce hallucination.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ run_qa_gate → render_video → validate_deliverable → export_clips
 | align_audio | soft | WhisperX word-level alignment; fallback to segment-level via faster-whisper | word timestamps |
 | detect_scenes | soft | PySceneDetect splits source video into `Scene` list | scene list |
 | match_clips | soft | Map scenes to script segments: embedding re-rank (when `[ml]` installed) or proportional heuristic; falls back on probe/model failure | `matches.json` |
-| mix_bgm | soft | Mix background music under narration; EP6 duck curve scales depth with narration energy | `mixed.mp3` |
+| mix_bgm | soft | Mix background music under narration; the duck curve scales depth with narration energy | `mixed.mp3` |
 | translate_subtitles | soft | Per-chunk translation via configured provider (default `llm`); retry-then-soft-degrade policy; CI passthrough | `ctx.translated_texts` |
 | generate_subtitle | hard | Format SRT from timed segments; bilingual support (`subtitle.<lang>.srt`, `subtitle.bilingual.srt`) | `subtitle.srt` + variants |
 | run_qa_gate | soft | Quality validation gate | QA report |
@@ -341,7 +341,7 @@ class MyPlugin:
 
 Plugins are discovered via `importlib.metadata` entry points under the `movie_narrator.plugins` group. See `examples/plugins/watermark/` for a complete reference implementation.
 
-## Pipeline Pause/Resume (EP9, v0.4.26+)
+## Pipeline Pause/Resume (v0.4.26+)
 
 The pipeline supports human-in-the-loop pause points via `PipelinePaused` exception and state serialization:
 
@@ -365,7 +365,7 @@ run_pipeline(ctx, start_step="align_audio")  # skips completed steps
 
 **Pause points**: `--pause-at script` (after script generation) or `--pause-at match` (after scene matching). User can edit `script.md` or `matches.json` before resuming.
 
-## Scene Filtering (WP6, v0.5+)
+## Scene Filtering (v0.5+)
 
 The `pipeline/scene_filter.py` module provides three scene-filtering features that improve narration quality by removing non-content segments and biasing selection toward highlights:
 

--- a/docs/ARCHITECTURE.zh-CN.md
+++ b/docs/ARCHITECTURE.zh-CN.md
@@ -78,7 +78,7 @@ run_qa_gate → render_video → validate_deliverable → export_clips
 | align_audio | 软 | WhisperX 词级对齐；失败时回退到 faster-whisper 段级 | 词级时间戳 |
 | detect_scenes | 软 | PySceneDetect 将源视频切分为 `Scene` 列表 | 场景列表 |
 | match_clips | 软 | 将场景映射到台词段：embedding 重排（`[ml]` 已安装时）或比例启发式；探测/模型失败时回退 | `matches.json` |
-| mix_bgm | 软 | 为旁白叠加背景音乐；EP6 duck 曲线随旁白能量缩放深度 | `mixed.mp3` |
+| mix_bgm | 软 | 为旁白叠加背景音乐；duck 曲线随旁白能量缩放深度 | `mixed.mp3` |
 | translate_subtitles | 软 | 按配置的 provider 分段翻译（默认 `llm`）；重试后软降级；CI 直通 | `ctx.translated_texts` |
 | generate_subtitle | 硬 | 从 timed_segments 格式化 SRT；双语支持（`subtitle.<lang>.srt`、`subtitle.bilingual.srt`） | `subtitle.srt` 及变体 |
 | run_qa_gate | 软 | 质量校验门 | QA 报告 |
@@ -335,7 +335,7 @@ class MyPlugin:
 
 插件通过 `importlib.metadata` entry points 的 `movie_narrator.plugins` 组自动发现。完整参考实现见 `examples/plugins/watermark/`。
 
-## 流水线暂停/恢复（EP9，v0.4.26+）
+## 流水线暂停/恢复（v0.4.26+）
 
 流水线通过 `PipelinePaused` 异常和状态序列化支持人工暂停点：
 
@@ -359,7 +359,7 @@ run_pipeline(ctx, start_step="align_audio")  # 跳过已完成步骤
 
 **暂停点**：`--pause-at script`（脚本生成后）或 `--pause-at match`（场景匹配后）。用户可在恢复前编辑 `script.md` 或 `matches.json`。
 
-## 场景过滤（WP6，v0.5+）
+## 场景过滤（v0.5+）
 
 `pipeline/scene_filter.py` 模块提供三个场景过滤功能，通过移除非内容片段和偏向高亮区域来提升解说质量：
 

--- a/docs/METADATA_SCHEMA.md
+++ b/docs/METADATA_SCHEMA.md
@@ -64,9 +64,9 @@ Records the match-quality breakdown for manual QA verification and downstream co
 | `captioning` | object | WhisperX captioning status (`used`, `usable_label_ratio`, `cached`, `language`, `model`) |
 | `embedding_model` | str | Embedding model name used |
 | `degraded_reason` | str\|null | `"fake_captions"` / `"all_heuristic"` / null |
-| `diversity` | object | WP3 diversity post-processing audit (`swaps`, `swaps_log`, `window`, `max_reuse`) |
-| `timeline` | object | EP1/EP2 timeline audit (`mode`, `act_weights`, `segments_per_act`, `anchored_count`) |
-| `topk` | object | EP3 top-K rerank audit (`k`, `reuse_penalty`, `topk_count`, `top1_count`) |
+| `diversity` | object | Diversity post-processing audit (`swaps`, `swaps_log`, `window`, `max_reuse`) |
+| `timeline` | object | Timeline audit (`mode`, `act_weights`, `segments_per_act`, `anchored_count`) |
+| `topk` | object | Top-K rerank audit (`k`, `reuse_penalty`, `topk_count`, `top1_count`) |
 
 **Back-compat fields** (legacy consumers): `total` = `segments`, `embedding` = `source_counts.embedding`, `heuristic` = `source_counts.heuristic`, `captions_fake` = (`degraded_reason == "fake_captions"`).
 
@@ -170,7 +170,7 @@ Per-beat metadata from structured LLM output. Absent when two-phase script gener
 | `act` | int | Act number (1–4) |
 | `approx_ratio` | float | Time anchor ratio (0–1) for time-anchored scene search |
 
-**EP2 beat anchor priority**: when beat metadata is available, the heuristic baseline uses `approx_ratio` as the primary time anchor. Priority chain: EP2 beat anchor > EP1 weighted acts > uniform proportional mapping.
+**Beat anchor priority**: when beat metadata is available, the heuristic baseline uses `approx_ratio` as the primary time anchor. Priority chain: beat anchor > weighted-act timeline > uniform proportional mapping.
 
 ---
 

--- a/docs/METADATA_SCHEMA.zh-CN.md
+++ b/docs/METADATA_SCHEMA.zh-CN.md
@@ -64,9 +64,9 @@
 | `captioning` | object | WhisperX 字幕状态（`used`、`usable_label_ratio`、`cached`、`language`、`model`） |
 | `embedding_model` | str | 使用的嵌入模型名称 |
 | `degraded_reason` | str\|null | `"fake_captions"` / `"all_heuristic"` / null |
-| `diversity` | object | WP3 多样性后处理审计（`swaps`、`swaps_log`、`window`、`max_reuse`） |
-| `timeline` | object | EP1/EP2 时间线审计（`mode`、`act_weights`、`segments_per_act`、`anchored_count`） |
-| `topk` | object | EP3 top-K 重排审计（`k`、`reuse_penalty`、`topk_count`、`top1_count`） |
+| `diversity` | object | 多样性后处理审计（`swaps`、`swaps_log`、`window`、`max_reuse`） |
+| `timeline` | object | 时间线审计（`mode`、`act_weights`、`segments_per_act`、`anchored_count`） |
+| `topk` | object | top-K 重排审计（`k`、`reuse_penalty`、`topk_count`、`top1_count`） |
 
 **向后兼容字段**（旧版消费者）：`total` = `segments`，`embedding` = `source_counts.embedding`，`heuristic` = `source_counts.heuristic`，`captions_fake` =（`degraded_reason == "fake_captions"`）。
 
@@ -170,7 +170,7 @@
 | `act` | int | 幕号（1–4） |
 | `approx_ratio` | float | 用于时间锚定场景搜索的时间锚点比率（0–1） |
 
-**EP2 拍锚点优先级**：当拍元数据可用时，启发式基线使用 `approx_ratio` 作为主要时间锚点。优先级链：EP2 拍锚点 > EP1 加权幕 > 均匀比例映射。
+**拍锚点优先级**：当拍元数据可用时，启发式基线使用 `approx_ratio` 作为主要时间锚点。优先级链：拍锚点 > 加权幕 > 均匀比例映射。
 
 ---
 

--- a/examples/cli-usage.sh
+++ b/examples/cli-usage.sh
@@ -81,7 +81,7 @@ mn preset
 mn preset mainstream-dry
 
 # ============================================================
-# 多候选赛马 (Q-P2)
+# 多候选赛马 (multi-candidate race)
 # ============================================================
 
 # 同输入跑 3 套变体，打分排名
@@ -91,7 +91,7 @@ mn race --movie "飞驰人生" --video movie.mp4 --candidates 3
 mn race --movie "飞驰人生" --video movie.mp4 --presets douyin-fast,mainstream-dry,bilibili-long --auto-pick
 
 # ============================================================
-# 参考片模仿 (Q-P7)
+# 参考片模仿 (reference imitation)
 # ============================================================
 
 # 分析爆款解说并生成同风格新片
@@ -109,7 +109,7 @@ mn imitate --reference viral_ref.mp4 --analyze-only
 # Then run: mn-web
 
 # ============================================================
-# 解说视角 (NA-M1-S4)
+# 解说视角 (narrator perspective)
 # ============================================================
 
 # 全知视角（默认，中性鸟瞰）
@@ -212,7 +212,7 @@ mn download <task_id> -r http://worker:8765 -f final.mp4
 mn download <task_id> -r http://worker:8765 -o ./output
 
 # ============================================================
-# 管线恢复 (EP9)
+# 管线恢复 (resume)
 # ============================================================
 
 # 从暂停点恢复管线

--- a/examples/job.example.yaml
+++ b/examples/job.example.yaml
@@ -120,8 +120,8 @@ params:
   # match_max_scene_reuse: 2        # 窗口内同一场景最大允许出现次数（超过则换景）
   # match_timeline_mode: uniform    # uniform（默认，全片比例映射）| weighted_acts（四幕时间桶，高光集中在高潮幕）
   # match_act_weights: [0.15, 0.25, 0.40, 0.20]  # 四幕时间占比（开/中/高潮/尾），仅 weighted_acts 模式生效
-  # match_topk: 5                    # EP3: 每句取 top-K 候选场景，贪心分配时避免近期已用场景（默认 5，0/1 = 禁用退回 top-1）
-  # match_topk_reuse_penalty: 0.15   # EP3: 近期已用场景的分数扣减值（默认 0.15，越大越倾向换景）
+  # match_topk: 5                    # 每句取 top-K 候选场景，贪心分配时避免近期已用场景（默认 5，0/1 = 禁用退回 top-1）
+  # match_topk_reuse_penalty: 0.15   # 近期已用场景的分数扣减值（默认 0.15，越大越倾向换景）
 
   # ---- BGM / 音频 ----
   # bgm_gain_db: -18          # BGM 基础增益（dB）
@@ -145,7 +145,7 @@ params:
   # ---- 调研 ----
   research_provider: llm    # 调研后端（目前仅支持 llm）
 
-  # ---- 视觉描述（Q-M5）----
+  # ---- 视觉描述（VLM 字幕）----
   # vision_captioner: vlm    # none（默认）| stub（占位标签）| vlm（云端 VLM API，需配置 MN_VLM_* 环境变量）
   # vlm provider 会从每个场景中点提取关键帧，发送给 OpenAI 兼容的视觉 API（GPT-4o/Qwen-VL 等）
   # 返回真实视觉描述，解锁 match.py 中的 embedding re-rank 功能
@@ -176,7 +176,7 @@ params:
   # render_require_footage: false    # true=覆盖率低于阈值时 warn + 标记 _degraded_steps
   # render_min_footage_coverage: 0.5 # footage 覆盖率阈值（0-1）
   # render_profile: publish          # publish（默认，crf=18/preset=slow）| draft（crf=28/preset=ultrafast，快速迭代）
-  # ---- EP5: 包装三件套（v0.4.26+，由 preset 自动注入）----
+  # ---- 包装三件套（v0.4.26+，由 preset 自动注入）----
   # render_title_card_sec: 1.0        # 片头标题卡时长（秒，0=禁用）；douyin-fast=1.0, bilibili-long=1.2
   # render_cover_export: true         # 导出 cover.jpg（取最高分镜头中点帧 + 电影名叠加）；失败不影响管线
   # render_vertical_safe_area: true   # 9:16 竖屏时自动收紧字幕安全区（bottom_margin≥0.15, max_width≤0.82）

--- a/scripts/compare_runs.py
+++ b/scripts/compare_runs.py
@@ -8,8 +8,8 @@ Usage:
         --output comparison_report.md
 
 Focus areas:
-    --focus beat_anchor   Compare EP2 beat anchor fields + src_mid distribution
-    --focus duck_curve    Compare EP6 duck curve / loudness fields
+    --focus beat_anchor   Compare beat-anchor fields + src_mid distribution
+    --focus duck_curve    Compare duck-curve / loudness fields
     --focus all           Compare everything (default)
 """
 
@@ -74,9 +74,9 @@ def compare_field(
 
 
 def compare_beat_anchor(baseline: dict, new: dict) -> str:
-    """Compare EP2 beat anchor fields."""
+    """Compare beat-anchor fields."""
     lines = [
-        "## EP2 — Beat Time Anchor\n",
+        "## Beat Time Anchor\n",
         "| Field | Baseline | New | Delta |",
         "|-------|----------|-----|-------|",
     ]
@@ -141,17 +141,17 @@ def compare_beat_anchor(baseline: dict, new: dict) -> str:
                 )
 
             # Uniformity check: if baseline is roughly linear (R² > 0.95)
-            # and new deviates, EP2 is working
+            # and new deviates, beat anchoring is working
             lines.append("\n**判读**: 若基线 src_mid 分位接近线性（0→1 均匀），"
-                        "而新版偏离线性（集中在高光区），则 EP2 beat anchor 生效。")
+                        "而新版偏离线性（集中在高光区），则 beat anchor 生效。")
 
     return "\n".join(lines)
 
 
 def compare_duck_curve(baseline: dict, new: dict) -> str:
-    """Compare EP6 duck curve / loudness fields."""
+    """Compare duck-curve / loudness fields."""
     lines = [
-        "## EP6 — Duck Curve + Loudnorm\n",
+        "## Duck Curve + Loudnorm\n",
         "| Field | Baseline | New | Delta |",
         "|-------|----------|-----|-------|",
     ]
@@ -298,9 +298,9 @@ def compare_basic(baseline: dict, new: dict) -> str:
 
 
 def compare_ep_params(baseline: dict, new: dict) -> str:
-    """Compare EP-specific params."""
+    """Compare pipeline-feature params."""
     lines = [
-        "## EP 参数对比\n",
+        "## 特性参数对比\n",
         "| Param | Baseline | New | Delta |",
         "|-------|----------|-----|-------|",
     ]
@@ -386,37 +386,37 @@ def generate_report(
 
     verdicts = []
 
-    # Check EP2
+    # Check beat anchor
     beat_anchor_n = safe_get(new, "match_summary", "beat_anchor")
     if beat_anchor_n is True:
-        verdicts.append("✅ EP2: beat_anchor=true — beat 时间锚已激活")
+        verdicts.append("✅ beat anchor: beat_anchor=true — beat 时间锚已激活")
     elif beat_anchor_n is False:
-        verdicts.append("⚠️ EP2: beat_anchor=false — LLM 未返回 approx_ratio，"
+        verdicts.append("⚠️ beat anchor: beat_anchor=false — LLM 未返回 approx_ratio，"
                        "回退到 timeline_mode")
     else:
-        verdicts.append("— EP2: beat_anchor 字段不存在（版本 < v0.4.26?）")
+        verdicts.append("— beat anchor: beat_anchor 字段不存在（版本 < v0.4.26?）")
 
-    # Check EP4
+    # Check hook templates
     hook_n = new.get("hook_templates")
     if hook_n and len(hook_n) > 0:
-        verdicts.append(f"✅ EP4: hook_templates 配置了 {len(hook_n)} 条模板")
+        verdicts.append(f"✅ hook templates: hook_templates 配置了 {len(hook_n)} 条模板")
     else:
-        verdicts.append("— EP4: hook_templates 未配置或为空")
+        verdicts.append("— hook templates: hook_templates 未配置或为空")
 
-    # Check EP5
+    # Check title card
     title_card_n = new.get("render_title_card_sec")
     if title_card_n and title_card_n > 0:
-        verdicts.append(f"✅ EP5: render_title_card_sec={title_card_n}s — "
+        verdicts.append(f"✅ title card: render_title_card_sec={title_card_n}s — "
                        "标题卡已启用")
     else:
-        verdicts.append("— EP5: render_title_card_sec=0 — 标题卡未启用")
+        verdicts.append("— title card: render_title_card_sec=0 — 标题卡未启用")
 
-    # Check EP6
+    # Check loudness normalization
     loudnorm_n = new.get("bgm_loudnorm")
     if loudnorm_n is True:
-        verdicts.append("✅ EP6: bgm_loudnorm=true — RMS 响度归一化已启用")
+        verdicts.append("✅ loudness normalization: bgm_loudnorm=true — RMS 响度归一化已启用")
     else:
-        verdicts.append("— EP6: bgm_loudnorm=false — 使用峰值归一化")
+        verdicts.append("— loudness normalization: bgm_loudnorm=false — 使用峰值归一化")
 
     for v in verdicts:
         lines.append(f"- {v}")

--- a/src/movie_narrator/pipeline/bgm.py
+++ b/src/movie_narrator/pipeline/bgm.py
@@ -407,9 +407,9 @@ def _mix_ambient_track(
 ) -> tuple[AudioSegment, dict]:
     """Mix an ambient/SFX track beneath the narration+BGM audio.
 
-    v0.7.1: Loads the ambient track, loops/trims it to match the
-    narration duration, applies gain reduction, and overlays it
-    with ducking during active narration segments.
+    v0.7.1: Loads the ambient track, applies gain reduction, and ducks it
+    under the narration in real time via :func:`duck_bgm`, so the ambient
+    sits lower while narration is active and swells back up in the pauses.
 
     Returns ``(mixed_audio, ambient_info_dict)``. On any error,
     returns the original audio unchanged with an empty info dict.
@@ -421,30 +421,22 @@ def _mix_ambient_track(
         logger.debug("ambient track load failed", exc_info=True)
         return narration_or_mixed, {"error": f"ambient load failed: {e}"}
 
-    target_ms = len(narration_or_mixed)
-    ambient_ms = len(ambient)
-
-    # Loop ambient track to match target duration
-    if ambient_ms < target_ms:
-        loops = int(target_ms / ambient_ms) + 1
-        ambient = ambient * loops
-    ambient = ambient[:target_ms]
-
-    # Apply gain reduction
-    ambient = ambient.apply_gain(ambient_gain_db)
-
-    # Simple ducking: reduce ambient volume further during narration
-    # We use a moderate fixed duck since per-segment ducking is already
-    # applied to BGM — the ambient sits even lower in the mix.
-    ambient = ambient.apply_gain(duck_db)
-
-    mixed = narration_or_mixed.overlay(ambient)
+    # duck_bgm handles loop/trim to narration length, per-window dynamic
+    # ducking (attack/release smoothed) and the overlay. ``timed_segments``
+    # is accepted for API compatibility; ducking is driven by the actual
+    # narration audio energy, which is more accurate than segment bounds.
+    mixed = duck_bgm(
+        narration_or_mixed,
+        ambient,
+        bgm_gain_db=ambient_gain_db,
+        duck_db=duck_db,
+    )
 
     info = {
         "path": str(ambient_path),
         "gain_db": ambient_gain_db,
         "duck_db": duck_db,
-        "duration_sec": round(target_ms / 1000.0, 2),
+        "duration_sec": round(len(narration_or_mixed) / 1000.0, 2),
     }
     return mixed, info
 

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -225,7 +225,7 @@ def build_context(
     subtitle_mode: Optional[str] = None,
     services: Optional[Services] = None,
     narration_preset: Optional[str] = None,
-    lang: str = "zh",  # R2-NA-LANG: narration language
+    lang: str = "zh",  # narration language
     log_level: int = logging.DEBUG,
     verbose: bool = False,
     json_format: bool = False,
@@ -297,7 +297,7 @@ def build_context(
             "translate_provider": (params or {}).get("translate_provider", "llm"),
             "translate_retries": (params or {}).get("translate_retries", 3),
             "research_provider": (params or {}).get("research_provider", "llm"),
-            # R2-NA-LANG: single source of truth for narration language.
+            # Single source of truth for narration language.
             "lang": lang,
             # v0.7.2: preview mode — render only the first N seconds for quick
             # iteration.  OFF by default (backward compatible).  These keys are
@@ -308,7 +308,7 @@ def build_context(
         }
     )
 
-    # R2-NA-LANG: consistency check — warn if subtitle target language
+    # Narration-language consistency check — warn if subtitle target language
     # matches narration language (translation would be a no-op).
     if subtitle_lang and subtitle_lang.lower() == lang.lower():
         services.console.inline_warn(
@@ -339,7 +339,7 @@ def build_context(
             if key in effective_params and effective_params[key] is not None:
                 ctx.metadata[key] = effective_params[key]
 
-    # ── WP7: Draft profile — fast iteration override ──
+    # ── Draft profile — fast iteration override ──
     # When render_profile=draft, override render params for speed.
     # User-supplied params (via job.yaml or preset) always take precedence
     # over draft defaults — draft only fills gaps.
@@ -366,7 +366,7 @@ def build_context(
 
 
 def _save_pipeline_state(ctx: Context, completed_step: str) -> Path:
-    """Serialize pipeline state for resume (EP9).
+    """Serialize pipeline state for resume.
 
     Writes ``pipeline_state.json`` to ``ctx.output_dir``. Excludes the
     non-serializable ``services`` field — the ``Context`` model_validator
@@ -388,7 +388,7 @@ def _save_pipeline_state(ctx: Context, completed_step: str) -> Path:
 
 
 def _load_pipeline_state(state_path: Path) -> tuple[Context, str]:
-    """Load pipeline state from a file (EP9).
+    """Load pipeline state from a file.
 
     Returns ``(context, completed_step)``. The context's ``services``
     field is auto-filled with ``SilentConsole`` by the model_validator —
@@ -421,7 +421,7 @@ def run_pipeline(
     passes a ``GradioController`` so the user can request a cooperative
     cancel at step boundaries.
 
-    ``start_step`` (EP9): when set, skip all steps before this step name.
+    ``start_step``: when set, skip all steps before this step name.
     Used by ``mn resume`` to avoid re-running already-completed steps.
 
     ``PipelineCancelled`` raises before ``_check_strict``, so ``--strict``
@@ -429,7 +429,7 @@ def run_pipeline(
     it is NOT a soft-step warning and does NOT set status fields to
     ``failed``.
 
-    ``PipelinePaused`` (EP9) raises after a step completes when
+    ``PipelinePaused`` raises after a step completes when
     ``ctx.metadata["pause_at"]`` matches the step name. The pipeline
     state is serialized before raising so ``mn resume`` can continue.
     """
@@ -452,13 +452,13 @@ def run_pipeline(
 
     total_start = time.time()
 
-    # EP9: When resuming, skip steps before start_step
+    # When resuming, skip steps before start_step
     _resume_started = start_step is None
 
     for step in STEPS:
         name = step.__name__
 
-        # EP9: Skip already-completed steps when resuming
+        # Skip already-completed steps when resuming
         if not _resume_started:
             if name == start_step:
                 _resume_started = True
@@ -470,7 +470,7 @@ def run_pipeline(
         # ── Pre-check: workflow_steps disabled? ──────────────
         # Authoritative path: runner short-circuits before step runs.
         # Checks both the function-name key and any short alias (spec §9).
-        # WP1: now uses _step_enabled() for full short-key coverage.
+        # Now uses _step_enabled() for full short-key coverage.
         if not _step_enabled(workflow_steps, name):
             ctx.step_state = StepState(
                 result=StepResult.SKIPPED, message="disabled by workflow config"
@@ -514,7 +514,7 @@ def run_pipeline(
                 raise
             except Exception as e:  # noqa: BLE001 — pipeline step barrier: catch all for retry/degrade policy
                 elapsed = time.time() - step_start
-                # R2-NA-ORCH: detect retryable (transient) errors via the
+                # Retryable-error orchestration: detect retryable (transient) errors via the
                 # `retryable` attribute on ProviderError subclasses (and any
                 # wrapped exception that sets it). Network timeouts / rate
                 # limits / temporary-unavailable set it True; config and
@@ -558,7 +558,7 @@ def run_pipeline(
 
         elapsed = time.time() - step_start
 
-        # ── F3: surface soft-step degradation from non-exception paths ──
+        # ── Surface soft-step degradation from non-exception paths ──
         # Some soft steps (e.g. align_audio in C1 fix) internally catch
         # exceptions and set status.<field>='failed' + step_state.result
         # = WARNING without re-raising. The runner's outer except block
@@ -583,7 +583,7 @@ def run_pipeline(
         _render_step_result(ctx, name, elapsed, console)
         _check_strict(ctx, name)
 
-        # ── EP9: Pause-at check ─────────────────────────────
+        # ── Pause-at check ─────────────────────────────────
         # If the user requested a pause after this step, serialize state
         # and raise PipelinePaused so the CLI can inform the user.
         pause_at = ctx.metadata.get("pause_at")
@@ -612,7 +612,7 @@ def run_pipeline(
             f"{', '.join(degraded)}. The final output may have reduced quality."
         )
 
-    # ── WP1: Re-export metadata.json after all steps ────
+    # ── Re-export metadata.json after all steps ──────────
     # render_video writes metadata.json before QA runs, so qa_report and
     # other late-stage diagnostics are missing. Re-export here to capture
     # the full picture (qa_report, degraded_steps, match_summary, etc.).
@@ -689,7 +689,7 @@ def _handle_step_error(
     GradioController or ``controller=None``), returns ``ABORT`` to
     preserve the existing fail-fast behavior.
 
-    R2-NA-ORCH: before delegating, inspect the exception's ``retryable``
+    Retryable-error orchestration: before delegating, inspect the exception's ``retryable``
     attribute. A retryable (transient, network-type) failure is a good
     candidate for an interactive [R]etry/[S]kip/[A]bort choice:
 

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -92,6 +92,9 @@ def generate_voice(ctx: Context) -> Context:
 
     async def _run_all():
         sem = asyncio.Semaphore(max_concurrent)
+        # v0.7-fix: parallel to ``results``, tracks whether each segment was
+        # served from the on-disk cache so cost tracking can mark it cached.
+        cached_flags: list[bool] = []
 
         async def _one(seg):
             async with sem:
@@ -106,6 +109,7 @@ def generate_voice(ctx: Context) -> Context:
                     await provider.synthesize(seg.text, voice, tmp)
                     audio = AudioSegment.from_mp3(tmp)
                     tmp.unlink(missing_ok=True)
+                    cached_flags.append(False)
                 else:
                     if not cached.exists():
                         # Per-segment retry: a single network hiccup shouldn't
@@ -133,6 +137,9 @@ def generate_voice(ctx: Context) -> Context:
                                     )
                         if last_err is not None:
                             raise last_err
+                        cached_flags.append(False)
+                    else:
+                        cached_flags.append(True)
                     # ST-07: if cached file is corrupt (from a previous
                     # interrupted write before the fix), delete and retry once.
                     try:
@@ -144,18 +151,21 @@ def generate_voice(ctx: Context) -> Context:
                         cached.unlink(missing_ok=True)
                         await provider.synthesize(seg.text, voice, cached)
                         audio = AudioSegment.from_mp3(cached)
+                        cached_flags[-1] = False
                 return audio, round(len(audio) / 1000.0, 3)
 
         return await tqdm_asyncio.gather(
             *[_one(s) for s in ctx.segments],
             desc="Narrating",
             unit="seg",
-        )
+        ), cached_flags
 
     with step_timing(console, "tts_batch_synthesize"):
-        results = run_async(_run_all())
+        results, cached_flags = run_async(_run_all())
 
-    # v0.7.0: Record TTS usage for cost tracking
+    # v0.7.0: Record TTS usage for cost tracking.
+    # v0.7-fix: use the per-segment cache-hit flags so cached segments are
+    # not double-counted in the estimated cost.
     if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
         provider_name = settings.tts_provider.value
         tts_model = (
@@ -163,13 +173,14 @@ def generate_voice(ctx: Context) -> Context:
             else settings.mimo_tts_model if settings.tts_provider is TTSProviderType.MIMO
             else ""
         )
-        for seg in ctx.segments:
+        for i, seg in enumerate(ctx.segments):
+            was_cached = cached_flags[i] if i < len(cached_flags) else False
             ctx.cost_tracker.record_tts_call(
                 provider=provider_name,
                 model=tts_model,
                 characters=len(seg.text),
                 segments=1,
-                cached=False,
+                cached=was_cached,
             )
 
     # ── v0.5.9: Emotion-aware prosody ───────────────────────

--- a/src/movie_narrator/vision/__init__.py
+++ b/src/movie_narrator/vision/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 zcbacxc
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Vision captioning abstraction layer (EP8 / Q-M5).
+"""Vision captioning abstraction layer (VLM captioning).
 
 Public API:
     from movie_narrator.vision import (

--- a/src/movie_narrator/vision/factory.py
+++ b/src/movie_narrator/vision/factory.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 zcbacxc
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Factory: settings → VisionCaptioner instance (EP8).
+"""Factory: settings → VisionCaptioner instance (vision captioner).
 
 Uses the :data:`vision_registry` to dispatch provider creation.
 Built-in provider (stub) is registered at import time. External

--- a/src/movie_narrator/vision/protocol.py
+++ b/src/movie_narrator/vision/protocol.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 zcbacxc
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""VisionCaptioner abstract interface (EP8).
+"""VisionCaptioner abstract interface (vision captioning).
 
 Defines the contract for visual scene captioning — producing a
 short text description of each scene from video frames, which

--- a/src/movie_narrator/vision/vlm.py
+++ b/src/movie_narrator/vision/vlm.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 zcbacxc
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""VLMCaptioner — real visual scene descriptions via cloud VLM API (Q-M5).
+"""VLMCaptioner — real visual scene descriptions via cloud VLM API (VLM captioning).
 
 Extracts a keyframe from each scene's midpoint, sends it to an
 OpenAI-compatible vision API (GPT-4o, Qwen-VL, etc.), and returns

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -196,11 +196,11 @@ def test_align_backend_none_when_neither_importable(tmp_path, monkeypatch):
     assert ctx.step_state.result.value == "skipped"
 
 
-# ── F4: backward jump detection ──
+# ── Backward jump detection ──
 
 
 def test_align_backward_jump_extreme_skips_segment(tmp_path):
-    """F4: wx segment mapping far behind prev_end (>50% of original duration)
+    """Backward-jump detection: wx segment mapping far behind prev_end (>50% of original duration)
     is skipped (TTS estimate kept) instead of crushed to 100ms.
 
     Scenario: seg1 midpoint=10 → maps to wx (8, 12) → prev_end=12.
@@ -245,7 +245,7 @@ def test_align_backward_jump_extreme_skips_segment(tmp_path):
         align_audio(ctx)
 
     assert ctx.status.align == "success"
-    # F4: seg2 should be skipped (backward jump > 50% of original duration)
+    # seg2 should be skipped (backward jump > 50% of original duration)
     assert ctx.metadata.get("align_backward_skipped") == 1
     # seg2's timestamps should be unchanged (TTS estimate kept)
     assert ctx.timed_segments[1].start == original_seg2_start
@@ -256,7 +256,7 @@ def test_align_backward_jump_extreme_skips_segment(tmp_path):
 
 
 def test_align_backward_jump_small_clamp_keeps_segment(tmp_path):
-    """F4: small backward jump (≤50% of original duration) is still clamped,
+    """Small backward jump (≤50% of original duration) is still clamped,
     not skipped. The segment is compressed but remains usable.
 
     Scenario: seg1 midpoint=9 → maps to wx (8, 10) → prev_end=10.
@@ -297,7 +297,7 @@ def test_align_backward_jump_small_clamp_keeps_segment(tmp_path):
         align_audio(ctx)
 
     assert ctx.status.align == "success"
-    # F4: no skips — backward jump was small enough to clamp
+    # No skips — backward jump was small enough to clamp
     assert ctx.metadata.get("align_backward_skipped") == 0
     # seg2 should be clamped: start=prev_end=10, end=12
     assert ctx.timed_segments[1].start == 10.0  # clamped to prev_end
@@ -305,7 +305,7 @@ def test_align_backward_jump_small_clamp_keeps_segment(tmp_path):
 
 
 def test_align_no_backward_jumps_zero_skipped(tmp_path):
-    """F4: normal forward-mapping alignment → 0 backward skips."""
+    """Normal forward-mapping alignment → 0 backward skips."""
     ctx = _make_ctx(tmp_path)
     mock_result = {
         "segments": [
@@ -405,22 +405,22 @@ def test_align_unequal_segment_counts(tmp_path):
     # AQ-01 fix: timestamps are now monotonically non-decreasing
     # and non-overlapping (multiple segments can't share the same
     # wx segment time range without being pushed forward).
-    # F4 caveat: segments skipped due to extreme backward jumps keep
+    # Backward-jump caveat: segments skipped due to extreme backward jumps keep
     # their TTS estimates, which may not be monotonic with neighbors.
     # Only assert monotonic for non-skipped segments (curr.start > 0
     # and curr.start >= prev.end OR curr was skipped).
     for prev, curr in zip(ctx.timed_segments, ctx.timed_segments[1:]):
         # Either monotonic holds, OR curr was skipped (kept TTS estimate)
-        # — F4 allows non-monotonic for skipped segments.
+        # — Backward-jump detection allows non-monotonic for skipped segments.
         is_monotonic = curr.start >= prev.end
         # A skipped segment keeps its original TTS start time, which may
         # be < prev.end. We can't directly detect skip here, but we can
         # verify positive duration always holds.
         assert curr.end > curr.start    # always positive duration
         # Monotonic should hold for most segments; if it doesn't, the
-        # segment was likely skipped by F4 (backward jump > 50%).
+        # segment was likely skipped by backward-jump detection (backward jump > 50%).
         if not is_monotonic:
-            # This is acceptable under F4 — log it but don't fail
+            # This is acceptable under backward-jump detection — log it but don't fail
             pass
 
 

--- a/tests/test_bgm.py
+++ b/tests/test_bgm.py
@@ -138,3 +138,66 @@ def test_mix_bgm_success(tmp_path):
     name = Path(ctx.final_audio_path).name
     assert name in ("mixed.mp3", "mixed.wav")
     assert Path(ctx.final_audio_path).exists()
+
+
+def test_mix_bgm_ambient_success(tmp_path):
+    """v0.7.1 ambient: a valid ambient track is mixed in and recorded."""
+    narr = _write_tone_mp3(tmp_path / "narration.mp3", 800, freq=440)
+    bgm = _write_tone_mp3(tmp_path / "bgm.mp3", 400, freq=880)
+    ambient = _write_tone_mp3(tmp_path / "ambient.mp3", 600, freq=220)
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        audio_path=str(narr),
+        assets=Assets(bgm=str(bgm)),
+    )
+    ctx.metadata["bgm_request"] = "explicit"
+    ctx.metadata["bgm_ambient_path"] = str(ambient)
+    mix_bgm(ctx)
+    assert ctx.status.bgm == "success"
+    assert ctx.metadata.get("ambient_track", {}).get("path") == str(ambient)
+    assert ctx.metadata["ambient_track"]["gain_db"] == -12.0
+    assert ctx.metadata["ambient_track"]["duck_db"] == -10.0
+    assert Path(ctx.final_audio_path).exists()
+
+
+def test_mix_bgm_ambient_missing_soft_fail(tmp_path):
+    """v0.7.1 ambient: a missing ambient file warns and keeps the mix going."""
+    narr = _write_tone_mp3(tmp_path / "narration.mp3", 800, freq=440)
+    bgm = _write_tone_mp3(tmp_path / "bgm.mp3", 400, freq=880)
+    ctx = Context(
+        movie_name="m",
+        output_dir=str(tmp_path),
+        audio_path=str(narr),
+        assets=Assets(bgm=str(bgm)),
+    )
+    ctx.metadata["bgm_request"] = "explicit"
+    ctx.metadata["bgm_ambient_path"] = str(tmp_path / "missing.mp3")
+    mix_bgm(ctx)
+    # Soft failure: BGM mix still succeeds, ambient skipped with an error.
+    assert ctx.status.bgm == "success"
+    info = ctx.metadata.get("ambient_track")
+    assert info is None or "error" in info
+    assert Path(ctx.final_audio_path).exists()
+
+
+def test_mix_bgm_ambient_ducking_applied(tmp_path):
+    """v0.7.1 ambient: ducking must reduce ambient loudness under narration."""
+    from movie_narrator.pipeline.bgm import _mix_ambient_track
+
+    narr = _write_tone_mp3(tmp_path / "narration.mp3", 800, freq=440)
+    ambient = _write_tone_mp3(tmp_path / "ambient.mp3", 400, freq=220)
+
+    base_mixed = AudioSegment.from_file(narr).overlay(
+        AudioSegment.from_file(ambient).apply_gain(0)
+    )
+    ducked_mixed, info = _mix_ambient_track(
+        AudioSegment.from_file(narr),
+        str(ambient),
+        ambient_gain_db=0.0,
+        duck_db=-20.0,
+    )
+    assert "error" not in info
+    # Ducking must attenuate the ambient, so the ducked mix is quieter
+    # than an equal-gain overlay (narration energy dominates both).
+    assert ducked_mixed.dBFS < base_mixed.dBFS

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -91,11 +91,11 @@ def test_match_clips_embedding_disabled_keeps_heuristic(tmp_path, monkeypatch):
     assert all(m.source == "heuristic" for m in ctx.matched_clips)
 
 
-# ── F1: match_summary full schema validation ──
+# ── match_summary full schema validation ──
 
 
 def test_match_summary_full_schema_when_embedding_path_runs(tmp_path, monkeypatch):
-    """F1: match_summary contains all CORE_ENGINE_TREATMENT_PLAN §5.2.3 fields
+    """match_summary contains all CORE_ENGINE_TREATMENT_PLAN §5.2.3 fields
     when embedding path runs successfully with real transcript."""
     ctx = _make_ctx(tmp_path)
     (tmp_path / "video.mp4").write_bytes(b"00")
@@ -137,7 +137,7 @@ def test_match_summary_full_schema_when_embedding_path_runs(tmp_path, monkeypatc
     match_clips(ctx)
     summary = ctx.metadata["match_summary"]
 
-    # F1: all required fields present
+    # All required fields present
     required_fields = [
         "version", "status", "segments", "scenes_in", "scenes_after_merge",
         "scenes_after_drop", "merge_min_duration", "drop_min_duration",
@@ -149,7 +149,7 @@ def test_match_summary_full_schema_when_embedding_path_runs(tmp_path, monkeypatc
         "total", "embedding", "heuristic", "captions_fake",
     ]
     for field in required_fields:
-        assert field in summary, f"F1: missing field '{field}' in match_summary"
+        assert field in summary, f"match_summary: missing field '{field}' in match_summary"
 
     # Specific value checks
     assert summary["version"] == 1
@@ -170,7 +170,7 @@ def test_match_summary_full_schema_when_embedding_path_runs(tmp_path, monkeypatc
 
 
 def test_match_summary_degraded_reason_all_heuristic(tmp_path, monkeypatch):
-    """F1: degraded_reason='all_heuristic' when all clips fall back to heuristic."""
+    """match_summary: degraded_reason='all_heuristic' when all clips fall back to heuristic."""
     ctx = _make_ctx(tmp_path)
     (tmp_path / "video.mp4").write_bytes(b"00")
     ctx.scenes = [
@@ -192,7 +192,7 @@ def test_match_summary_degraded_reason_all_heuristic(tmp_path, monkeypatch):
 
 
 def test_match_summary_low_score_fallback_count(tmp_path, monkeypatch):
-    """F1: low_score_fallback_count tracks segments that fell back due to low score."""
+    """match_summary: low_score_fallback_count tracks segments that fell back due to low score."""
     ctx = _make_ctx(tmp_path)
     (tmp_path / "video.mp4").write_bytes(b"00")
     ctx.scenes = [
@@ -252,11 +252,11 @@ def test_match_summary_low_score_fallback_count(tmp_path, monkeypatch):
     assert summary["raw_score"]["min"] == 0.0  # gamma's score
 
 
-# ── F2: is_fake contract tests ──
+# ── is_fake contract tests ──
 
 
 def test_build_scene_captions_returns_tuples_with_is_fake_flag():
-    """F2: _build_scene_captions returns List[Tuple[str, bool]] not List[str].
+    """is_fake contract: _build_scene_captions returns List[Tuple[str, bool]] not List[str].
 
     The is_fake flag replaces fragile string-pattern matching for detecting
     placeholder labels. Callers should use the flag, not startswith().
@@ -281,7 +281,7 @@ def test_build_scene_captions_returns_tuples_with_is_fake_flag():
 
 
 def test_build_scene_captions_real_transcript_marks_is_fake_false():
-    """F2: scenes with overlapping speech get is_fake=False."""
+    """is_fake contract: scenes with overlapping speech get is_fake=False."""
     from movie_narrator.pipeline.match import _build_scene_captions
 
     scenes = [
@@ -302,7 +302,7 @@ def test_build_scene_captions_real_transcript_marks_is_fake_false():
 
 
 def test_build_scene_captions_mixed_real_and_fake():
-    """F2: scenes without overlapping speech get is_fake=True even with transcript."""
+    """is_fake contract: scenes without overlapping speech get is_fake=True even with transcript."""
     from movie_narrator.pipeline.match import _build_scene_captions
 
     scenes = [
@@ -322,11 +322,11 @@ def test_build_scene_captions_mixed_real_and_fake():
     assert result[2][1] is False  # scene 2 has speech
 
 
-# ── F1 back-compat: old metadata_export consumers must not break ──
+# ── Legacy match_summary fields: old metadata_export consumers must not break ──
 
 
 def test_match_summary_keys_compatible_with_old_metadata_export(tmp_path, monkeypatch):
-    """F1 back-compat: match_summary preserves the 4 legacy fields
+    """Legacy match_summary fields: match_summary preserves the 4 legacy fields
     (total/embedding/heuristic/captions_fake) so existing consumers
     (metadata_export, QA checklist jq queries, older scripts) don't break.
     """
@@ -375,7 +375,7 @@ def test_match_summary_keys_compatible_with_old_metadata_export(tmp_path, monkey
     legacy_fields = ["total", "embedding", "heuristic", "captions_fake"]
     for field in legacy_fields:
         assert field in summary, (
-            f"F1 back-compat: legacy field '{field}' missing from match_summary — "
+            f"Legacy match_summary fields: legacy field '{field}' missing from match_summary — "
             f"existing metadata_export consumers will break"
         )
 
@@ -387,7 +387,7 @@ def test_match_summary_keys_compatible_with_old_metadata_export(tmp_path, monkey
 
 
 def test_match_summary_legacy_fields_when_all_heuristic(tmp_path, monkeypatch):
-    """F1 back-compat: legacy fields present even when embedding path doesn't run."""
+    """Legacy match_summary fields: legacy fields present even when embedding path doesn't run."""
     ctx = _make_ctx(tmp_path)
     (tmp_path / "video.mp4").write_bytes(b"00")
     ctx.scenes = [

--- a/tests/test_runner_workflow_metadata.py
+++ b/tests/test_runner_workflow_metadata.py
@@ -55,16 +55,16 @@ def test_run_pipeline_omits_workflow_keys_when_empty(tmp_path):
     assert "config_path" not in ctx.metadata
 
 
-# ── F3: runner surfaces soft-step degradation from non-exception paths ──
+# ── Soft-step degradation: runner surfaces it from non-exception paths ──
 
 
 def test_run_pipeline_accumulates_degraded_steps_for_internal_fallback(tmp_path):
-    """F3: soft step that internally sets status='failed'+WARNING (no raise)
+    """Soft-step degradation: soft step that internally sets status='failed'+WARNING (no raise)
     is accumulated into _degraded_steps by the runner.
 
     Reproduces the C1 align_fallback scenario: align_audio catches
     whisperx.align() exception internally, sets status.align='failed'
-    + step_state.result=WARNING, and returns normally. Before F3, the
+    + step_state.result=WARNING, and returns normally. Before this fix, the
     runner's outer except block never fired, so _degraded_steps stayed
     empty and the degradation was invisible in the runner's summary.
     """
@@ -97,17 +97,17 @@ def test_run_pipeline_accumulates_degraded_steps_for_internal_fallback(tmp_path)
     with patch("movie_narrator.pipeline.runner.STEPS", fake_steps):
         ctx = run_pipeline(ctx)
 
-    # F3: _degraded_steps should contain 'align_audio' even though the
+    # Soft-step degradation: _degraded_steps should contain 'align_audio' even though the
     # step returned normally (no exception propagated to runner).
     degraded = ctx.metadata.get("_degraded_steps", [])
     assert "align_audio" in degraded, (
-        f"F3: align_audio should be in _degraded_steps for internal fallback, "
+        f"Soft-step degradation: align_audio should be in _degraded_steps for internal fallback, "
         f"got {degraded}"
     )
 
 
 def test_run_pipeline_does_not_duplicate_degraded_steps(tmp_path):
-    """F3: if a soft step both raises AND sets status='failed', the runner
+    """Soft-step degradation: if a soft step both raises AND sets status='failed', the runner
     should not add it to _degraded_steps twice (idempotent)."""
     def _passthrough(ctx: Context) -> Context:
         return ctx
@@ -137,15 +137,15 @@ def test_run_pipeline_does_not_duplicate_degraded_steps(tmp_path):
         ctx = run_pipeline(ctx)
 
     degraded = ctx.metadata.get("_degraded_steps", [])
-    # Should appear exactly once (exception path adds it, F3 dedupes)
+    # Should appear exactly once (exception path adds it; soft-step degradation dedupes)
     assert degraded.count("align_audio") == 1, (
-        f"F3: align_audio should appear exactly once in _degraded_steps, "
+        f"Soft-step degradation: align_audio should appear exactly once in _degraded_steps, "
         f"got {degraded}"
     )
 
 
 def test_run_pipeline_no_degraded_when_step_succeeds(tmp_path):
-    """F3: a step that returns normally with status='success' should NOT
+    """Soft-step degradation: a step that returns normally with status='success' should NOT
     be added to _degraded_steps."""
     def _passthrough(ctx: Context) -> Context:
         return ctx
@@ -172,6 +172,6 @@ def test_run_pipeline_no_degraded_when_step_succeeds(tmp_path):
 
     degraded = ctx.metadata.get("_degraded_steps", [])
     assert "align_audio" not in degraded, (
-        f"F3: align_audio should NOT be in _degraded_steps when it succeeds, "
+        f"Soft-step degradation: align_audio should NOT be in _degraded_steps when it succeeds, "
         f"got {degraded}"
     )


### PR DESCRIPTION
## v0.7.x code-review fixes

Three real issues found in the v0.7.x implementation review, all fixed.

### 1. TTS cost tracking: cached segments double-counted
\`pipeline/tts.py\` recorded every segment with \`cached=False\` regardless of whether \`_one()\` served it from the on-disk cache — so \`cost.tts.cached_segments\` was always 0 and the estimated TTS cost charged for cache hits. \`_one()\` now collects a per-segment \`cached_flags\` list (parallel to \`results\`), and the cost loop consumes it.

### 2. Ambient track ducking was fake
\`pipeline/bgm.py::_mix_ambient_track()\` accepted \`timed_segments\` but never used it; ducking was a fixed whole-track \`apply_gain(duck_db)\`, contradicting the docstring ("ducking during active narration segments"). Reimplemented on top of \`duck_bgm()\` — per-window dynamic ducking with attack/release smoothing, driven by actual narration audio energy. Added 3 tests (success, missing-file soft-fail, ducking attenuation) — ambient previously had **zero** test coverage.

### 3. Legacy tracking codes removed (99 occurrences / 16 files)
Per the v0.7.5 CONTRIBUTING rule, removed all remaining internal engineering tracking codes (\`EP*\`/\`WP*\`/\`R2-NA-*\`/\`Q-M5\`/\`F1-F4\`) from \`runner.py\`, \`vision/\`, 3 test files, 4 docs, 2 examples, \`scripts/compare_runs.py\` and \`.env.example\`, replacing them with plain technical descriptions. \`CHANGELOG.md\` historical records untouched.

### Verification
- Full suite: **1903 passed / 0 failed / 5 skipped** (baseline 1900 + 3 new ambient tests)
- mypy: clean (53 source files)
