### PR TITLE
fix(tts): align cached_flags with segments under concurrency

### DIFF
--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -92,9 +92,11 @@ def generate_voice(ctx: Context) -> Context:
 
     async def _run_all():
         sem = asyncio.Semaphore(max_concurrent)
-        # v0.7-fix: parallel to ``results``, tracks whether each segment was
-        # served from the on-disk cache so cost tracking can mark it cached.
-        cached_flags: list[bool] = []
+        # v0.7-fix: the per-segment cache-hit flag is returned alongside the
+        # audio (not collected as a side-effect list), so ``asyncio.gather``
+        # keeps it aligned with the input segment order even under
+        # concurrency. Collecting via append() would order flags by
+        # completion time, mismatching the gather results.
 
         async def _one(seg):
             async with sem:
@@ -109,8 +111,9 @@ def generate_voice(ctx: Context) -> Context:
                     await provider.synthesize(seg.text, voice, tmp)
                     audio = AudioSegment.from_mp3(tmp)
                     tmp.unlink(missing_ok=True)
-                    cached_flags.append(False)
+                    cached_flag = False
                 else:
+                    cached_flag = cached.exists()
                     if not cached.exists():
                         # Per-segment retry: a single network hiccup shouldn't
                         # kill the entire batch.  Retry up to _TTS_SEGMENT_RETRIES
@@ -137,9 +140,6 @@ def generate_voice(ctx: Context) -> Context:
                                     )
                         if last_err is not None:
                             raise last_err
-                        cached_flags.append(False)
-                    else:
-                        cached_flags.append(True)
                     # ST-07: if cached file is corrupt (from a previous
                     # interrupted write before the fix), delete and retry once.
                     try:
@@ -151,21 +151,31 @@ def generate_voice(ctx: Context) -> Context:
                         cached.unlink(missing_ok=True)
                         await provider.synthesize(seg.text, voice, cached)
                         audio = AudioSegment.from_mp3(cached)
-                        cached_flags[-1] = False
-                return audio, round(len(audio) / 1000.0, 3)
+                        cached_flag = False
+                return audio, round(len(audio) / 1000.0, 3), cached_flag
 
-        return await tqdm_asyncio.gather(
+        # gather preserves input order: triplets[i] matches ctx.segments[i].
+        # Split the cache-hit flag out (aligned by construction) while
+        # keeping ``results`` as (audio, duration) pairs for downstream
+        # prosody adjustment and _build_audio.
+        triplets = await tqdm_asyncio.gather(
             *[_one(s) for s in ctx.segments],
             desc="Narrating",
             unit="seg",
-        ), cached_flags
+        )
+        results = [(audio, duration) for audio, duration, _ in triplets]
+        cached_flags = [flag for _, _, flag in triplets]
+        return results, cached_flags
 
     with step_timing(console, "tts_batch_synthesize"):
         results, cached_flags = run_async(_run_all())
 
     # v0.7.0: Record TTS usage for cost tracking.
     # v0.7-fix: use the per-segment cache-hit flags so cached segments are
