### PR TITLE
fix(test): make test_submit_success timing-independent (CI flaky)

### DIFF
--- a/tests/test_v093_batch_schedule.py
+++ b/tests/test_v093_batch_schedule.py
@@ -172,9 +172,13 @@ class TestSubmitBatch:
         )
         assert batch.batch_id
         assert len(batch.task_ids) == 2
+        # The batch may already be terminal when the mock pipeline runs fast
+        # (e.g. on CI); only a *completed* state is asserted after the wait
+        # loop below, so the initial state check must accept any state.
         assert batch.status in (
             BatchStatus.PENDING,
             BatchStatus.RUNNING,
+            BatchStatus.COMPLETED,
         )
 
         deadline = time.time() + 10


### PR DESCRIPTION
test_submit_success asserted the batch is PENDING/RUNNING right after submit_batch. On CI the mock pipeline can finish both sub-tasks before the assertion runs (batch already COMPLETED), failing the run. The behavioral assertion is the wait-loop to COMPLETED, so the initial state check now accepts any state.

Fixes the v0.9.4 main CI failure (test-matrix all versions).