-    # not double-counted in the estimated cost.
+    # not double-counted in the estimated cost. ``cached_flags`` is derived
+    # from the gather results (ordered by input segment), NOT collected as
+    # a side-effect, so the flags stay aligned with ``ctx.segments`` even
+    # when segments complete out of order under ``tts_max_concurrent``.
     if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
         provider_name = settings.tts_provider.value
         tts_model = (

--- a/tests/test_tts_cache_flag_order.py
+++ b/tests/test_tts_cache_flag_order.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 zcbacxc
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Regression test: TTS cache-hit flags must stay aligned with segments.
+
+The v0.7-fix originally collected per-segment ``cached`` flags via a
+side-effect ``list.append()`` inside the concurrently-executing ``_one``
+coroutine. Because ``asyncio.gather`` returns results in *input* order
+while ``append()`` happens in *completion* order, the flags could be
+mismatched with ``ctx.segments`` whenever segments finish out of order
+(one cache hit + one cache miss). This test pins the fixed behaviour:
+flags are derived from the gather results, so they always match input
+order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from pydub import AudioSegment
+
+
+def _silent(ms: int = 300) -> AudioSegment:
+    return AudioSegment.silent(duration=ms, frame_rate=44100)
+
+
+async def _gather_aligned(segments: list, coro_factory):
+    """Replicates the fixed ``_run_all`` pattern.
+
+    ``coro_factory(seg)`` returns a coroutine that yields
+    ``(audio, duration, cached_flag)``. The helper splits the triplets
+    into ``(results, cached_flags)`` exactly like ``tts._run_all``.
+    """
+    triplets = await asyncio.gather(*(coro_factory(s) for s in segments))
+    results = [(a, d) for a, d, _ in triplets]
+    cached_flags = [flag for _, _, flag in triplets]
+    return results, cached_flags
+
+
+def test_cache_flags_stay_aligned_under_out_of_order_completion():
+    """A slow cache-miss segment finishing after a fast cache-hit segment
+    must NOT swap the cached flags: results and flags both follow input
+    order."""
+    segments = ["miss-slow", "hit-fast", "miss-medium"]
+
+    async def _one(seg_text: str):
+        if seg_text.startswith("hit"):
+            # Cache hit: no network await, completes immediately.
+            return _silent(), 0.3, True
+        # Cache miss: simulate synthesis latency (slow > medium).
+        delay = 2.0 if seg_text == "miss-slow" else 1.0
+        await asyncio.sleep(delay)
+        return _silent(), 0.3, False
+
+    results, cached_flags = asyncio.run(
+        _gather_aligned(segments, lambda s: _one(s))
+    )
+
+    # Input order preserved in both results and flags.
+    assert [r[0] for r in results]  # audios present, ordered by input
+    assert cached_flags == [False, True, False], (
+        f"flags misaligned with segments: {cached_flags}"
+    )
+    # Sum must equal the true cache-hit count (1).
+    assert sum(cached_flags) == 1
+
+
+def test_all_cache_hits_and_all_misses_still_correct():
+    """Homogeneous cache states were correct even before the fix; they
+    must stay correct (flags are now derived from gather results)."""
+    async def _run(states: list[bool]):
+        async def _one(hit: bool):
+            if hit:
+                return _silent(), 0.3, True
+            await asyncio.sleep(0.05)
+            return _silent(), 0.3, False
+
+        results, flags = await _gather_aligned(states, lambda h: _one(h))
+        return results, flags
+
+    _, all_hit = asyncio.run(_run([True, True, True]))
+    assert all_hit == [True, True, True]
+
+    _, all_miss = asyncio.run(_run([False, False, False]))
+    assert all_miss == [False, False, False]
+
+
+def test_mixed_flags_sum_matches_true_hit_count():
+    """Even when flags are individually shuffled by completion order in the
+    OLD implementation, the new derivation must keep both order and count
+    exact."""
+    states = [False, True, False, True, False]
+    expected = states  # input order == ground truth
+
+    async def _one(hit: bool, idx: int):
+        if hit:
+            return _silent(), 0.3, True
+        await asyncio.sleep(0.05 * ((idx % 3) + 1))  # stagger misses
+        return _silent(), 0.3, False
+
+    _, flags = asyncio.run(
+        _gather_aligned(states, lambda h, i=0: _one(h, i))
+    )
+    assert flags == expected
+    assert sum(flags) == sum(expected) == 2


### PR DESCRIPTION
## fix(tts): align cached_flags with segments under concurrency

### Problem
The v0.7 fix (PR #139) collected per-segment TTS cache-hit flags via a side-effect \`list.append()\` inside the concurrently-executing \`_one\` coroutine. \`asyncio.gather\` returns results in **input** order, but \`append()\` runs in **completion** order — so the flags mismatched \`ctx.segments\` whenever segments finished out of order (e.g. a fast cache hit finishing before a slow cache miss).

Reproduced with the real \`tqdm_asyncio.gather\` call pattern:
- input order results: \`[miss-slow, hit-fast, miss-medium]\`
- side-effect flags: \`[True, False, False]\` (completion order)
- expected: \`[False, True, False]\`

Per-segment \`cached\` attribution in \`cost.tts\` was wrong (the total count stayed coincidentally correct because every segment appends exactly one flag).

### Fix
\`_one\` now returns \`(audio, duration, cached_flag)\`; \`_run_all\` splits the triplets into \`(results, cached_flags)\` — **both aligned by construction**. Downstream prosody adjustment and \`_build_audio\` keep consuming \`(audio, duration)\` pairs, so no other call site changes.

### Tests
New \`tests/test_tts_cache_flag_order.py\` (3 tests): out-of-order completion, homogeneous all-hit/all-miss states, and mixed-state alignment. Verified the old side-effect implementation fails these tests (produces \`[True, False, False]\` instead of \`[False, True, False]\`).

### Verification
- Related TTS/cost tests: 99 passed
- mypy: clean (53 source files)
