### PR TITLE
chore: apply ruff format to src/ and tests/

### DIFF
--- a/src/movie_narrator/cli.py
+++ b/src/movie_narrator/cli.py
@@ -79,20 +79,17 @@ def _format_degradation_hints(ctx: Context) -> list[str]:
             )
         elif degraded == "all_heuristic":
             hints.append(
-                "match: all segments fell back to heuristic — "
-                "check embedding model availability"
+                "match: all segments fell back to heuristic — check embedding model availability"
             )
         elif degraded:
             hints.append(f"match degraded: {degraded}")
 
     degraded_steps = ctx.metadata.get("_degraded_steps", [])
     if degraded_steps:
-        hints.append(
-            f"degraded steps: {', '.join(degraded_steps)} — "
-            f"see metadata.json for details"
-        )
+        hints.append(f"degraded steps: {', '.join(degraded_steps)} — see metadata.json for details")
 
     return hints
+
 
 app = typer.Typer(
     help="Movie Narrator — 从一个提示词生成解说短视频 / Generate narrated movie recap videos from a single prompt.",
@@ -142,6 +139,7 @@ class InteractiveCLIController:
             return StepAction.SKIP
         return StepAction.ABORT
 
+
 from .utils.sanitize import sanitize_filename as _sanitize_filename  # noqa: E402
 
 
@@ -149,53 +147,94 @@ from .utils.sanitize import sanitize_filename as _sanitize_filename  # noqa: E40
 def create(
     movie: Optional[str] = typer.Option(None, "--movie", "-m", help="电影名称 / Movie name"),
     style: str = typer.Option("热血搞笑", "--style", "-s", help="解说风格 / Narration style"),
-    duration: int = typer.Option(60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"),
-    voice: Optional[str] = typer.Option(None, "--voice", "-v", help="TTS 语音 / TTS voice (Edge TTS)"),
-    video_format: str = typer.Option("16:9", "--video-format", "--format", "-f", help="视频格式 16:9 或 9:16 / Video format: 16:9 or 9:16"),
-    keep_cache: bool = typer.Option(False, "--keep-cache", help="保留 TTS 缓存 / Keep TTS cache files"),
-    video: Optional[str] = typer.Option(None, "--video", help="源视频文件路径 / Source movie file path"),
-    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library directory"),
-    research: Optional[bool] = typer.Option(None, "--research/--no-research", help="启用剧��研究 / Enable plot research"),
+    duration: int = typer.Option(
+        60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"
+    ),
+    voice: Optional[str] = typer.Option(
+        None, "--voice", "-v", help="TTS 语音 / TTS voice (Edge TTS)"
+    ),
+    video_format: str = typer.Option(
+        "16:9",
+        "--video-format",
+        "--format",
+        "-f",
+        help="视频格式 16:9 或 9:16 / Video format: 16:9 or 9:16",
+    ),
+    keep_cache: bool = typer.Option(
+        False, "--keep-cache", help="保留 TTS 缓存 / Keep TTS cache files"
+    ),
+    video: Optional[str] = typer.Option(
+        None, "--video", help="源视频文件路径 / Source movie file path"
+    ),
+    library_dir: Optional[str] = typer.Option(
+        None, "--library-dir", help="影视库目录 / Movie library directory"
+    ),
+    research: Optional[bool] = typer.Option(
+        None, "--research/--no-research", help="启用剧��研究 / Enable plot research"
+    ),
     bgm: Optional[str] = typer.Option(None, "--bgm", help="背景音乐文件 / Background music file"),
-    no_bgm: bool = typer.Option(False, "--no-bgm", help="禁用 BGM / Disable BGM even if default set"),
+    no_bgm: bool = typer.Option(
+        False, "--no-bgm", help="禁用 BGM / Disable BGM even if default set"
+    ),
     no_clips: bool = typer.Option(False, "--no-clips", help="跳过片段导出 / Skip clips/export"),
-    strict: bool = typer.Option(False, "--strict", help="软步骤失败即中止 / Abort on soft step failure"),
-    retry: bool = typer.Option(False, "--retry", help="硬步骤失败时交互重试 / Enable interactive retry on hard step failure"),
-    config: Optional[str] = typer.Option(None, "--config", help="job YAML ��置路径 / Path to job YAML config"),
+    strict: bool = typer.Option(
+        False, "--strict", help="软步骤失败即中止 / Abort on soft step failure"
+    ),
+    retry: bool = typer.Option(
+        False,
+        "--retry",
+        help="硬步骤失败时交互重试 / Enable interactive retry on hard step failure",
+    ),
+    config: Optional[str] = typer.Option(
+        None, "--config", help="job YAML ��置路径 / Path to job YAML config"
+    ),
     # Multi-language subtitle (v0.3).
     subtitle_lang: Optional[str] = typer.Option(
-        None, "--subtitle-lang", help="目标语言标签(如 en, ja, zh-TW) / Target language tag; empty = off",
+        None,
+        "--subtitle-lang",
+        help="目标语言标签(如 en, ja, zh-TW) / Target language tag; empty = off",
     ),
     subtitle_mode: Optional[str] = typer.Option(
-        None, "--subtitle-mode", help="字幕模式 original|translated|bilingual / Overlay mode",
+        None,
+        "--subtitle-mode",
+        help="字幕模式 original|translated|bilingual / Overlay mode",
     ),
     narration_preset: Optional[str] = typer.Option(
-        None, "--narration-preset", "-p",
+        None,
+        "--narration-preset",
+        "-p",
         help="解说风格预设 douyin-fast | mainstream-dry | bilibili-long / Narration style preset",
     ),
     narrator_perspective: Optional[str] = typer.Option(
-        None, "--narrator-perspective",
+        None,
+        "--narrator-perspective",
         help="解说视角 omniscient | character | detective / Narrator perspective mode",
     ),
     focus_character: Optional[str] = typer.Option(
-        None, "--focus-character",
+        None,
+        "--focus-character",
         help="聚焦角色名(��合 character 视角) / Focus character name (used with 'character' perspective)",
     ),
     output_dir: Optional[str] = typer.Option(
-        None, "--output-dir", "-o",
+        None,
+        "--output-dir",
+        "-o",
         help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
     ),
     pause_at: Optional[str] = typer.Option(
-        None, "--pause-at",
+        None,
+        "--pause-at",
         help="在指定步骤后暂停(人在环) / Pause after this step name "
-             "(e.g. match_clips, generate_script). Resume with: mn resume --state <path>",
+        "(e.g. match_clips, generate_script). Resume with: mn resume --state <path>",
     ),
     log_level: str = typer.Option(
-        "DEBUG", "--log-level",
+        "DEBUG",
+        "--log-level",
         help="日志级别 DEBUG|INFO|WARNING|ERROR / Log level (default: DEBUG)",
     ),
     verbose: bool = typer.Option(
-        False, "--verbose",
+        False,
+        "--verbose",
         help="在控制台显示 DEBUG 日志 / Show debug logs in console",
     ),
 ):
@@ -288,36 +327,40 @@ def create(
 
     # --output-dir / -o: user-specified output directory.
     # Default: output/<sanitized-movie-name>
-    out_dir = Path(output_dir) if output_dir else Path("output") / _sanitize_filename(resolved.movie)
+    out_dir = (
+        Path(output_dir) if output_dir else Path("output") / _sanitize_filename(resolved.movie)
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
 
     _resolved_level = resolve_log_level(log_level)
 
-    ctx = build_context(**common_build_kwargs(
-        movie=resolved.movie,
-        style=resolved.style,
-        duration=resolved.duration,
-        voice=resolved.voice,
-        video_format=resolved.video_format,
-        output_dir=out_dir,
-        keep_cache=resolved.keep_cache,
-        video=resolved.video,
-        library_dir=resolved.library_dir,
-        research=resolved.research,
-        bgm=resolved.bgm,
-        no_bgm=resolved.no_bgm,
-        no_clips=resolved.no_clips,
-        strict=resolved.strict,
-        workflow_steps=resolved.workflow_steps or None,
-        params=resolved.params or None,
-        config_path=resolved.config_path,
-        subtitle_lang=resolved.subtitle_lang,
-        subtitle_mode=resolved.subtitle_mode,
-        narration_preset=resolved.narration_preset or narration_preset,
-        lang=resolved.lang,
-        log_level=_resolved_level,
-        verbose=verbose,
-    ))
+    ctx = build_context(
+        **common_build_kwargs(
+            movie=resolved.movie,
+            style=resolved.style,
+            duration=resolved.duration,
+            voice=resolved.voice,
+            video_format=resolved.video_format,
+            output_dir=out_dir,
+            keep_cache=resolved.keep_cache,
+            video=resolved.video,
+            library_dir=resolved.library_dir,
+            research=resolved.research,
+            bgm=resolved.bgm,
+            no_bgm=resolved.no_bgm,
+            no_clips=resolved.no_clips,
+            strict=resolved.strict,
+            workflow_steps=resolved.workflow_steps or None,
+            params=resolved.params or None,
+            config_path=resolved.config_path,
+            subtitle_lang=resolved.subtitle_lang,
+            subtitle_mode=resolved.subtitle_mode,
+            narration_preset=resolved.narration_preset or narration_preset,
+            lang=resolved.lang,
+            log_level=_resolved_level,
+            verbose=verbose,
+        )
+    )
     controller = InteractiveCLIController() if retry else None
 
     # Store pause-at request in context metadata
@@ -329,14 +372,16 @@ def create(
     except Exception as e:  # noqa: BLE001 — CLI top-level error barrier
         # PipelinePaused — state saved, inform user how to resume
         from .pipeline.errors import PipelinePaused
+
         if isinstance(e, PipelinePaused):
             typer.echo(
                 f"\n⏸ Pipeline paused after '{e.completed_step}'. "
-                f"Resume with: mn resume --state \"{Path(ctx.output_dir) / 'pipeline_state.json'}\""
+                f'Resume with: mn resume --state "{Path(ctx.output_dir) / "pipeline_state.json"}"'
             )
             raise typer.Exit(code=0)
         # PreflightError gets a targeted remediation hint.
         from .pipeline.preflight import PreflightError
+
         if isinstance(e, PreflightError):
             typer.echo(str(e), err=True)
             raise typer.Exit(code=1)
@@ -362,26 +407,46 @@ def create(
 def race(
     movie: Optional[str] = typer.Option(None, "--movie", "-m", help="电影名称 / Movie name"),
     style: str = typer.Option("热血搞笑", "--style", "-s", help="解说风格 / Narration style"),
-    duration: int = typer.Option(60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"),
-    voice: Optional[str] = typer.Option(None, "--voice", "-v", help="TTS 语音 / TTS voice (Edge TTS)"),
-    video_format: str = typer.Option("16:9", "--video-format", "--format", "-f", help="视频格式 16:9 或 9:16 / Video format"),
-    video: Optional[str] = typer.Option(None, "--video", help="源视频文件路径 / Source movie file path"),
-    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library directory"),
-    research: Optional[bool] = typer.Option(None, "--research/--no-research", help="启用剧��研究 / Enable plot research"),
+    duration: int = typer.Option(
+        60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"
+    ),
+    voice: Optional[str] = typer.Option(
+        None, "--voice", "-v", help="TTS 语音 / TTS voice (Edge TTS)"
+    ),
+    video_format: str = typer.Option(
+        "16:9", "--video-format", "--format", "-f", help="视频格式 16:9 或 9:16 / Video format"
+    ),
+    video: Optional[str] = typer.Option(
+        None, "--video", help="源视频文件路径 / Source movie file path"
+    ),
+    library_dir: Optional[str] = typer.Option(
+        None, "--library-dir", help="影视库目录 / Movie library directory"
+    ),
+    research: Optional[bool] = typer.Option(
+        None, "--research/--no-research", help="启用剧��研究 / Enable plot research"
+    ),
     bgm: Optional[str] = typer.Option(None, "--bgm", help="背景音乐文件 / Background music file"),
     no_bgm: bool = typer.Option(False, "--no-bgm", help="禁用 BGM / Disable BGM"),
-    config: Optional[str] = typer.Option(None, "--config", help="job YAML ��置路径 / Path to job YAML config"),
-    candidates: int = typer.Option(3, "--candidates", "-n", help="候选数量(1-6) / Number of candidates (1-6)"),
+    config: Optional[str] = typer.Option(
+        None, "--config", help="job YAML ��置路径 / Path to job YAML config"
+    ),
+    candidates: int = typer.Option(
+        3, "--candidates", "-n", help="候选数量(1-6) / Number of candidates (1-6)"
+    ),
     presets: Optional[str] = typer.Option(
-        None, "--presets",
+        None,
+        "--presets",
         help="自定义预设列表(逗号分隔) / Custom presets (comma-separated, e.g. douyin-fast,mainstream-dry)",
     ),
     auto_pick: bool = typer.Option(
-        False, "--auto-pick",
+        False,
+        "--auto-pick",
         help="自动选优并复制到输出根目录 / Auto-pick best and copy to output root",
     ),
     output_dir: Optional[str] = typer.Option(
-        None, "--output-dir", "-o",
+        None,
+        "--output-dir",
+        "-o",
         help="输出目录(默认 output/<电影名>_race) / Output directory",
     ),
 ):
@@ -472,40 +537,55 @@ def race(
 @app.command()
 def imitate(
     reference: str = typer.Option(
-        ..., "--reference", "-r",
+        ...,
+        "--reference",
+        "-r",
         help="参考视频路径 / Reference video path (viral narration to imitate)",
     ),
     movie: Optional[str] = typer.Option(None, "--movie", "-m", help="电影名称 / Movie name"),
     style: str = typer.Option("热血搞笑", "--style", "-s", help="解说风格 / Narration style"),
-    duration: int = typer.Option(60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"),
+    duration: int = typer.Option(
+        60, "--duration", "-d", help="目标时长(秒) / Target duration (seconds)"
+    ),
     voice: Optional[str] = typer.Option(None, "--voice", "-v", help="TTS 语音 / TTS voice"),
-    video_format: str = typer.Option("16:9", "--video-format", "--format", "-f", help="视频格式 / Video format"),
+    video_format: str = typer.Option(
+        "16:9", "--video-format", "--format", "-f", help="视频格式 / Video format"
+    ),
     keep_cache: bool = typer.Option(False, "--keep-cache", help="保留 TTS 缓存 / Keep TTS cache"),
-    video: Optional[str] = typer.Option(None, "--video", help="源视频文件路径 / Source movie file path"),
+    video: Optional[str] = typer.Option(
+        None, "--video", help="源视频文件路径 / Source movie file path"
+    ),
     library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录"),
     research: Optional[bool] = typer.Option(None, "--research/--no-research", help="启用剧��研究"),
     bgm: Optional[str] = typer.Option(None, "--bgm", help="背景音乐文件 / Background music file"),
     no_bgm: bool = typer.Option(False, "--no-bgm", help="禁用 BGM / Disable BGM"),
     no_clips: bool = typer.Option(False, "--no-clips", help="跳过片段导出 / Skip clips"),
-    strict: bool = typer.Option(False, "--strict", help="软步骤失败即中止 / Abort on soft step failure"),
+    strict: bool = typer.Option(
+        False, "--strict", help="软步骤失败即中止 / Abort on soft step failure"
+    ),
     retry: bool = typer.Option(False, "--retry", help="硬步骤失败时交互重试"),
     config: Optional[str] = typer.Option(None, "--config", help="job YAML ��置路径"),
     subtitle_lang: Optional[str] = typer.Option(None, "--subtitle-lang", help="目标语言标签"),
     subtitle_mode: Optional[str] = typer.Option(None, "--subtitle-mode", help="字幕模式"),
     output_dir: Optional[str] = typer.Option(
-        None, "--output-dir", "-o",
+        None,
+        "--output-dir",
+        "-o",
         help="输出目录(默认 output/<电影名>_imitate) / Output directory",
     ),
     analyze_only: bool = typer.Option(
-        False, "--analyze-only",
+        False,
+        "--analyze-only",
         help="只分析参考片不生成 / Only analyze reference, don't generate",
     ),
     log_level: str = typer.Option(
-        "DEBUG", "--log-level",
+        "DEBUG",
+        "--log-level",
         help="日志级别 DEBUG|INFO|WARNING|ERROR / Log level (default: DEBUG)",
     ),
     verbose: bool = typer.Option(
-        False, "--verbose",
+        False,
+        "--verbose",
         help="在控制台显示 DEBUG 日志 / Show debug logs in console",
     ),
 ):
@@ -575,30 +655,32 @@ def imitate(
     _resolved_level = resolve_log_level(log_level)
 
     assert movie is not None
-    ctx = build_context(**common_build_kwargs(
-        movie=movie,
-        style=style,
-        duration=duration,
-        voice=voice,
-        video_format=video_format,
-        output_dir=out_dir,
-        keep_cache=keep_cache,
-        video=video,
-        library_dir=library_dir,
-        research=research,
-        bgm=bgm,
-        no_bgm=no_bgm,
-        no_clips=no_clips,
-        strict=strict,
-        params=params,
-        config_path=config,
-        subtitle_lang=subtitle_lang,
-        subtitle_mode=subtitle_mode,
-        narration_preset=preset_name,
-        lang="zh",  # imitate command defaults to Chinese
-        log_level=_resolved_level,
-        verbose=verbose,
-    ))
+    ctx = build_context(
+        **common_build_kwargs(
+            movie=movie,
+            style=style,
+            duration=duration,
+            voice=voice,
+            video_format=video_format,
+            output_dir=out_dir,
+            keep_cache=keep_cache,
+            video=video,
+            library_dir=library_dir,
+            research=research,
+            bgm=bgm,
+            no_bgm=no_bgm,
+            no_clips=no_clips,
+            strict=strict,
+            params=params,
+            config_path=config,
+            subtitle_lang=subtitle_lang,
+            subtitle_mode=subtitle_mode,
+            narration_preset=preset_name,
+            lang="zh",  # imitate command defaults to Chinese
+            log_level=_resolved_level,
+            verbose=verbose,
+        )
+    )
 
     controller = InteractiveCLIController() if retry else None
 
@@ -608,7 +690,7 @@ def imitate(
         if isinstance(e, PipelinePaused):
             typer.echo(
                 f"\n⏸ Pipeline paused after '{e.completed_step}'. "
-                f"Resume with: mn resume --state \"{Path(ctx.output_dir) / 'pipeline_state.json'}\""
+                f'Resume with: mn resume --state "{Path(ctx.output_dir) / "pipeline_state.json"}"'
             )
             raise typer.Exit(code=0)
         if isinstance(e, PreflightError):
@@ -629,14 +711,22 @@ def imitate(
 
 @app.command()
 def resume(
-    state: str = typer.Option(..., "--state", help="pipeline_state.json 路径 / Path to pipeline state file"),
-    retry: bool = typer.Option(False, "--retry", help="硬步骤失败时交互重试 / Enable interactive retry on hard step failure"),
+    state: str = typer.Option(
+        ..., "--state", help="pipeline_state.json 路径 / Path to pipeline state file"
+    ),
+    retry: bool = typer.Option(
+        False,
+        "--retry",
+        help="硬步骤失败时交互重试 / Enable interactive retry on hard step failure",
+    ),
     log_level: str = typer.Option(
-        "DEBUG", "--log-level",
+        "DEBUG",
+        "--log-level",
         help="日志级别 DEBUG|INFO|WARNING|ERROR / Log level (default: DEBUG)",
     ),
     verbose: bool = typer.Option(
-        False, "--verbose",
+        False,
+        "--verbose",
         help="在控制台显示 DEBUG 日志 / Show debug logs in console",
     ),
 ):
@@ -663,6 +753,7 @@ def resume(
 
     # Re-inject a real console (serialized state has SilentConsole)
     from .models import Services
+
     console: Console = build_console(
         Path(ctx.output_dir),
         log_level=_resolved_level,
@@ -676,10 +767,7 @@ def resume(
     # Determine the step to start from (the step AFTER the completed one)
     start_step = _next_step_after(completed_step)
     if start_step is None:
-        typer.echo(
-            f"Pipeline already completed (last step: {completed_step}). "
-            f"Nothing to resume."
-        )
+        typer.echo(f"Pipeline already completed (last step: {completed_step}). Nothing to resume.")
         raise typer.Exit(code=0)
 
     console = ctx.services.console
@@ -692,7 +780,7 @@ def resume(
         if isinstance(e, PipelinePaused):
             typer.echo(
                 f"\n⏸ Pipeline paused after '{e.completed_step}'. "
-                f"Resume with: mn resume --state \"{Path(ctx.output_dir) / 'pipeline_state.json'}\""
+                f'Resume with: mn resume --state "{Path(ctx.output_dir) / "pipeline_state.json"}"'
             )
             raise typer.Exit(code=0)
         if isinstance(e, PreflightError):
@@ -712,10 +800,14 @@ def resume(
 @app.command()
 def resolve(
     movie: str = typer.Option(..., "--movie", "-m", help="电影名称 / Movie name to resolve"),
-    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library directory"),
+    library_dir: Optional[str] = typer.Option(
+        None, "--library-dir", help="影视库目录 / Movie library directory"
+    ),
     json_output: bool = typer.Option(False, "--json", help="JSON 格式输出 / Output result as JSON"),
     output_dir: Optional[str] = typer.Option(
-        None, "--output-dir", "-o",
+        None,
+        "--output-dir",
+        "-o",
         help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
     ),
 ):
@@ -743,7 +835,9 @@ def resolve(
 def research(
     movie: str = typer.Option(..., "--movie", "-m", help="电影名称 / Movie name to research"),
     output_dir: Optional[str] = typer.Option(
-        None, "--output-dir", "-o",
+        None,
+        "--output-dir",
+        "-o",
         help="输出目录(默认 output/<电影名>) / Output directory (default: output/<movie>)",
     ),
 ):
@@ -768,12 +862,15 @@ def research(
 @app.command()
 def scenes(
     video: str = typer.Option(..., "--video", help="视频文件路径 / Video file path"),
-    threshold: float = typer.Option(27.0, "--threshold", help="场景检测阈值 / Scene detection threshold"),
+    threshold: float = typer.Option(
+        27.0, "--threshold", help="场景检测阈值 / Scene detection threshold"
+    ),
     output: Optional[str] = typer.Option(None, "--output", help="输出目录 / Output directory"),
 ):
     """Detect scenes in a video file."""
     from movie_narrator.pipeline.scenes import detect_scenes
     from movie_narrator.models import Context
+
     out = Path(output) if output else Path("output") / "scenes_debug"
     out.mkdir(parents=True, exist_ok=True)
     ctx = Context(movie_name="debug", output_dir=str(out), source_video_path=video)
@@ -796,12 +893,15 @@ def scenes(
 @app.command()
 def align(
     audio: str = typer.Option(..., "--audio", help="音频文件路径 / Audio file path"),
-    script: Optional[str] = typer.Option(None, "--script", help="脚本文本文件(每行一句) / Script text file"),
+    script: Optional[str] = typer.Option(
+        None, "--script", help="脚本文本文件(每行一句) / Script text file"
+    ),
     output: Optional[str] = typer.Option(None, "--output", help="输出目录 / Output directory"),
 ):
     """Align audio with script using WhisperX."""
     from movie_narrator.pipeline.align import align_audio
     from movie_narrator.models import Context, TimedSegment
+
     out = Path(output) if output else Path("output") / "align_debug"
     out.mkdir(parents=True, exist_ok=True)
     segments = []
@@ -837,6 +937,7 @@ def clips(
     from movie_narrator.pipeline.export_clips import export_clips
     from movie_narrator.models import Context, Scene
     import json
+
     out = Path(output) if output else Path("output") / "clips_debug"
     out.mkdir(parents=True, exist_ok=True)
     data = json.loads(Path(scenes_path).read_text(encoding="utf-8"))
@@ -861,9 +962,7 @@ def clips(
 
 @app.command()
 def plugin(
-    action: str = typer.Argument(
-        ..., help="list | discover | registries | version"
-    ),
+    action: str = typer.Argument(..., help="list | discover | registries | version"),
 ):
     """Plugin system commands — list, discover, inspect registries.
 
@@ -877,6 +976,7 @@ def plugin(
     """
     if action == "list":
         from .plugin_loader import list_available_plugins
+
         plugins = list_available_plugins()
         if not plugins:
             typer.echo("No plugins found via entry_points.")
@@ -890,6 +990,7 @@ def plugin(
 
     elif action == "discover":
         from .plugin_loader import discover_plugins
+
         results = discover_plugins()
         if not results:
             typer.echo("No plugins found to discover.")
@@ -911,8 +1012,10 @@ def plugin(
 
         from .pipeline.registry import step_registry
         from .providers import (
-            tts_registry, vision_registry,
-            llm_registry, research_registry,
+            tts_registry,
+            vision_registry,
+            llm_registry,
+            research_registry,
         )
 
         typer.echo("=== Step Registry ===")
@@ -948,6 +1051,7 @@ def plugin(
 
     elif action == "version":
         from .contract import CONTRACT_VERSION
+
         typer.echo(f"CONTRACT_VERSION = {CONTRACT_VERSION}")
         typer.echo(f"  semver: {'.'.join(str(v) for v in CONTRACT_VERSION)}")
 
@@ -1023,8 +1127,10 @@ def _get_queue(remote: Optional[str] = None):
             given URL. Otherwise, returns a LocalTaskQueue.
     """
     from .cloud import LocalTaskQueue
+
     if remote:
         from .cloud import RemoteTaskQueue
+
         return RemoteTaskQueue(remote)
     return LocalTaskQueue(auto_start=False)
 
@@ -1035,25 +1141,40 @@ def submit(
     style: str = typer.Option("热血搞笑", "--style", "-s", help="解说风格 / Narration style"),
     duration: int = typer.Option(60, "--duration", "-d", help="目标时长(秒) / Target duration"),
     voice: Optional[str] = typer.Option(None, "--voice", "-v", help="TTS 语音 / TTS voice"),
-    video_format: str = typer.Option("16:9", "--video-format", "--format", "-f", help="视频格式 / Video format"),
+    video_format: str = typer.Option(
+        "16:9", "--video-format", "--format", "-f", help="视频格式 / Video format"
+    ),
     video: Optional[str] = typer.Option(None, "--video", help="源视频路径 / Source video path"),
-    library_dir: Optional[str] = typer.Option(None, "--library-dir", help="影视库目录 / Movie library"),
-    research: Optional[bool] = typer.Option(None, "--research/--no-research", help="启用研究 / Enable research"),
+    library_dir: Optional[str] = typer.Option(
+        None, "--library-dir", help="影视库目录 / Movie library"
+    ),
+    research: Optional[bool] = typer.Option(
+        None, "--research/--no-research", help="启用研究 / Enable research"
+    ),
     bgm: Optional[str] = typer.Option(None, "--bgm", help="背景音乐 / Background music"),
     no_bgm: bool = typer.Option(False, "--no-bgm", help="禁用BGM / Disable BGM"),
     no_clips: bool = typer.Option(False, "--no-clips", help="跳过片段导出 / Skip clips"),
     strict: bool = typer.Option(False, "--strict", help="严格模式 / Strict mode"),
-    subtitle_lang: Optional[str] = typer.Option(None, "--subtitle-lang", help="字幕语言 / Subtitle language"),
-    subtitle_mode: Optional[str] = typer.Option(None, "--subtitle-mode", help="字幕模式 / Subtitle mode"),
-    narration_preset: Optional[str] = typer.Option(None, "--narration-preset", "-p", help="解说预设 / Narration preset"),
+    subtitle_lang: Optional[str] = typer.Option(
+        None, "--subtitle-lang", help="字幕语言 / Subtitle language"
+    ),
+    subtitle_mode: Optional[str] = typer.Option(
+        None, "--subtitle-mode", help="字幕模式 / Subtitle mode"
+    ),
+    narration_preset: Optional[str] = typer.Option(
+        None, "--narration-preset", "-p", help="解说预设 / Narration preset"
+    ),
     lang: str = typer.Option("zh", "--lang", help="解说语言 / Narration language"),
-    output_dir: Optional[str] = typer.Option(None, "--output-dir", "-o", help="输出目录 / Output directory"),
+    output_dir: Optional[str] = typer.Option(
+        None, "--output-dir", "-o", help="输出目录 / Output directory"
+    ),
     max_retries: int = typer.Option(3, "--max-retries", help="最大重试次数 / Max retries"),
     wait: bool = typer.Option(False, "--wait", help="提交后等��完成 / Wait for completion"),
-    timeout: Optional[float] = typer.Option(None, "--timeout", help="等����时(秒) / Wait timeout (seconds)"),
+    timeout: Optional[float] = typer.Option(
+        None, "--timeout", help="等����时(秒) / Wait timeout (seconds)"
+    ),
     remote: Optional[str] = typer.Option(
-        None, "--remote", "-r",
-        help="远程服务器URL / Remote server URL (e.g. http://worker:8765)"
+        None, "--remote", "-r", help="远程服务器URL / Remote server URL (e.g. http://worker:8765)"
     ),
 ):
     """Submit an async narration task.
@@ -1116,8 +1237,7 @@ def submit(
 def status(
     task_id: str = typer.Argument(..., help="任务ID / Task ID"),
     remote: Optional[str] = typer.Option(
-        None, "--remote", "-r",
-        help="远程服务器URL / Remote server URL"
+        None, "--remote", "-r", help="远程服务器URL / Remote server URL"
     ),
 ):
     """Show task status.
@@ -1146,8 +1266,7 @@ def status(
 
     if task.progress:
         p = task.progress
-        typer.echo(f"  Progress: {p.current_step_index}/{p.total_steps} "
-                    f"({p.percentage:.0f}%)")
+        typer.echo(f"  Progress: {p.current_step_index}/{p.total_steps} ({p.percentage:.0f}%)")
         if p.current_step:
             typer.echo(f"  Current step: {p.current_step}")
         if p.elapsed_seconds > 0:
@@ -1177,13 +1296,14 @@ def status(
 @app.command()
 def tasks(
     status_filter: Optional[str] = typer.Option(
-        None, "--status", "-s",
-        help="过滤状态 pending|running|completed|failed|cancelled / Filter by status"
+        None,
+        "--status",
+        "-s",
+        help="过滤状态 pending|running|completed|failed|cancelled / Filter by status",
     ),
     limit: int = typer.Option(20, "--limit", "-n", help="显示数量 / Number of tasks to show"),
     remote: Optional[str] = typer.Option(
-        None, "--remote", "-r",
-        help="远程服务器URL / Remote server URL"
+        None, "--remote", "-r", help="远程服务器URL / Remote server URL"
     ),
 ):
     """List tasks.
@@ -1233,8 +1353,7 @@ def tasks(
 def cancel(
     task_id: str = typer.Argument(..., help="任务ID / Task ID"),
     remote: Optional[str] = typer.Option(
-        None, "--remote", "-r",
-        help="远程服务器URL / Remote server URL"
+        None, "--remote", "-r", help="远程服务器URL / Remote server URL"
     ),
 ):
     """Cancel a running task.
@@ -1250,8 +1369,7 @@ def cancel(
         typer.echo(f"Task {task_id}: cancellation requested.")
     else:
         typer.echo(
-            f"Task {task_id}: could not cancel "
-            f"(not found or already in terminal state).",
+            f"Task {task_id}: could not cancel (not found or already in terminal state).",
             err=True,
         )
         raise typer.Exit(1)
@@ -1261,16 +1379,13 @@ def cancel(
 def wait(
     task_id: str = typer.Argument(..., help="任务ID / Task ID"),
     timeout: Optional[float] = typer.Option(
-        None, "--timeout", "-t",
-        help="等����时(秒) / Timeout in seconds (default: infinite)"
+        None, "--timeout", "-t", help="等����时(秒) / Timeout in seconds (default: infinite)"
     ),
     poll_interval: float = typer.Option(
-        1.0, "--poll-interval",
-        help="轮询间隔(秒) / Poll interval in seconds"
+        1.0, "--poll-interval", help="轮询间隔(秒) / Poll interval in seconds"
     ),
     remote: Optional[str] = typer.Option(
-        None, "--remote", "-r",
-        help="远程服务器URL / Remote server URL"
+        None, "--remote", "-r", help="远程服务器URL / Remote server URL"
     ),
 ):
     """Wait for task completion.
@@ -1283,7 +1398,9 @@ def wait(
     queue = _get_queue(remote=remote)
     result = queue.wait(task_id, timeout=timeout, poll_interval=poll_interval)
     if result is None:
-        typer.echo(f"Task {task_id}: did not complete (timeout, cancelled, or not found).", err=True)
+        typer.echo(
+            f"Task {task_id}: did not complete (timeout, cancelled, or not found).", err=True
+        )
         raise typer.Exit(1)
     if result.succeeded:
         typer.echo(f"✓ Task {task_id} completed: {result.video_path}")
@@ -1295,8 +1412,7 @@ def wait(
 @app.command()
 def cleanup(
     all_tasks: bool = typer.Option(
-        False, "--all",
-        help="��除所有任务(��括运行中) / Clear all tasks including active ones"
+        False, "--all", help="��除所有任务(��括运行中) / Clear all tasks including active ones"
     ),
 ):
     """Clean up terminal tasks.
@@ -1322,27 +1438,31 @@ def serve(
     port: int = typer.Option(8765, "--port", help="监听端口 / Listen port"),
     max_workers: int = typer.Option(2, "--max-workers", help="最大并发任务 / Max concurrent tasks"),
     storage_dir: Optional[str] = typer.Option(
-        None, "--storage-dir",
-        help="任务存储目录 / Task storage directory"
+        None, "--storage-dir", help="任务存储目录 / Task storage directory"
     ),
     public: bool = typer.Option(
-        False, "--public",
-        help="监听所有网络接口(默认��本机) / Listen on all interfaces (default: localhost only)"
+        False,
+        "--public",
+        help="监听所有网络接口(默认��本机) / Listen on all interfaces (default: localhost only)",
     ),
     api_key: Optional[str] = typer.Option(
-        None, "--api-key",
+        None,
+        "--api-key",
         help="API key for X-API-Key authentication. Reads MN_API_KEY env var by default.",
     ),
     insecure: bool = typer.Option(
-        False, "--insecure",
+        False,
+        "--insecure",
         help="Allow starting on public interface without API key (not recommended).",
     ),
     log_format: Optional[str] = typer.Option(
-        None, "--log-format",
+        None,
+        "--log-format",
         help="日志格式 / Log format: text|json (default: MN_LOG_FORMAT, else text).",
     ),
     log_level: Optional[str] = typer.Option(
-        None, "--log-level",
+        None,
+        "--log-level",
         help="日志级别 / Log level: DEBUG|INFO|WARNING|ERROR (default: MN_LOG_LEVEL, else INFO).",
     ),
 ):
@@ -1427,12 +1547,10 @@ def download(
     task_id: str = typer.Argument(..., help="任务ID / Task ID"),
     remote: str = typer.Option(..., "--remote", "-r", help="远程服务器URL / Remote server URL"),
     filename: Optional[str] = typer.Option(
-        None, "--filename", "-f",
-        help="指定文件名(不指定则下载��部) / Specific file (default: all)"
+        None, "--filename", "-f", help="指定文件名(不指定则下载��部) / Specific file (default: all)"
     ),
     dest_dir: Optional[str] = typer.Option(
-        None, "--dest-dir", "-o",
-        help="保存目录 / Destination directory"
+        None, "--dest-dir", "-o", help="保存目录 / Destination directory"
     ),
 ):
     """Download artifacts from a remote server.
@@ -1461,12 +1579,13 @@ def download(
 @app.command("api-spec")
 def api_spec(
     output: Optional[str] = typer.Option(
-        None, "--output", "-o",
-        help="输出文件路径(默认输出到 stdout) / Output file path (default: stdout)"
+        None,
+        "--output",
+        "-o",
+        help="输出文件路径(默认输出到 stdout) / Output file path (default: stdout)",
     ),
     indent: int = typer.Option(
-        2, "--indent",
-        help="JSON 缩进空格数(0 表示紧凑输出) / JSON indent width (0 = compact)"
+        2, "--indent", help="JSON 缩进空格数(0 表示紧凑输出) / JSON indent width (0 = compact)"
     ),
 ):
     """Dump the REST API OpenAPI 3.1 spec.
@@ -1522,7 +1641,9 @@ def _artifacts_open_store(backend: Optional[str], root: Optional[str]):
 
 @artifacts_app.command("list")
 def artifacts_list(
-    prefix: str = typer.Option("", "--prefix", help="仅列出该前缀下的产物 / Only list keys under this prefix"),
+    prefix: str = typer.Option(
+        "", "--prefix", help="仅列出该前缀下的产物 / Only list keys under this prefix"
+    ),
     backend: Optional[str] = typer.Option(
         None, "--backend", help="local 或 s3(默认读 MN_STORAGE_BACKEND) / Backend override"
     ),
@@ -1555,18 +1676,26 @@ def artifacts_list(
 @artifacts_app.command("cleanup")
 def artifacts_cleanup(
     ttl: Optional[int] = typer.Option(
-        None, "--ttl", help="过期秒数,0=永久保留(默认读 MN_ARTIFACT_TTL) / TTL in seconds, 0 = keep forever"
+        None,
+        "--ttl",
+        help="过期秒数,0=永久保留(默认读 MN_ARTIFACT_TTL) / TTL in seconds, 0 = keep forever",
     ),
     max_bytes: Optional[int] = typer.Option(
-        None, "--max-bytes", help="总容量上限字节数,0=不限(默认读 MN_ARTIFACT_MAX_BYTES) / Total size cap in bytes"
+        None,
+        "--max-bytes",
+        help="总容量上限字节数,0=不限(默认读 MN_ARTIFACT_MAX_BYTES) / Total size cap in bytes",
     ),
     keep_last: Optional[int] = typer.Option(
-        None, "--keep-last", help="始终保留最新 N 个产物(默认读 MN_ARTIFACT_KEEP_LAST) / Always keep the N newest"
+        None,
+        "--keep-last",
+        help="始终保留最新 N 个产物(默认读 MN_ARTIFACT_KEEP_LAST) / Always keep the N newest",
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="仅预览不删除 / Preview without deleting"
     ),
-    prefix: str = typer.Option("", "--prefix", help="仅清理该前缀下的产物 / Restrict cleanup to this prefix"),
+    prefix: str = typer.Option(
+        "", "--prefix", help="仅清理该前缀下的产物 / Restrict cleanup to this prefix"
+    ),
     backend: Optional[str] = typer.Option(
         None, "--backend", help="local 或 s3(默认读 MN_STORAGE_BACKEND) / Backend override"
     ),
@@ -1606,9 +1735,7 @@ def artifacts_cleanup(
         typer.echo(f"  {line}")
 
     if not policy.enabled:
-        typer.echo(
-            "No retention rule active (--ttl / --max-bytes are both 0) — nothing to do."
-        )
+        typer.echo("No retention rule active (--ttl / --max-bytes are both 0) — nothing to do.")
         return
 
     report = cleanup_artifacts(store, policy, prefix=prefix)

--- a/src/movie_narrator/cloud/api.py
+++ b/src/movie_narrator/cloud/api.py
@@ -127,14 +127,22 @@ class PayloadTooLargeError(Exception):
     HTTP 413 instead of a generic 400 for an oversized body.
     """
 
+
 #: Environment variable opting ``/metrics`` out of API-key auth.
 _ENV_METRICS_PUBLIC = "MN_METRICS_PUBLIC"
 
 #: Paths that are already templates (no variable segment).
 _STATIC_PATHS = frozenset(
     {
-        "/health", "/info", "/tasks", "/ready", "/openapi.json",
-        _METRICS_PATH, "/tasks/batch", "/batches", "/schedules",
+        "/health",
+        "/info",
+        "/tasks",
+        "/ready",
+        "/openapi.json",
+        _METRICS_PATH,
+        "/tasks/batch",
+        "/batches",
+        "/schedules",
         "/deadletters",
     }
 )
@@ -179,7 +187,10 @@ def _metrics_public() -> bool:
     and error rates.
     """
     return os.environ.get(_ENV_METRICS_PUBLIC, "").strip().lower() in {
-        "1", "true", "yes", "on",
+        "1",
+        "true",
+        "yes",
+        "on",
     }
 
 
@@ -282,9 +293,7 @@ class _APIHandler(BaseHTTPRequestHandler):
             # in a clean state and the client can read the 413 response
             # instead of failing with a broken pipe mid-send.
             self._drain_body(length)
-            raise PayloadTooLargeError(
-                f"request body too large (max {_MAX_BODY_BYTES} bytes)"
-            )
+            raise PayloadTooLargeError(f"request body too large (max {_MAX_BODY_BYTES} bytes)")
         raw = self.rfile.read(length)
         try:
             return json.loads(raw.decode("utf-8"))
@@ -338,9 +347,7 @@ class _APIHandler(BaseHTTPRequestHandler):
         is generated. :meth:`send_response` echoes it on every response.
         """
         inbound = (
-            self.headers.get(REQUEST_ID_HEADER)
-            or self.headers.get(CORRELATION_HEADER)
-            or None
+            self.headers.get(REQUEST_ID_HEADER) or self.headers.get(CORRELATION_HEADER) or None
         )
         with correlation_scope(inbound):
             handler()
@@ -462,9 +469,7 @@ class _APIHandler(BaseHTTPRequestHandler):
     @_route_registry.register("GET", r"^/openapi\.json$", auth_required=False)
     def _handle_get_openapi(self) -> None:
         host = self.headers.get("Host")
-        self._send_json(
-            build_openapi_spec(server_url=f"http://{host}" if host else None)
-        )
+        self._send_json(build_openapi_spec(server_url=f"http://{host}" if host else None))
 
     @_route_registry.register("GET", r"^/metrics$", auth_required=False)
     def _handle_get_metrics(self) -> None:
@@ -476,14 +481,16 @@ class _APIHandler(BaseHTTPRequestHandler):
 
     @_route_registry.register("GET", r"^/info$")
     def _handle_get_info(self) -> None:
-        self._send_json({
-            "version": __version__,
-            "active_tasks": self.queue.active_count,
-            "is_started": self.queue.is_started,
-            # v0.9.2: orchestration tooling can watch this to detect
-            # that the server has begun its graceful shutdown.
-            "shutting_down": self._is_shutting_down(),
-        })
+        self._send_json(
+            {
+                "version": __version__,
+                "active_tasks": self.queue.active_count,
+                "is_started": self.queue.is_started,
+                # v0.9.2: orchestration tooling can watch this to detect
+                # that the server has begun its graceful shutdown.
+                "shutting_down": self._is_shutting_down(),
+            }
+        )
 
     @_route_registry.register("GET", r"^/tasks$")
     def _handle_get_tasks(self) -> None:
@@ -501,10 +508,12 @@ class _APIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.BAD_REQUEST, "Invalid limit")
             return
         tasks = self.queue.list_tasks(status=status_filter, limit=limit)
-        self._send_json({
-            "tasks": [t.to_summary() for t in tasks],
-            "count": len(tasks),
-        })
+        self._send_json(
+            {
+                "tasks": [t.to_summary() for t in tasks],
+                "count": len(tasks),
+            }
+        )
 
     @_route_registry.register("GET", r"^/tasks/(?P<task_id>[a-f0-9]+)/result$")
     def _handle_get_task_result(self, task_id: str) -> None:
@@ -548,10 +557,12 @@ class _APIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.BAD_REQUEST, "Invalid limit")
             return
         batches = self.queue.list_batches(limit=limit)
-        self._send_json({
-            "batches": [b.model_dump(mode="json") for b in batches],
-            "count": len(batches),
-        })
+        self._send_json(
+            {
+                "batches": [b.model_dump(mode="json") for b in batches],
+                "count": len(batches),
+            }
+        )
 
     @_route_registry.register("GET", r"^/batches/(?P<batch_id>[a-f0-9]+)$")
     def _handle_get_batch(self, batch_id: str) -> None:
@@ -564,39 +575,41 @@ class _APIHandler(BaseHTTPRequestHandler):
     @_route_registry.register("GET", r"^/schedules$")
     def _handle_get_schedules(self) -> None:
         schedules = self.scheduler.list_schedules()
-        self._send_json({
-            "schedules": [s.model_dump(mode="json") for s in schedules],
-            "count": len(schedules),
-        })
+        self._send_json(
+            {
+                "schedules": [s.model_dump(mode="json") for s in schedules],
+                "count": len(schedules),
+            }
+        )
 
     @_route_registry.register("GET", r"^/schedules/(?P<schedule_id>[a-f0-9]+)/runs$")
     def _handle_get_schedule_runs(self, schedule_id: str) -> None:
         if self.scheduler.get_schedule(schedule_id) is None:
-            self._send_error(
-                HTTPStatus.NOT_FOUND, f"Schedule {schedule_id} not found"
-            )
+            self._send_error(HTTPStatus.NOT_FOUND, f"Schedule {schedule_id} not found")
             return
         runs = self.scheduler.get_runs(schedule_id)
-        self._send_json({
-            "runs": [r.model_dump(mode="json") for r in runs],
-            "count": len(runs),
-        })
+        self._send_json(
+            {
+                "runs": [r.model_dump(mode="json") for r in runs],
+                "count": len(runs),
+            }
+        )
 
     @_route_registry.register("GET", r"^/deadletters$")
     def _handle_get_deadletters(self) -> None:
         records = self.dead_letter_store.list()
-        self._send_json({
-            "deadletters": [r.model_dump(mode="json") for r in records],
-            "count": len(records),
-        })
+        self._send_json(
+            {
+                "deadletters": [r.model_dump(mode="json") for r in records],
+                "count": len(records),
+            }
+        )
 
     @_route_registry.register("GET", r"^/deadletters/(?P<task_id>[a-f0-9]+)$")
     def _handle_get_deadletter(self, task_id: str) -> None:
         record = self.dead_letter_store.get(task_id)
         if record is None:
-            self._send_error(
-                HTTPStatus.NOT_FOUND, f"Dead letter {task_id} not found"
-            )
+            self._send_error(HTTPStatus.NOT_FOUND, f"Dead letter {task_id} not found")
             return
         self._send_json(record.model_dump(mode="json"))
 
@@ -669,9 +682,7 @@ class _APIHandler(BaseHTTPRequestHandler):
         try:
             new_task_id = replay_dead_letter(task_id, queue=self.queue)
         except KeyError:
-            self._send_error(
-                HTTPStatus.NOT_FOUND, f"Dead letter {task_id} not found"
-            )
+            self._send_error(HTTPStatus.NOT_FOUND, f"Dead letter {task_id} not found")
             return
         self._send_json(
             {
@@ -742,9 +753,7 @@ class _APIHandler(BaseHTTPRequestHandler):
         if self.scheduler.cancel_schedule(schedule_id):
             self._send_json({"schedule_id": schedule_id, "deleted": True})
         else:
-            self._send_error(
-                HTTPStatus.NOT_FOUND, f"Schedule {schedule_id} not found"
-            )
+            self._send_error(HTTPStatus.NOT_FOUND, f"Schedule {schedule_id} not found")
 
     @_route_registry.register("DELETE", r"^/deadletters/(?P<task_id>[a-f0-9]+)$")
     def _handle_delete_deadletter(self, task_id: str) -> None:
@@ -753,9 +762,7 @@ class _APIHandler(BaseHTTPRequestHandler):
         if removed:
             self._send_json({"task_id": task_id, "removed": True})
         else:
-            self._send_error(
-                HTTPStatus.NOT_FOUND, f"Dead letter {task_id} not found"
-            )
+            self._send_error(HTTPStatus.NOT_FOUND, f"Dead letter {task_id} not found")
 
     # ── HTTP method dispatch ────────────────────────────────
 
@@ -827,11 +834,13 @@ class _APIHandler(BaseHTTPRequestHandler):
             # Preserve v0.6.1 semantics: top-level files only, no dotfiles.
             if "/" in info.key or info.key.startswith("."):
                 continue
-            artifacts.append({
-                "filename": info.key,
-                "size": info.size,
-                "path": artifact_location(store, info.key),
-            })
+            artifacts.append(
+                {
+                    "filename": info.key,
+                    "size": info.size,
+                    "path": artifact_location(store, info.key),
+                }
+            )
         return artifacts
 
     def _serve_task_artifact(self, task: Task, filename: str) -> None:
@@ -943,7 +952,6 @@ class TaskAPIServer:
         artifact_policy: Optional[ArtifactLifecyclePolicy] = None,
         drain_timeout: Optional[float] = None,
         scheduler: Optional[JobScheduler] = None,
-
         dead_letter_store: Optional[DeadLetterStore] = None,
     ) -> None:
         self.host = host
@@ -1120,11 +1128,7 @@ class TaskAPIServer:
             self._sweeper = None
 
         if self._owns_queue:
-            timeout = (
-                drain_timeout
-                if drain_timeout is not None
-                else self._drain_timeout
-            )
+            timeout = drain_timeout if drain_timeout is not None else self._drain_timeout
             if timeout is None:
                 from .daemon import graceful_shutdown_timeout
 

--- a/src/movie_narrator/cloud/artifact_store.py
+++ b/src/movie_narrator/cloud/artifact_store.py
@@ -475,9 +475,7 @@ class S3ArtifactStore:
             The streaming body of *key*.
         """
         try:
-            response = self._client.get_object(
-                Bucket=self.bucket, Key=self.object_key(key)
-            )
+            response = self._client.get_object(Bucket=self.bucket, Key=self.object_key(key))
         except UnsafeKeyError:
             raise
         except Exception as exc:  # noqa: BLE001
@@ -587,7 +585,7 @@ class S3ArtifactStore:
             return raw_key.lstrip("/")
         marker = self.prefix + "/"
         if raw_key.startswith(marker):
-            return raw_key[len(marker):]
+            return raw_key[len(marker) :]
         if raw_key == self.prefix:
             return ""
         return raw_key.lstrip("/")
@@ -612,9 +610,7 @@ def _translate_s3_error(exc: Exception, key: str) -> ArtifactStoreError:
     if isinstance(response, dict):
         error = response.get("Error", {})
         code = str(error.get("Code", "")) if isinstance(error, dict) else ""
-        status = str(
-            response.get("ResponseMetadata", {}).get("HTTPStatusCode", "")
-        )
+        status = str(response.get("ResponseMetadata", {}).get("HTTPStatusCode", ""))
         if code in _S3_MISSING_MARKERS or status == "404":
             return ArtifactNotFoundError(f"Artifact not found: {key!r}")
 
@@ -679,8 +675,10 @@ def get_artifact_store(
     name = (backend or environ.get("MN_STORAGE_BACKEND") or "local").strip().lower()
 
     if name == "local":
-        base = Path(root) if root is not None else Path(
-            environ.get("MN_STORAGE_ROOT") or DEFAULT_LOCAL_ROOT
+        base = (
+            Path(root)
+            if root is not None
+            else Path(environ.get("MN_STORAGE_ROOT") or DEFAULT_LOCAL_ROOT)
         )
         if sub_prefix:
             base = base / normalize_key(sub_prefix)
@@ -689,9 +687,7 @@ def get_artifact_store(
     if name == "s3":
         bucket = environ.get("MN_S3_BUCKET", "")
         if not bucket:
-            raise ArtifactStoreError(
-                "MN_STORAGE_BACKEND=s3 requires MN_S3_BUCKET to be set."
-            )
+            raise ArtifactStoreError("MN_STORAGE_BACKEND=s3 requires MN_S3_BUCKET to be set.")
         prefix = join_prefix(environ.get("MN_S3_PREFIX", ""), sub_prefix)
         return S3ArtifactStore(
             bucket=bucket,

--- a/src/movie_narrator/cloud/checkpoint.py
+++ b/src/movie_narrator/cloud/checkpoint.py
@@ -169,9 +169,7 @@ class CheckpointStore:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 return TaskCheckpoint(**data)
             except (json.JSONDecodeError, ValueError, OSError) as exc:
-                logger.warning(
-                    "Failed to load checkpoint for task %s: %s", task_id, exc
-                )
+                logger.warning("Failed to load checkpoint for task %s: %s", task_id, exc)
                 return None
 
     def delete(self, task_id: str) -> bool:

--- a/src/movie_narrator/cloud/daemon.py
+++ b/src/movie_narrator/cloud/daemon.py
@@ -18,7 +18,7 @@ Typical usage::
     reverse proxy), pass ``host="0.0.0.0"`` explicitly.  Binding to
     loopback by default prevents unintended public exposure of the
     unauthenticated API server.
-    """
+"""
 
 from __future__ import annotations
 
@@ -39,12 +39,14 @@ logger = logging.getLogger(__name__)
 # without authentication. Binding to anything else exposes the API to
 # the network and requires an ``api_key`` (or an explicit opt-in via
 # ``allow_insecure=True``).
-_LOOPBACK_HOSTS = frozenset({
-    "127.0.0.1",
-    "localhost",
-    "::1",
-    "0:0:0:0:0:0:0:1",  # expanded ::1
-})
+_LOOPBACK_HOSTS = frozenset(
+    {
+        "127.0.0.1",
+        "localhost",
+        "::1",
+        "0:0:0:0:0:0:0:1",  # expanded ::1
+    }
+)
 
 #: Fallback drain budget when ``MN_GRACEFUL_SHUTDOWN_TIMEOUT`` is unset
 #: or unreadable (v0.9.2).
@@ -216,7 +218,7 @@ def run_daemon(
         drain_timeout = graceful_shutdown_timeout()
 
         def _shutdown(signum, frame):
-            sig_name = signal.Signals(signum).name if hasattr(signal, 'Signals') else str(signum)
+            sig_name = signal.Signals(signum).name if hasattr(signal, "Signals") else str(signum)
             logger.info("Received %s, shutting down...", sig_name)
             drain_inflight(server, queue, drain_timeout)
             # Hard exit: the daemon's worker threads are non-daemon, so a
@@ -230,7 +232,9 @@ def run_daemon(
 
         logger.info(
             "Worker daemon starting on %s:%d (max_workers=%d)",
-            host, port, max_workers,
+            host,
+            port,
+            max_workers,
         )
         logger.info(
             "Storage: %s",
@@ -243,7 +247,8 @@ def run_daemon(
         server.start(blocking=False)
         logger.info(
             "Worker daemon started on %s:%d (non-blocking)",
-            host, port,
+            host,
+            port,
         )
 
     return server

--- a/src/movie_narrator/cloud/distributed.py
+++ b/src/movie_narrator/cloud/distributed.py
@@ -100,9 +100,7 @@ class NodeRegistry:
                 nodes = settings.distributed_nodes or ""
             if health_timeout is None:
                 health_timeout = settings.distributed_node_health_timeout
-        self._nodes: List[str] = [
-            url.strip() for url in nodes.split(",") if url.strip()
-        ]
+        self._nodes: List[str] = [url.strip() for url in nodes.split(",") if url.strip()]
         self._health_timeout = float(health_timeout)
         self._healthy: List[str] = []
         self._probed = False
@@ -143,9 +141,7 @@ class NodeRegistry:
         Returns:
             The currently healthy node base URLs.
         """
-        self._healthy = [
-            url for url in self._nodes if self._probe(url)
-        ]
+        self._healthy = [url for url in self._nodes if self._probe(url)]
         self._probed = True
         return list(self._healthy)
 
@@ -205,9 +201,7 @@ class DistributedRenderPlanner:
         self.enabled: bool = bool(enabled)
         self.min_render_seconds: float = float(min_render_seconds)
         self._injected_nodes = available_nodes is not None
-        self._nodes: List[str] = (
-            list(available_nodes) if available_nodes is not None else []
-        )
+        self._nodes: List[str] = list(available_nodes) if available_nodes is not None else []
         self._registry = node_registry
 
     # ── Public API ──────────────────────────────────────────
@@ -335,20 +329,14 @@ def render_task_dispatcher(
     try:
         task_id = queue.submit(render_only)
     except RemoteQueueError as e:
-        raise DistributedRenderError(
-            f"submit render subtask to {node} failed: {e}"
-        ) from e
+        raise DistributedRenderError(f"submit render subtask to {node} failed: {e}") from e
 
     try:
         result = queue.wait(task_id, timeout=timeout, poll_interval=poll_interval)
     except RemoteQueueError as e:
-        raise DistributedRenderError(
-            f"wait for render subtask {task_id} failed: {e}"
-        ) from e
+        raise DistributedRenderError(f"wait for render subtask {task_id} failed: {e}") from e
     if result is None or not result.succeeded:
-        raise DistributedRenderError(
-            f"render subtask {task_id} did not succeed"
-        )
+        raise DistributedRenderError(f"render subtask {task_id} did not succeed")
 
     dest = download_dir or "."
     if result.video_path:
@@ -363,9 +351,7 @@ def render_task_dispatcher(
                 api_key=api_key,
             )
         except RemoteQueueError as e:
-            raise DistributedRenderError(
-                f"download artifact from {node} failed: {e}"
-            ) from e
+            raise DistributedRenderError(f"download artifact from {node} failed: {e}") from e
         result.video_path = str(local_path)
     if result.audio_path:
         filename = Path(result.audio_path).name
@@ -379,8 +365,6 @@ def render_task_dispatcher(
                 api_key=api_key,
             )
         except RemoteQueueError as e:
-            raise DistributedRenderError(
-                f"download audio from {node} failed: {e}"
-            ) from e
+            raise DistributedRenderError(f"download audio from {node} failed: {e}") from e
         result.audio_path = str(local_path)
     return result

--- a/src/movie_narrator/cloud/dlq.py
+++ b/src/movie_narrator/cloud/dlq.py
@@ -87,9 +87,7 @@ class DeadLetterStore:
     """
 
     def __init__(self, storage_dir: Optional[Path] = None) -> None:
-        self.storage_dir = (
-            Path(storage_dir) if storage_dir else DEFAULT_DEADLETTER_DIR
-        )
+        self.storage_dir = Path(storage_dir) if storage_dir else DEFAULT_DEADLETTER_DIR
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self._lock = threading.RLock()
 
@@ -114,13 +112,9 @@ class DeadLetterStore:
         if not path.exists():
             return None
         try:
-            return DeadLetterRecord.model_validate_json(
-                path.read_text(encoding="utf-8")
-            )
+            return DeadLetterRecord.model_validate_json(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError, ValueError) as e:
-            logger.warning(
-                "Failed to load dead-letter record %s: %s", task_id, e
-            )
+            logger.warning("Failed to load dead-letter record %s: %s", task_id, e)
             return None
 
     def list(self) -> List[DeadLetterRecord]:

--- a/src/movie_narrator/cloud/health.py
+++ b/src/movie_narrator/cloud/health.py
@@ -327,8 +327,7 @@ def run_dependency_checks() -> Dict[str, Dict[str, Any]]:
     """
     targets = _dependency_targets()
     results: Dict[str, Dict[str, Any]] = {
-        name: _result(STATUS_SKIPPED, "not configured", 0.0)
-        for name in DEPENDENCY_NAMES
+        name: _result(STATUS_SKIPPED, "not configured", 0.0) for name in DEPENDENCY_NAMES
     }
     if not targets:
         return results
@@ -360,9 +359,7 @@ def run_dependency_checks() -> Dict[str, Dict[str, Any]]:
                 ok, detail = future.result()
             except Exception as e:  # noqa: BLE001 — probes must never raise
                 ok, detail = False, f"probe raised {type(e).__name__}: {e}"
-            results[name] = _result(
-                STATUS_PASS if ok else STATUS_FAIL, detail, elapsed_ms
-            )
+            results[name] = _result(STATUS_PASS if ok else STATUS_FAIL, detail, elapsed_ms)
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
 

--- a/src/movie_narrator/cloud/lifecycle.py
+++ b/src/movie_narrator/cloud/lifecycle.py
@@ -279,7 +279,7 @@ def cleanup_artifacts(
     # The ``keep_last_n`` newest artifacts are exempt from every rule.
     kept_recent: Set[str] = set()
     if policy.keep_last_n > 0:
-        kept_recent = {info.key for info in artifacts[-policy.keep_last_n:]}
+        kept_recent = {info.key for info in artifacts[-policy.keep_last_n :]}
 
     def _exempt(info: ArtifactInfo) -> bool:
         if info.key in guarded:

--- a/src/movie_narrator/cloud/metrics.py
+++ b/src/movie_narrator/cloud/metrics.py
@@ -82,7 +82,17 @@ HTTP_REQUESTS_TOTAL = "mn_http_requests_total"
 #: Bucket boundaries (seconds) tuned for end-to-end pipeline runs, which
 #: span from a few seconds (fully cached, no render) to tens of minutes.
 DEFAULT_DURATION_BUCKETS: Tuple[float, ...] = (
-    0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+    120.0,
+    300.0,
+    600.0,
+    1800.0,
 )
 
 _LabelKey = Tuple[str, ...]
@@ -98,11 +108,7 @@ def _escape_help(text: str) -> str:
 
 def _escape_label_value(value: str) -> str:
     """Escape a label value: backslash, double quote and newline."""
-    return (
-        value.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\n", "\\n")
-    )
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
 def _format_float(value: float) -> str:
@@ -129,8 +135,7 @@ def _render_labels(
 ) -> str:
     """Build the ``{k="v",...}`` suffix for a sample line."""
     parts = [
-        f'{name}="{_escape_label_value(value)}"'
-        for name, value in zip(label_names, label_values)
+        f'{name}="{_escape_label_value(value)}"' for name, value in zip(label_names, label_values)
     ]
     if extra is not None:
         parts.append(f'{extra[0]}="{_escape_label_value(extra[1])}"')
@@ -180,14 +185,10 @@ class _Metric:
         labels = labels or {}
         missing = set(self.label_names) - set(labels)
         if missing:
-            raise ValueError(
-                f"Metric {self.name!r} missing labels: {sorted(missing)}"
-            )
+            raise ValueError(f"Metric {self.name!r} missing labels: {sorted(missing)}")
         unexpected = set(labels) - set(self.label_names)
         if unexpected:
-            raise ValueError(
-                f"Metric {self.name!r} got unexpected labels: {sorted(unexpected)}"
-            )
+            raise ValueError(f"Metric {self.name!r} got unexpected labels: {sorted(unexpected)}")
         return tuple(str(labels[n]) for n in self.label_names)
 
     def render(self) -> List[str]:
@@ -383,16 +384,13 @@ class Histogram(_Metric):
         with self._lock:
             keys = sorted(self._counts)
             snapshot = {
-                key: (list(self._counts[key]), self._sums[key], self._totals[key])
-                for key in keys
+                key: (list(self._counts[key]), self._sums[key], self._totals[key]) for key in keys
             }
         lines: List[str] = []
         for key in keys:
             counts, total_sum, total_count = snapshot[key]
             for bound, cumulative in zip(self.buckets, counts):
-                suffix = _render_labels(
-                    self.label_names, key, extra=("le", _format_float(bound))
-                )
+                suffix = _render_labels(self.label_names, key, extra=("le", _format_float(bound)))
                 lines.append(f"{self.name}_bucket{suffix} {cumulative}")
             inf_suffix = _render_labels(self.label_names, key, extra=("le", "+Inf"))
             lines.append(f"{self.name}_bucket{inf_suffix} {total_count}")
@@ -434,8 +432,7 @@ class MetricsRegistry:
             if existing is not None:
                 if not isinstance(existing, cls):
                     raise ValueError(
-                        f"Metric {name!r} already registered as "
-                        f"{type(existing).__name__}"
+                        f"Metric {name!r} already registered as {type(existing).__name__}"
                     )
                 if existing.label_names != tuple(label_names):
                     raise ValueError(
@@ -479,9 +476,7 @@ class MetricsRegistry:
         buckets: Iterable[float] = DEFAULT_DURATION_BUCKETS,
     ) -> Histogram:
         """Get or create a Histogram."""
-        return self._get_or_create(
-            Histogram, name, help_text, label_names, buckets=buckets
-        )
+        return self._get_or_create(Histogram, name, help_text, label_names, buckets=buckets)
 
     def names(self) -> List[str]:
         """Sorted names of all registered metric families."""
@@ -586,9 +581,7 @@ def reset_registry() -> None:
 def record_task_submitted() -> None:
     """Count a task accepted into the queue."""
     try:
-        _registry.counter(TASKS_TOTAL, label_names=("status",)).inc(
-            labels={"status": "submitted"}
-        )
+        _registry.counter(TASKS_TOTAL, label_names=("status",)).inc(labels={"status": "submitted"})
     except Exception:  # noqa: BLE001 — telemetry must never break the caller
         logger.debug("Failed to record task submission metric", exc_info=True)
 
@@ -596,9 +589,7 @@ def record_task_submitted() -> None:
 def record_task_terminal(status: str) -> None:
     """Count a task reaching a terminal state (completed/failed/cancelled)."""
     try:
-        _registry.counter(TASKS_TOTAL, label_names=("status",)).inc(
-            labels={"status": status}
-        )
+        _registry.counter(TASKS_TOTAL, label_names=("status",)).inc(labels={"status": status})
     except Exception:  # noqa: BLE001 — telemetry must never break the caller
         logger.debug("Failed to record terminal task metric", exc_info=True)
 
@@ -661,9 +652,9 @@ def record_http_request(method: str, path: str, code: int) -> None:
         code: HTTP status code.
     """
     try:
-        _registry.counter(
-            HTTP_REQUESTS_TOTAL, label_names=("method", "path", "code")
-        ).inc(labels={"method": method, "path": path, "code": str(code)})
+        _registry.counter(HTTP_REQUESTS_TOTAL, label_names=("method", "path", "code")).inc(
+            labels={"method": method, "path": path, "code": str(code)}
+        )
     except Exception:  # noqa: BLE001 — telemetry must never break the caller
         logger.debug("Failed to record HTTP request metric", exc_info=True)
 

--- a/src/movie_narrator/cloud/models.py
+++ b/src/movie_narrator/cloud/models.py
@@ -134,18 +134,14 @@ class TaskRequest(BaseModel):
     @classmethod
     def _check_subtitle_mode(cls, v: Optional[str]) -> Optional[str]:
         if v is not None and v not in VALID_SUBTITLE_MODES:
-            raise ValueError(
-                f"subtitle_mode must be one of {sorted(VALID_SUBTITLE_MODES)}"
-            )
+            raise ValueError(f"subtitle_mode must be one of {sorted(VALID_SUBTITLE_MODES)}")
         return v
 
     @field_validator("lang")
     @classmethod
     def _check_lang(cls, v: str) -> str:
         if v not in SUPPORTED_LANGS:
-            raise ValueError(
-                f"lang must be one of {sorted(SUPPORTED_LANGS)}"
-            )
+            raise ValueError(f"lang must be one of {sorted(SUPPORTED_LANGS)}")
         return v
 
     @field_validator("log_level")
@@ -309,9 +305,7 @@ class Task(BaseModel):
                 if self.progress and self.progress.current_step
                 else "—"
             ),
-            "current_step": (
-                self.progress.current_step if self.progress else ""
-            ),
+            "current_step": (self.progress.current_step if self.progress else ""),
             "retries": self.retries,
             "created_at": self.created_at,
             "completed_at": self.completed_at or "",

--- a/src/movie_narrator/cloud/openapi.py
+++ b/src/movie_narrator/cloud/openapi.py
@@ -204,9 +204,7 @@ def _manual_schemas() -> Dict[str, Any]:
                         "`remote_storage`). Skipped unless "
                         "`MN_HEALTH_DEEP_DEPS=1`, and always skipped when `CI=1`."
                     ),
-                    "additionalProperties": {
-                        "$ref": "#/components/schemas/CheckResult"
-                    },
+                    "additionalProperties": {"$ref": "#/components/schemas/CheckResult"},
                 },
                 "duration_ms": {
                     "type": "number",
@@ -419,8 +417,7 @@ def _manual_schemas() -> Dict[str, Any]:
         "DeadLetterReplayed": {
             "type": "object",
             "description": (
-                "Acknowledgement returned by "
-                "`POST /deadletters/{id}/replay` (v0.9.4)."
+                "Acknowledgement returned by `POST /deadletters/{id}/replay` (v0.9.4)."
             ),
             "properties": {
                 "original_task_id": _string("ID of the dead-letter record."),
@@ -431,10 +428,7 @@ def _manual_schemas() -> Dict[str, Any]:
         },
         "DeadLetterRemoved": {
             "type": "object",
-            "description": (
-                "Acknowledgement returned by `DELETE /deadletters/{id}` "
-                "(v0.9.4)."
-            ),
+            "description": ("Acknowledgement returned by `DELETE /deadletters/{id}` (v0.9.4)."),
             "properties": {
                 "task_id": _string("ID of the removed record."),
                 "removed": {"type": "boolean", "description": "Always true."},
@@ -452,9 +446,7 @@ def _json_response(description: str, schema_name: str) -> Dict[str, Any]:
     return {
         "description": description,
         "content": {
-            "application/json": {
-                "schema": {"$ref": f"#/components/schemas/{schema_name}"}
-            }
+            "application/json": {"schema": {"$ref": f"#/components/schemas/{schema_name}"}}
         },
     }
 
@@ -543,9 +535,7 @@ def _paths() -> Dict[str, Any]:
                 "requestBody": {
                     "required": True,
                     "content": {
-                        "application/json": {
-                            "schema": {"$ref": "#/components/schemas/TaskRequest"}
-                        }
+                        "application/json": {"schema": {"$ref": "#/components/schemas/TaskRequest"}}
                     },
                 },
                 "responses": {
@@ -797,12 +787,8 @@ def _paths() -> Dict[str, Any]:
                                 "type": "object",
                                 "description": "Cron schedule creation payload.",
                                 "properties": {
-                                    "cron": _string(
-                                        "Standard 5-field cron expression."
-                                    ),
-                                    "task_request": {
-                                        "$ref": "#/components/schemas/TaskRequest"
-                                    },
+                                    "cron": _string("Standard 5-field cron expression."),
+                                    "task_request": {"$ref": "#/components/schemas/TaskRequest"},
                                     "enabled": {
                                         "type": "boolean",
                                         "description": "Start active (default true).",
@@ -914,9 +900,7 @@ def _paths() -> Dict[str, Any]:
                 "security": _secured(),
                 "parameters": [_task_id_param()],
                 "responses": {
-                    "201": _json_response(
-                        "Task accepted and queued.", "DeadLetterReplayed"
-                    ),
+                    "201": _json_response("Task accepted and queued.", "DeadLetterReplayed"),
                     "401": unauthorized,
                     "404": not_found,
                 },
@@ -928,7 +912,7 @@ def _paths() -> Dict[str, Any]:
                 "summary": "Health check",
                 "description": (
                     "Without a query string this returns the shallow "
-                    "`{\"status\": \"ok\"}` payload introduced in v0.6.1 — that "
+                    '`{"status": "ok"}` payload introduced in v0.6.1 — that '
                     "shape is frozen for backward compatibility. Pass "
                     "`?deep=1` for the full report. Exempt from authentication."
                 ),
@@ -949,8 +933,7 @@ def _paths() -> Dict[str, Any]:
                 "responses": {
                     "200": {
                         "description": (
-                            "Healthy, or degraded when only a dependency probe "
-                            "failed."
+                            "Healthy, or degraded when only a dependency probe failed."
                         ),
                         "content": {
                             "application/json": {
@@ -963,9 +946,7 @@ def _paths() -> Dict[str, Any]:
                             }
                         },
                     },
-                    "503": _json_response(
-                        "Deep check only: a core check failed.", "HealthDeep"
-                    ),
+                    "503": _json_response("Deep check only: a core check failed.", "HealthDeep"),
                 },
             },
         },

--- a/src/movie_narrator/cloud/queue.py
+++ b/src/movie_narrator/cloud/queue.py
@@ -309,9 +309,7 @@ class LocalTaskQueue:
         """
         # v0.9.2: a shutting-down queue must not accept new work.
         if self._shutting_down:
-            raise QueueShutdownError(
-                "TaskQueue has been shut down — not accepting new tasks"
-            )
+            raise QueueShutdownError("TaskQueue has been shut down — not accepting new tasks")
         if not self._started or not self._executor:
             raise RuntimeError("TaskQueue is not started. Call start() first.")
 
@@ -384,6 +382,7 @@ class LocalTaskQueue:
         # Task is pending but not yet running — mark as cancelled
         task.status = TaskStatus.CANCELLED
         from datetime import datetime, timezone
+
         task.completed_at = datetime.now(timezone.utc).isoformat()
         self._storage.save(task)
         # Task transitioned from active to terminal — update counter
@@ -508,7 +507,9 @@ class LocalTaskQueue:
             except Exception as e:  # noqa: BLE001 — one bad request must not abort the batch
                 logger.warning(
                     "Batch %s: member %d could not be submitted: %s",
-                    batch.batch_id, idx, e,
+                    batch.batch_id,
+                    idx,
+                    e,
                 )
                 submission_failures.append({"index": idx, "error": str(e)})
 
@@ -517,9 +518,7 @@ class LocalTaskQueue:
             meta = dict(request.metadata or {})
             meta["submission_failures"] = submission_failures
             batch.metadata = meta
-            batch.status = (
-                BatchStatus.FAILED if not submitted else BatchStatus.PARTIAL_FAILED
-            )
+            batch.status = BatchStatus.FAILED if not submitted else BatchStatus.PARTIAL_FAILED
         self._batch_storage.save(batch)
         return self._refresh_batch(batch)
 
@@ -598,6 +597,7 @@ class LocalTaskQueue:
             batch.status = BatchStatus.FAILED
             if batch.completed_at is None:
                 from datetime import datetime, timezone
+
                 batch.completed_at = datetime.now(timezone.utc).isoformat()
         elif total > 0 and missing > 0:
             # Some members never became tasks: the batch can never be fully
@@ -606,6 +606,7 @@ class LocalTaskQueue:
             batch.status = BatchStatus.PARTIAL_FAILED
             if active == 0 and batch.completed_at is None:
                 from datetime import datetime, timezone
+
                 batch.completed_at = datetime.now(timezone.utc).isoformat()
         elif total > 0 and terminal_or_missing == total:
             if completed == total:
@@ -616,6 +617,7 @@ class LocalTaskQueue:
                 batch.status = BatchStatus.PARTIAL_FAILED
             if batch.completed_at is None:
                 from datetime import datetime, timezone
+
                 batch.completed_at = datetime.now(timezone.utc).isoformat()
         elif active > 0:
             batch.status = BatchStatus.RUNNING
@@ -693,6 +695,7 @@ class LocalTaskQueue:
                     task.status = TaskStatus.FAILED
                     task.last_error = f"Worker thread error: {e}"
                     from datetime import datetime, timezone
+
                     task.completed_at = datetime.now(timezone.utc).isoformat()
                     self._storage.save(task)
             except (OSError, ValueError):
@@ -772,9 +775,7 @@ class LocalTaskQueue:
             observe_task_duration(duration)
             if task.status == TaskStatus.FAILED:
                 error_type = (
-                    task.result.error_type
-                    if task.result and task.result.error_type
-                    else "unknown"
+                    task.result.error_type if task.result and task.result.error_type else "unknown"
                 )
                 record_error(error_type)
             elif task.status == TaskStatus.DEAD:

--- a/src/movie_narrator/cloud/remote_provider.py
+++ b/src/movie_narrator/cloud/remote_provider.py
@@ -124,13 +124,9 @@ def download_artifact(
                         break
                     f.write(chunk)
     except urllib.error.HTTPError as e:
-        raise RemoteQueueError(
-            f"Download failed: HTTP {e.code} {e.reason}"
-        ) from e
+        raise RemoteQueueError(f"Download failed: HTTP {e.code} {e.reason}") from e
     except urllib.error.URLError as e:
-        raise RemoteQueueError(
-            f"Download failed: {e.reason}"
-        ) from e
+        raise RemoteQueueError(f"Download failed: {e.reason}") from e
 
     logger.info("Downloaded %s -> %s (%d bytes)", filename, out_path, out_path.stat().st_size)
     return out_path
@@ -149,9 +145,7 @@ def download_all_artifacts(
     Returns:
         A list of paths to downloaded files.
     """
-    artifacts = list_artifacts(
-        base_url, task_id, timeout=timeout, api_key=api_key
-    )
+    artifacts = list_artifacts(base_url, task_id, timeout=timeout, api_key=api_key)
     downloaded: List[Path] = []
     for artifact in artifacts:
         filename = artifact.get("filename", "")
@@ -159,8 +153,12 @@ def download_all_artifacts(
             continue
         try:
             path = download_artifact(
-                base_url, task_id, filename,
-                dest_dir=dest_dir, timeout=timeout, api_key=api_key,
+                base_url,
+                task_id,
+                filename,
+                dest_dir=dest_dir,
+                timeout=timeout,
+                api_key=api_key,
             )
             downloaded.append(path)
         except Exception as e:
@@ -205,6 +203,7 @@ def register_remote_llm(base_url: str, api_key: Optional[str] = None) -> None:
                 yield LLMClient(client=client, model="remote")
             finally:
                 http_client.close()
+
         return _cm()
 
     logger.info("Registered remote LLM provider: %s", base_url)
@@ -239,10 +238,13 @@ def register_remote_tts(base_url: str, api_key: Optional[str] = None) -> None:
         ) -> None:
             """(async) Synthesize speech from text."""
             import asyncio
-            payload = json.dumps({
-                "text": text,
-                "voice": voice,
-            }).encode("utf-8")
+
+            payload = json.dumps(
+                {
+                    "text": text,
+                    "voice": voice,
+                }
+            ).encode("utf-8")
             headers = {"Content-Type": "application/json"}
             if self._key:
                 headers["X-API-Key"] = self._key

--- a/src/movie_narrator/cloud/scheduler.py
+++ b/src/movie_narrator/cloud/scheduler.py
@@ -152,9 +152,7 @@ def _parse_cron_field(expr: str, lo: int, hi: int, name: str) -> CronField:
         if segment.startswith("*/"):
             step_str = segment[2:]
             if not step_str.isdigit() or int(step_str) <= 0:
-                raise ScheduleError(
-                    f"invalid step {step_str!r} in cron field {name!r}"
-                )
+                raise ScheduleError(f"invalid step {step_str!r} in cron field {name!r}")
             values.update(range(lo, hi + 1, int(step_str)))
             continue
         if "-" in segment:
@@ -163,32 +161,22 @@ def _parse_cron_field(expr: str, lo: int, hi: int, name: str) -> CronField:
             if "/" in segment:
                 range_part, step_str = segment.split("/", 1)
                 if not step_str.isdigit() or int(step_str) <= 0:
-                    raise ScheduleError(
-                        f"invalid step {step_str!r} in cron field {name!r}"
-                    )
+                    raise ScheduleError(f"invalid step {step_str!r} in cron field {name!r}")
                 step = int(step_str)
             if "-" not in range_part:
-                raise ScheduleError(
-                    f"invalid range {segment!r} in cron field {name!r}"
-                )
+                raise ScheduleError(f"invalid range {segment!r} in cron field {name!r}")
             start_s, end_s = range_part.split("-", 1)
             if not start_s.isdigit() or not end_s.isdigit():
-                raise ScheduleError(
-                    f"invalid range {segment!r} in cron field {name!r}"
-                )
+                raise ScheduleError(f"invalid range {segment!r} in cron field {name!r}")
             start, end = int(start_s), int(end_s)
             if start > end:
-                raise ScheduleError(
-                    f"range {segment!r} is reversed in cron field {name!r}"
-                )
+                raise ScheduleError(f"range {segment!r} is reversed in cron field {name!r}")
             _check_bounds(start, lo, hi, name)
             _check_bounds(end, lo, hi, name)
             values.update(range(start, end + 1, step))
             continue
         if not segment.isdigit():
-            raise ScheduleError(
-                f"invalid token {segment!r} in cron field {name!r}"
-            )
+            raise ScheduleError(f"invalid token {segment!r} in cron field {name!r}")
         value = int(segment)
         _check_bounds(value, lo, hi, name)
         values.add(value)
@@ -200,9 +188,7 @@ def _parse_cron_field(expr: str, lo: int, hi: int, name: str) -> CronField:
 def _check_bounds(value: int, lo: int, hi: int, name: str) -> None:
     """Validate a numeric cron field value against its bounds."""
     if value < lo or value > hi:
-        raise ScheduleError(
-            f"value {value} out of range {lo}-{hi} in cron field {name!r}"
-        )
+        raise ScheduleError(f"value {value} out of range {lo}-{hi} in cron field {name!r}")
 
 
 class CronExpression:
@@ -249,9 +235,7 @@ class CronExpression:
                 parts[2], *_FIELD_BOUNDS["day-of-month"], "day-of-month"
             ),
             month=_parse_cron_field(parts[3], *_FIELD_BOUNDS["month"], "month"),
-            day_of_week=_parse_cron_field(
-                parts[4], *_FIELD_BOUNDS["day-of-week"], "day-of-week"
-            ),
+            day_of_week=_parse_cron_field(parts[4], *_FIELD_BOUNDS["day-of-week"], "day-of-week"),
         )
 
     def _day_matches(self, date: date_type) -> bool:
@@ -299,14 +283,16 @@ class CronExpression:
             for hour in hours:
                 for minute in minutes:
                     candidate = datetime(
-                        date.year, date.month, date.day, hour, minute,
+                        date.year,
+                        date.month,
+                        date.day,
+                        hour,
+                        minute,
                         tzinfo=dt.tzinfo,
                     )
                     if candidate > dt:
                         return candidate
-        raise ScheduleError(
-            f"no next run time for cron expression within {_MAX_SCAN_DAYS} days"
-        )
+        raise ScheduleError(f"no next run time for cron expression within {_MAX_SCAN_DAYS} days")
 
 
 # ── JobScheduler ───────────────────────────────────────────
@@ -389,9 +375,7 @@ class JobScheduler:
             cron=cron,
             task_request=task_request,
             enabled=enabled,
-            next_run_at=expression.next_after(
-                now or datetime.now(timezone.utc)
-            ).isoformat(),
+            next_run_at=expression.next_after(now or datetime.now(timezone.utc)).isoformat(),
         )
         self._store.save(schedule)
         return schedule
@@ -432,9 +416,7 @@ class JobScheduler:
             daemon=True,
         )
         self._thread.start()
-        logger.info(
-            "Job scheduler started (poll interval %.1fs)", self._poll_interval
-        )
+        logger.info("Job scheduler started (poll interval %.1fs)", self._poll_interval)
 
     def stop(self) -> None:
         """Stop the scheduler loop and join the thread."""
@@ -486,9 +468,7 @@ class JobScheduler:
         except Exception as e:  # noqa: BLE001 — a failed trigger must not stop the loop
             status = "failed"
             error = str(e)
-            logger.warning(
-                "Schedule %s: job submission failed: %s", schedule.schedule_id, e
-            )
+            logger.warning("Schedule %s: job submission failed: %s", schedule.schedule_id, e)
 
         try:
             expression = CronExpression.parse(schedule.cron)
@@ -498,7 +478,8 @@ class JobScheduler:
             # it rather than erroring every cycle.
             logger.error(
                 "Schedule %s: invalid cron %r — disabling",
-                schedule.schedule_id, schedule.cron,
+                schedule.schedule_id,
+                schedule.cron,
             )
             schedule.enabled = False
         self._store.save(schedule)

--- a/src/movie_narrator/cloud/storage.py
+++ b/src/movie_narrator/cloud/storage.py
@@ -204,11 +204,7 @@ class TaskStorage:
             self._ensure_loaded()
             if status is None:
                 return len(self._cache)
-            return sum(
-                1
-                for v in self._cache.values()
-                if v.get("status") == status.value
-            )
+            return sum(1 for v in self._cache.values() if v.get("status") == status.value)
 
     # ── Bulk operations ──────────────────────────────────────
 
@@ -227,9 +223,7 @@ class TaskStorage:
                 TaskStatus.DEAD.value,
             }
             to_remove = [
-                tid
-                for tid, data in self._cache.items()
-                if data.get("status") in terminal_values
+                tid for tid, data in self._cache.items() if data.get("status") in terminal_values
             ]
             for tid in to_remove:
                 del self._cache[tid]

--- a/src/movie_narrator/cloud/worker.py
+++ b/src/movie_narrator/cloud/worker.py
@@ -114,9 +114,7 @@ class ProgressConsole(BaseConsole):
             try:
                 self._on_step_complete(name)
             except Exception:  # noqa: BLE001 — checkpointing must not break the pipeline
-                logger.debug(
-                    "Checkpoint callback failed for step %s", name, exc_info=True
-                )
+                logger.debug("Checkpoint callback failed for step %s", name, exc_info=True)
 
     def step(self, name: str) -> None:
         """Record the start of a pipeline step."""
@@ -214,6 +212,7 @@ def _build_output_dir(request: TaskRequest) -> Path:
         return Path(request.output_dir)
     # Default: ./output/<movie_name>_<task_id>
     from ..utils.sanitize import sanitize_filename
+
     safe_name = sanitize_filename(request.movie_name) or "movie"
     return Path("output") / safe_name
 
@@ -250,6 +249,7 @@ def _restore_context(
     ctx = Context(**context_dump)
     ctx.services = services
     from ..utils.cost_tracker import CostTracker
+
     ctx.cost_tracker = CostTracker()
     return ctx
 
@@ -301,9 +301,7 @@ def _route_to_dead_letter(task: Task) -> None:
         _dlq_store().save(record)
         task.status = TaskStatus.DEAD
     except Exception as e:  # noqa: BLE001 — DLQ is best-effort
-        logger.debug(
-            "Failed to write dead-letter record for %s: %s", task.id, e
-        )
+        logger.debug("Failed to write dead-letter record for %s: %s", task.id, e)
 
 
 # ── Conditional distributed rendering (v0.9.4) ─────────────
@@ -363,7 +361,8 @@ def _maybe_dispatch_render(
     except DistributedRenderError as e:
         logger.debug(
             "Distributed render to %s failed, falling back to local: %s",
-            node, e,
+            node,
+            e,
         )
         return None
 
@@ -391,9 +390,7 @@ def _apply_distributed_result(
         ctx.subtitle_path = result.subtitle_path
     ctx.metadata.setdefault("distributed_render", True)
 
-    render_index = next(
-        i for i, step in enumerate(STEPS) if step.__name__ == _RENDER_STEP
-    )
+    render_index = next(i for i, step in enumerate(STEPS) if step.__name__ == _RENDER_STEP)
     console.set_step_index(render_index)
     console.step_ok(_RENDER_STEP, elapsed)
 
@@ -458,32 +455,34 @@ def _execute_task(
             resume.start_step if resume.start_step else "<done>",
         )
     else:
-        ctx = build_context(**common_build_kwargs(
-            movie=request.movie_name,
-            style=request.style,
-            duration=request.duration,
-            voice=request.voice,
-            video_format=request.video_format,
-            output_dir=output_dir,
-            keep_cache=request.keep_cache,
-            video=request.video,
-            library_dir=request.library_dir,
-            research=request.research,
-            bgm=request.bgm,
-            no_bgm=request.no_bgm,
-            no_clips=request.no_clips,
-            strict=request.strict,
-            workflow_steps=request.workflow_steps,
-            params=request.params,
-            config_path=request.config_path,
-            subtitle_lang=request.subtitle_lang,
-            subtitle_mode=request.subtitle_mode,
-            services=services,
-            narration_preset=request.narration_preset,
-            lang=request.lang,
-            log_level=log_level,
-            verbose=request.verbose,
-        ))
+        ctx = build_context(
+            **common_build_kwargs(
+                movie=request.movie_name,
+                style=request.style,
+                duration=request.duration,
+                voice=request.voice,
+                video_format=request.video_format,
+                output_dir=output_dir,
+                keep_cache=request.keep_cache,
+                video=request.video,
+                library_dir=request.library_dir,
+                research=request.research,
+                bgm=request.bgm,
+                no_bgm=request.no_bgm,
+                no_clips=request.no_clips,
+                strict=request.strict,
+                workflow_steps=request.workflow_steps,
+                params=request.params,
+                config_path=request.config_path,
+                subtitle_lang=request.subtitle_lang,
+                subtitle_mode=request.subtitle_mode,
+                services=services,
+                narration_preset=request.narration_preset,
+                lang=request.lang,
+                log_level=log_level,
+                verbose=request.verbose,
+            )
+        )
 
     # v0.9.2: checkpoint hook — snapshot the context after each completed
     # step. The closure reads the current ``ctx`` (steps mutate it in
@@ -492,12 +491,14 @@ def _execute_task(
     if checkpoint_store is not None:
 
         def _write_checkpoint(step_name: str) -> None:
-            checkpoint_store.save(TaskCheckpoint(
-                task_id=task.id,
-                completed_step=step_name,
-                context_dump=ctx.model_dump(mode="json", exclude={"services", "cost_tracker"}),
-                attempt=attempt,
-            ))
+            checkpoint_store.save(
+                TaskCheckpoint(
+                    task_id=task.id,
+                    completed_step=step_name,
+                    context_dump=ctx.model_dump(mode="json", exclude={"services", "cost_tracker"}),
+                    attempt=attempt,
+                )
+            )
             progress.latest_checkpoint_step = step_name
             progress.checkpoint_updated_at = datetime.now(timezone.utc).isoformat()
 
@@ -510,9 +511,7 @@ def _execute_task(
         start_time=start_time,
         on_step_complete=_write_checkpoint if checkpoint_store is not None else _noop_checkpoint,
         initial_step_index=(
-            _step_index_of(resume.start_step)
-            if resume is not None and resume.start_step
-            else 0
+            _step_index_of(resume.start_step) if resume is not None and resume.start_step else 0
         ),
     )
     services.console = progress_console
@@ -542,9 +541,7 @@ def _execute_task(
             _apply_distributed_result(
                 ctx, distributed_result, progress_console, distributed_elapsed
             )
-            ctx = run_pipeline(
-                ctx, controller=controller, start_step=_step_after_render()
-            )
+            ctx = run_pipeline(ctx, controller=controller, start_step=_step_after_render())
             task.result = _extract_result(ctx, output_dir)
             task.status = TaskStatus.COMPLETED
             task.completed_at = datetime.now(timezone.utc).isoformat()
@@ -632,9 +629,7 @@ def run_task(
             try:
                 resume = checkpoint_store.resolve_resume(task.id)
             except Exception:  # noqa: BLE001 — checkpointing must never block a run
-                logger.debug(
-                    "Failed to resolve checkpoint for task %s", task.id, exc_info=True
-                )
+                logger.debug("Failed to resolve checkpoint for task %s", task.id, exc_info=True)
             if resume is not None and not resume.done:
                 logger.info(
                     "Task %s: resuming from checkpoint (start at '%s')",
@@ -658,9 +653,7 @@ def run_task(
                 try:
                     checkpoint_store.delete(task.id)
                 except Exception:  # noqa: BLE001 — best-effort cleanup
-                    logger.debug(
-                        "Failed to delete checkpoint for task %s", task.id, exc_info=True
-                    )
+                    logger.debug("Failed to delete checkpoint for task %s", task.id, exc_info=True)
             if on_status_change:
                 on_status_change(task)
             return task
@@ -679,18 +672,26 @@ def run_task(
             # Check if the original exception had retryable attribute
             # We stored the error type; check common retryable patterns
             retryable_types = {
-                "ConnectionError", "TimeoutError", "ConnectError",
-                "ReadTimeout", "WriteTimeout", "PoolTimeout",
-                "HTTPStatusError", "RateLimitError",
+                "ConnectionError",
+                "TimeoutError",
+                "ConnectError",
+                "ReadTimeout",
+                "WriteTimeout",
+                "PoolTimeout",
+                "HTTPStatusError",
+                "RateLimitError",
             }
             is_retryable = error_type in retryable_types
 
         if attempt < max_retries and is_retryable:
             # Wait with exponential backoff
-            delay = task.request.retry_delay * (2 ** attempt)
+            delay = task.request.retry_delay * (2**attempt)
             logger.info(
                 "Task %s: retrying in %.1fs (attempt %d/%d)",
-                task.id, delay, attempt + 1, max_retries,
+                task.id,
+                delay,
+                attempt + 1,
+                max_retries,
             )
             # Interruptible sleep
             if controller._event.wait(timeout=delay):

--- a/src/movie_narrator/config.py
+++ b/src/movie_narrator/config.py
@@ -19,9 +19,9 @@ _USER_ENV = _USER_DIR / ".env"
 # Package-level .env.example — single source of truth for default config.
 # At runtime we resolve it relative to this file so it works in editable
 # installs, wheels, and source checkouts alike.
-_PACKAGE_DIR = Path(__file__).resolve().parent          # src/movie_narrator/
-_SRC_DIR = _PACKAGE_DIR.parent                            # src/
-_PROJECT_ROOT = _SRC_DIR.parent                           # movie-narrator/
+_PACKAGE_DIR = Path(__file__).resolve().parent  # src/movie_narrator/
+_SRC_DIR = _PACKAGE_DIR.parent  # src/
+_PROJECT_ROOT = _SRC_DIR.parent  # movie-narrator/
 _EXAMPLE_ENV = _PROJECT_ROOT / ".env.example"
 
 
@@ -115,6 +115,7 @@ class Settings(BaseSettings):
     call params only. All pipeline behavior (scene, match, render, etc.)
     is configured via job.yaml params — see ``examples/job.example.yaml`` for defaults.
     """
+
     # ── API server / Remote inference (v0.8.0) ──
     # X-API-Key for authenticating the remote inference API server
     # (``mn serve``). When None, the API server runs unauthenticated —

--- a/src/movie_narrator/contract.py
+++ b/src/movie_narrator/contract.py
@@ -75,6 +75,7 @@ def check_version(required: tuple[int, int, int]) -> None:
             f"pip install -U movie-narrator"
         )
 
+
 # ── Re-exports: console abstraction ────────────────────────
 
 from .utils.console import BaseConsole, Console
@@ -499,6 +500,7 @@ from .reliability import (  # noqa: E402
     with_async_retry,
     with_retry,
 )
+
 # Cloud / task lifecycle (v0.9.2) — task checkpointing + graceful
 # shutdown. Backward compatible: existing exports are untouched.
 from .cloud import (  # noqa: E402
@@ -507,6 +509,7 @@ from .cloud import (  # noqa: E402
     ResumePlan,
     TaskCheckpoint,
 )
+
 # Cloud / batch & schedule (v0.9.3) — new exports, backward compatible.
 from .cloud import (  # noqa: E402
     Batch,
@@ -516,6 +519,7 @@ from .cloud import (  # noqa: E402
     ScheduleError,
     ScheduleRequest,
 )
+
 # Cloud / dead-letter queue + conditional distributed rendering (v0.9.4) —
 # new exports, backward compatible. TaskStatus was already exported with
 # the v0.6.0 Cloud / Task Queue group above.

--- a/src/movie_narrator/imitate.py
+++ b/src/movie_narrator/imitate.py
@@ -87,8 +87,11 @@ def _get_video_duration(video_path: str) -> float:
     """
     try:
         cmd = [
-            "ffprobe", "-v", "quiet",
-            "-print_format", "json",
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
             "-show_format",
             video_path,
         ]
@@ -137,10 +140,12 @@ def _count_scenes(video_path: str, threshold: float = 27.0) -> tuple[int, List[D
         scene_list = scene_manager.get_scene_list()
         scenes = []
         for start, end in scene_list:
-            scenes.append({
-                "start": start.get_seconds(),
-                "end": end.get_seconds(),
-            })
+            scenes.append(
+                {
+                    "start": start.get_seconds(),
+                    "end": end.get_seconds(),
+                }
+            )
         return len(scenes), scenes
     except ImportError:
         logger.warning("scenedetect not available — scene count will be 0")
@@ -173,11 +178,13 @@ def _transcribe_reference(
         for seg in segments_gen:
             text = seg.text.strip()
             if text:
-                segments.append({
-                    "start": seg.start,
-                    "end": seg.end,
-                    "text": text,
-                })
+                segments.append(
+                    {
+                        "start": seg.start,
+                        "end": seg.end,
+                        "text": text,
+                    }
+                )
         return len(segments), segments
     except ImportError:
         pass
@@ -195,17 +202,16 @@ def _transcribe_reference(
             for seg in result["segments"]:
                 text = seg.get("text", "").strip()
                 if text:
-                    segments.append({
-                        "start": seg.get("start", 0.0),
-                        "end": seg.get("end", 0.0),
-                        "text": text,
-                    })
+                    segments.append(
+                        {
+                            "start": seg.get("start", 0.0),
+                            "end": seg.get("end", 0.0),
+                            "text": text,
+                        }
+                    )
         return len(segments), segments
     except ImportError:
-        logger.warning(
-            "Neither whisperx nor faster-whisper available — "
-            "sentence count will be 0"
-        )
+        logger.warning("Neither whisperx nor faster-whisper available — sentence count will be 0")
         return 0, []
     except Exception as e:
         logger.warning(f"Transcription failed: {e}")
@@ -257,9 +263,7 @@ def analyze_reference(
         metrics.sentence_count / duration_min if duration_min > 0 else 0.0
     )
     metrics.avg_segment_duration = (
-        metrics.duration_sec / metrics.sentence_count
-        if metrics.sentence_count > 0
-        else 0.0
+        metrics.duration_sec / metrics.sentence_count if metrics.sentence_count > 0 else 0.0
     )
 
     # Save raw data if output_dir is provided
@@ -319,9 +323,7 @@ def metrics_to_params(metrics: ReferenceMetrics) -> Dict[str, Any]:
         target_sentences = max(8, min(30, target_sentences))  # clamp
 
         params["prompt_target_sentences"] = target_sentences
-        params["prompt_target_segment_duration"] = round(
-            target_duration / target_sentences, 2
-        )
+        params["prompt_target_segment_duration"] = round(target_duration / target_sentences, 2)
         # Max chars per sentence based on avg segment duration
         # Shorter segments = fewer chars
         if metrics.avg_segment_duration > 0:

--- a/src/movie_narrator/models.py
+++ b/src/movie_narrator/models.py
@@ -25,6 +25,7 @@ class MetadataDict(TypedDict, total=False):
     All keys are optional (total=False).  Provides IDE autocompletion and
     static-analysis catch for typos — zero runtime overhead.
     """
+
     # Pipeline I/O
     voice: str
     video_format: str
@@ -344,6 +345,7 @@ class SubtitlePaths(BaseModel):
       (or degraded-with-originals — same on-disk content, but the field
       is still set so render_subtitle_path resolution can pick the track).
     """
+
     original: str
     translated: Optional[str] = None
     bilingual: Optional[str] = None
@@ -373,6 +375,7 @@ class MovieCard(BaseModel):
     read it is unaffected. When the research step is skipped or fails,
     the card is simply absent from ``ctx.metadata["movie_card"]``.
     """
+
     title: str
     year: Optional[str] = None
     genres: List[str] = Field(default_factory=list)
@@ -403,7 +406,9 @@ class MatchedClip(BaseModel):
     src_end: float
     score: float
     scene_index: Optional[int] = None
-    source: Literal["scene", "heuristic", "embedding", "embedding_topk", "embedding_top1", "fallback"] = "fallback"
+    source: Literal[
+        "scene", "heuristic", "embedding", "embedding_topk", "embedding_top1", "fallback"
+    ] = "fallback"
     # v0.5.11: per-dimension quality scores for composite scoring.
     # None for heuristic clips where no embedding/rhythm data exists.
     embedding_score: Optional[float] = None

--- a/src/movie_narrator/pipeline/_align_backend.py
+++ b/src/movie_narrator/pipeline/_align_backend.py
@@ -142,9 +142,11 @@ def transcribe_with_faster_whisper(
     for seg in segments:
         text = seg.text.strip()
         if text:
-            wx_segments.append({
-                "start": float(seg.start),
-                "end": float(seg.end),
-                "text": text,
-            })
+            wx_segments.append(
+                {
+                    "start": float(seg.start),
+                    "end": float(seg.end),
+                    "text": text,
+                }
+            )
     return wx_segments

--- a/src/movie_narrator/pipeline/align.py
+++ b/src/movie_narrator/pipeline/align.py
@@ -153,9 +153,7 @@ def align_audio(ctx: Context) -> Context:
     ctx.metadata["align_backend_reason"] = backend_reason
 
     if backend == "none":
-        ctx.services.console.inline_warn(
-            f"Audio alignment unavailable: {backend_reason}"
-        )
+        ctx.services.console.inline_warn(f"Audio alignment unavailable: {backend_reason}")
         ctx.status.align = "disabled"
         ctx.step_state.result = StepResult.SKIPPED
         ctx.step_state.message = backend_reason
@@ -168,12 +166,8 @@ def align_audio(ctx: Context) -> Context:
             return _align_with_whisperx(ctx)
     except BackendUnavailable as e:
         # faster-whisper was selected but failed at runtime — try whisperx
-        ctx.services.console.inline_warn(
-            f"faster-whisper failed ({e}); trying whisperx"
-        )
-        ctx.metadata.setdefault("align_backend_attempted", []).append(
-            f"faster_whisper: {e}"
-        )
+        ctx.services.console.inline_warn(f"faster-whisper failed ({e}); trying whisperx")
+        ctx.metadata.setdefault("align_backend_attempted", []).append(f"faster_whisper: {e}")
         try:
             return _align_with_whisperx(ctx)
         except Exception as fallback_err:
@@ -196,16 +190,13 @@ def _align_with_whisperx(ctx: Context) -> Context:
         device = ctx.metadata.get("whisperx_device", "cpu")
         language = ctx.metadata.get("whisperx_language", "zh")
         audio = whisperx.load_audio(ctx.audio_path)
-        model = whisperx.load_model(
-            ctx.metadata.get("whisperx_model", "medium"), device=device
-        )
+        model = whisperx.load_model(ctx.metadata.get("whisperx_model", "medium"), device=device)
         result = model.transcribe(audio, language=language)
 
         if not result or "segments" not in result or not result["segments"]:
             # ── Empty ASR → skipped (not success) ──
             ctx.services.console.inline_warn(
-                "WhisperX returned no speech segments; "
-                "timestamps remain TTS-estimated"
+                "WhisperX returned no speech segments; timestamps remain TTS-estimated"
             )
             ctx.status.align = "skipped"
             ctx.step_state.result = StepResult.WARNING
@@ -219,12 +210,8 @@ def _align_with_whisperx(ctx: Context) -> Context:
         # v0.5.11: preserve word-level segments for sub-segment precision.
         word_segments_data: list[dict] = []
         try:
-            model_a, metadata = whisperx.load_align_model(
-                language_code=language, device=device
-            )
-            result = whisperx.align(
-                result["segments"], model_a, metadata, audio, device=device
-            )
+            model_a, metadata = whisperx.load_align_model(language_code=language, device=device)
+            result = whisperx.align(result["segments"], model_a, metadata, audio, device=device)
             # v0.5.11: Extract word-level segments from align result
             word_segments_data = extract_word_segments(result)
         except Exception as align_err:
@@ -259,8 +246,7 @@ def _align_with_whisperx(ctx: Context) -> Context:
 
         if not wx_segments:
             ctx.services.console.inline_warn(
-                "WhisperX alignment produced no usable segments; "
-                "timestamps remain TTS-estimated"
+                "WhisperX alignment produced no usable segments; timestamps remain TTS-estimated"
             )
             ctx.status.align = "skipped"
             ctx.step_state.result = StepResult.WARNING
@@ -279,12 +265,8 @@ def _align_with_whisperx(ctx: Context) -> Context:
         # Assign word-level timestamps to timed segments, then apply
         # word-level remapping for sub-segment precision.
         if word_segments_data:
-            assigned = assign_words_to_segments(
-                ctx.timed_segments, word_segments_data, wx_segments
-            )
-            tightened = word_level_remap(
-                ctx.timed_segments, word_segments_data
-            )
+            assigned = assign_words_to_segments(ctx.timed_segments, word_segments_data, wx_segments)
+            tightened = word_level_remap(ctx.timed_segments, word_segments_data)
             ctx.metadata["align_word_segments"] = len(word_segments_data)
             ctx.metadata["align_words_assigned"] = assigned
             ctx.metadata["align_word_tightened"] = tightened
@@ -328,8 +310,7 @@ def _align_with_faster_whisper(ctx: Context) -> Context:
 
     if not wx_segments:
         ctx.services.console.inline_warn(
-            "faster-whisper returned no speech segments; "
-            "timestamps remain TTS-estimated"
+            "faster-whisper returned no speech segments; timestamps remain TTS-estimated"
         )
         ctx.status.align = "skipped"
         ctx.step_state.result = StepResult.WARNING

--- a/src/movie_narrator/pipeline/bgm.py
+++ b/src/movie_narrator/pipeline/bgm.py
@@ -31,9 +31,7 @@ def _export_robust(seg: AudioSegment, out: Path) -> str:
         seg.export(out, format="mp3")
         return str(out)
     except Exception:
-        logger.debug(
-            "MP3 export failed for %s, falling back to WAV", out, exc_info=True
-        )
+        logger.debug("MP3 export failed for %s, falling back to WAV", out, exc_info=True)
         wav_out = out.with_suffix(".wav")
         seg.export(wav_out, format="wav")
         return str(wav_out)
@@ -154,9 +152,7 @@ def _score_bgm_candidate(sample: dict, emotion_profile: dict[str, float]) -> flo
 
     # Energy alignment: compute the narration's weighted average energy
     # and compare it to the BGM's energy field. Closer = better.
-    narration_energy = sum(
-        _EMOTION_ENERGY.get(e, 0.5) * f for e, f in emotion_profile.items()
-    )
+    narration_energy = sum(_EMOTION_ENERGY.get(e, 0.5) * f for e, f in emotion_profile.items())
     bgm_energy = sample.get("energy")
     if isinstance(bgm_energy, (int, float)) and 0.0 <= bgm_energy <= 1.0:
         energy_diff = abs(narration_energy - float(bgm_energy))
@@ -202,9 +198,7 @@ def select_bgm_by_emotion(ctx: Context) -> Optional[str]:
         metadata_path = Path(metadata_path_str)
     else:
         # Default to the packaged template alongside this package.
-        metadata_path = (
-            Path(__file__).resolve().parent.parent / "assets" / "bgm_metadata.yaml"
-        )
+        metadata_path = Path(__file__).resolve().parent.parent / "assets" / "bgm_metadata.yaml"
     if not metadata_path.is_file():
         return None
 
@@ -293,12 +287,14 @@ def _detect_emotion_zones(
     for i in range(1, len(timed_segments)):
         emo = segment_emotions[i] if i < len(segment_emotions) else None
         if emo != current_emotion:
-            zones.append({
-                "start": round(current_start, 3),
-                "end": round(timed_segments[i].start, 3),
-                "emotion": current_emotion,
-                "segment_range": [current_indices[0], current_indices[-1]],
-            })
+            zones.append(
+                {
+                    "start": round(current_start, 3),
+                    "end": round(timed_segments[i].start, 3),
+                    "emotion": current_emotion,
+                    "segment_range": [current_indices[0], current_indices[-1]],
+                }
+            )
             current_emotion = emo
             current_start = timed_segments[i].start
             current_indices = [i]
@@ -306,12 +302,14 @@ def _detect_emotion_zones(
             current_indices.append(i)
 
     # Final zone
-    zones.append({
-        "start": round(current_start, 3),
-        "end": round(timed_segments[-1].end, 3),
-        "emotion": current_emotion,
-        "segment_range": [current_indices[0], current_indices[-1]],
-    })
+    zones.append(
+        {
+            "start": round(current_start, 3),
+            "end": round(timed_segments[-1].end, 3),
+            "emotion": current_emotion,
+            "segment_range": [current_indices[0], current_indices[-1]],
+        }
+    )
     return zones
 
 
@@ -367,14 +365,8 @@ def _apply_emotion_transitions(
             )
             if transition_samples > 0:
                 prev_emotion = zones[i - 1].get("emotion")
-                prev_gain_db = (
-                    _EMOTION_BGM_GAIN.get(prev_emotion, 0.0)
-                    if prev_emotion else 0.0
-                )
-                prev_factor = (
-                    float(db_to_float(prev_gain_db))
-                    if prev_gain_db != 0.0 else 1.0
-                )
+                prev_gain_db = _EMOTION_BGM_GAIN.get(prev_emotion, 0.0) if prev_emotion else 0.0
+                prev_factor = float(db_to_float(prev_gain_db)) if prev_gain_db != 0.0 else 1.0
 
                 ramp_start = max(0, start_sample - transition_samples)
                 ramp_len = start_sample - ramp_start
@@ -382,12 +374,14 @@ def _apply_emotion_transitions(
                     ramp = np.linspace(prev_factor, gain_factor, ramp_len)
                     envelope[ramp_start:start_sample] = ramp
 
-                transitions.append({
-                    "position_s": zone["start"],
-                    "from_emotion": prev_emotion,
-                    "to_emotion": emotion,
-                    "transition_ms": transition_ms,
-                })
+                transitions.append(
+                    {
+                        "position_s": zone["start"],
+                        "from_emotion": prev_emotion,
+                        "to_emotion": emotion,
+                        "transition_ms": transition_ms,
+                    }
+                )
 
     # Apply envelope to BGM samples
     raw = np.array(bgm.get_array_of_samples(), dtype=np.float64)
@@ -497,9 +491,7 @@ def mix_bgm(ctx: Context) -> Context:
         # v0.5.9: BGM dynamic transition — adjust BGM gain per emotion zone
         # with smooth ramps at zone boundaries to avoid abrupt mood changes.
         beats_meta = ctx.metadata.get("beats_meta") or []
-        segment_emotions = map_segment_emotions(
-            len(ctx.timed_segments), beats_meta
-        )
+        segment_emotions = map_segment_emotions(len(ctx.timed_segments), beats_meta)
         zones = _detect_emotion_zones(ctx.timed_segments, segment_emotions)
         if zones and len(zones) > 1:
             bgm_raw, transitions = _apply_emotion_transitions(bgm_raw, zones)
@@ -507,8 +499,10 @@ def mix_bgm(ctx: Context) -> Context:
                 ctx.metadata["bgm_transitions"] = transitions
 
         mixed = duck_bgm(
-            narration, bgm_raw,
-            bgm_gain_db=gain_db, duck_db=duck_db,
+            narration,
+            bgm_raw,
+            bgm_gain_db=gain_db,
+            duck_db=duck_db,
         )
         do_norm = ctx.metadata.get("bgm_normalize", True)
         if do_norm:
@@ -527,15 +521,14 @@ def mix_bgm(ctx: Context) -> Context:
             ambient_gain = ctx.metadata.get("bgm_ambient_gain_db", -12.0)
             ambient_duck = ctx.metadata.get("bgm_duck_db", -10.0)
             mixed, ambient_info = _mix_ambient_track(
-                mixed, ambient_path,
+                mixed,
+                ambient_path,
                 ambient_gain_db=ambient_gain,
                 duck_db=ambient_duck,
                 timed_segments=ctx.timed_segments,
             )
             if "error" in ambient_info:
-                ctx.services.console.inline_warn(
-                    f"Ambient track skipped: {ambient_info['error']}"
-                )
+                ctx.services.console.inline_warn(f"Ambient track skipped: {ambient_info['error']}")
             else:
                 ctx.metadata["ambient_track"] = ambient_info
                 ctx.services.console.debug(

--- a/src/movie_narrator/pipeline/export_clips.py
+++ b/src/movie_narrator/pipeline/export_clips.py
@@ -67,13 +67,20 @@ def export_clips(ctx: Context) -> Context:
             # so MoviePy adds unnecessary overhead.  Direct subprocess gives
             # precise control over codec params, timeout, and error handling.
             cmd = [
-                ffmpeg, "-y",
-                "-ss", str(scene.start),
-                "-to", str(scene.end),
-                "-i", ctx.source_video_path,
-                "-c:v", video_codec,
-                "-c:a", audio_codec,
-                "-movflags", "+faststart",
+                ffmpeg,
+                "-y",
+                "-ss",
+                str(scene.start),
+                "-to",
+                str(scene.end),
+                "-i",
+                ctx.source_video_path,
+                "-c:v",
+                video_codec,
+                "-c:a",
+                audio_codec,
+                "-movflags",
+                "+faststart",
                 str(clip_path),
             ]
             result = subprocess.run(

--- a/src/movie_narrator/pipeline/match.py
+++ b/src/movie_narrator/pipeline/match.py
@@ -14,7 +14,9 @@ from typing import Any, List, Optional, Tuple, cast
 from ..models import Context, MatchedClip, Scene, StepResult
 from ..utils.optional_deps import probe
 
-_EMBEDDING_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"  # default, overridden by ctx.metadata
+_EMBEDDING_MODEL_NAME = (
+    "paraphrase-multilingual-MiniLM-L12-v2"  # default, overridden by ctx.metadata
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +103,7 @@ def _transcribe_video_audio(
     # Fallback: faster-whisper (works on Windows CPU where k2-fsa missing)
     try:
         from ._align_backend import transcribe_with_faster_whisper
+
         segments = transcribe_with_faster_whisper(
             audio_path=video_path,
             device=device,
@@ -140,10 +143,7 @@ def _build_scene_captions(
         (eliminates fragile startswith("scene ") heuristic).
     """
     if not transcript:
-        return [
-            (_build_scene_label(s.index, s.start, s.end), True)
-            for s in scenes
-        ]
+        return [(_build_scene_label(s.index, s.start, s.end), True) for s in scenes]
 
     labels: List[Tuple[str, bool]] = []
     for scene in scenes:
@@ -160,9 +160,7 @@ def _build_scene_captions(
             labels.append((caption, False))
         else:
             # No speech in this scene — use placeholder
-            labels.append(
-                (_build_scene_label(scene.index, scene.start, scene.end), True)
-            )
+            labels.append((_build_scene_label(scene.index, scene.start, scene.end), True))
 
     return labels
 
@@ -238,9 +236,7 @@ def _cosine_top1(target_vec, candidate_matrix) -> int:
     return int(sims.argmax())
 
 
-def _cosine_topk(
-    target_vec, candidate_matrix, k: int = 5
-) -> list[tuple[int, float]]:
+def _cosine_topk(target_vec, candidate_matrix, k: int = 5) -> list[tuple[int, float]]:
     """
     Returns:
         Top-K candidates as ``(local_index, score)`` sorted by score descending.
@@ -311,9 +307,7 @@ def _greedy_topk_assign(
         # Determine candidate pool
         if use_weighted_acts and act_assignments and act_scenes and act_weights:
             act_idx = act_assignments[i]
-            cand_indices = _get_act_candidate_indices(
-                act_idx, len(act_weights), act_scenes
-            )
+            cand_indices = _get_act_candidate_indices(act_idx, len(act_weights), act_scenes)
             cand_indices = [idx for idx in cand_indices if idx < n_scenes]
             if not cand_indices:
                 cand_indices = list(range(n_scenes))
@@ -553,11 +547,13 @@ def _apply_diversity(
         matched_clips[i].src_start = clamped_start
         matched_clips[i].src_end = clamped_end
         swaps += 1
-        swaps_log.append({
-            "segment_index": matched_clips[i].segment_index,
-            "old_scene": old_scene,
-            "new_scene": best_scene.index,
-        })
+        swaps_log.append(
+            {
+                "segment_index": matched_clips[i].segment_index,
+                "old_scene": old_scene,
+                "new_scene": best_scene.index,
+            }
+        )
 
     return swaps, swaps_log
 
@@ -825,7 +821,9 @@ def _match_clips_impl(
     match_texts = _resolve_match_texts(ctx)
     if ctx.translated_texts and len(ctx.translated_texts) == len(ctx.timed_segments):
         ctx.metadata["match_text_source"] = "translated"
-        ctx.metadata["match_lang"] = ctx.metadata.get("subtitle_lang", ctx.metadata.get("lang", "zh"))
+        ctx.metadata["match_lang"] = ctx.metadata.get(
+            "subtitle_lang", ctx.metadata.get("lang", "zh")
+        )
     else:
         ctx.metadata["match_text_source"] = "narration"
         ctx.metadata["match_lang"] = ctx.metadata.get("lang", "zh")
@@ -873,9 +871,7 @@ def _match_clips_impl(
 
     dark_luma = ctx.metadata.get("match_drop_dark_luma", 0.0)
     if dark_luma > 0:
-        scenes, dark_dropped = filter_dark_scenes(
-            scenes, ctx.source_video_path, dark_luma
-        )
+        scenes, dark_dropped = filter_dark_scenes(scenes, ctx.source_video_path, dark_luma)
         if dark_dropped:
             ctx.services.console.debug(
                 f"  dark drop: removed {dark_dropped} scenes "
@@ -911,18 +907,14 @@ def _match_clips_impl(
     timeline_mode = ctx.metadata.get("match_timeline_mode", "uniform")
     act_weights = ctx.metadata.get("match_act_weights", list(_DEFAULT_ACT_WEIGHTS))
     use_weighted_acts = (
-        timeline_mode == "weighted_acts"
-        and len(scenes) >= 8
-        and len(ctx.timed_segments) >= 4
+        timeline_mode == "weighted_acts" and len(scenes) >= 8 and len(ctx.timed_segments) >= 4
     )
     # Top-K rerank params
     topk = ctx.metadata.get("match_topk", 5)
     reuse_penalty = ctx.metadata.get("match_topk_reuse_penalty", 0.15)
     if use_weighted_acts:
         act_scenes = _partition_scenes_by_act(scenes, n_acts=len(act_weights))
-        act_assignments = _assign_segments_to_acts(
-            len(ctx.timed_segments), act_weights
-        )
+        act_assignments = _assign_segments_to_acts(len(ctx.timed_segments), act_weights)
         ctx.services.console.debug(
             f"  weighted_acts: {len(act_weights)} acts, "
             f"segments per act: {[act_assignments.count(a) for a in range(len(act_weights))]}"
@@ -946,14 +938,11 @@ def _match_clips_impl(
     # uniform narration-position mapping for improving D2 (scene-dialogue
     # relevance). Priority: beat anchor > weighted acts > uniform.
     beats_meta = ctx.metadata.get("beats_meta", [])
-    use_beat_anchor = (
-        len(beats_meta) == len(ctx.timed_segments)
-        and any(bm.get("approx_ratio") is not None for bm in beats_meta)
+    use_beat_anchor = len(beats_meta) == len(ctx.timed_segments) and any(
+        bm.get("approx_ratio") is not None for bm in beats_meta
     )
     if use_beat_anchor:
-        n_with_ratio = sum(
-            1 for bm in beats_meta if bm.get("approx_ratio") is not None
-        )
+        n_with_ratio = sum(1 for bm in beats_meta if bm.get("approx_ratio") is not None)
         ctx.services.console.debug(
             f"  beat anchor: {n_with_ratio}/{len(beats_meta)} "
             f"segments have approx_ratio — using beat-based time anchoring"
@@ -1100,14 +1089,11 @@ def _match_clips_impl(
             if vision_provider != "none":
                 try:
                     from ..vision import get_vision_captioner
+
                     captioner = get_vision_captioner(vision_provider)
-                    vision_labels = captioner.caption_scenes(
-                        scenes, ctx.source_video_path
-                    )
+                    vision_labels = captioner.caption_scenes(scenes, ctx.source_video_path)
                     is_stub = vision_provider == "stub"
-                    scene_captions = [
-                        (label, is_stub) for label in vision_labels
-                    ]
+                    scene_captions = [(label, is_stub) for label in vision_labels]
                     ctx.services.console.debug(
                         f"  vision captioner ({vision_provider}): "
                         f"{len(scene_captions)} captions, "
@@ -1115,8 +1101,7 @@ def _match_clips_impl(
                     )
                 except Exception as ve:
                     ctx.services.console.debug(
-                        f"  vision captioner failed ({ve}); "
-                        f"using audio-transcript captions"
+                        f"  vision captioner failed ({ve}); using audio-transcript captions"
                     )
                     logger.debug("vision captioner failed", exc_info=True)
 
@@ -1142,8 +1127,10 @@ def _match_clips_impl(
                     f"Install WhisperX with: pip install 'movie-narrator[ml]'"
                 )
                 ctx.metadata["match_captions_fake"] = True
-                final = cast(List[Tuple[dict[str, Any], float, Optional[Scene], str]],
-                         [(h, 1.0, None, "heuristic") for h in heuristic])
+                final = cast(
+                    List[Tuple[dict[str, Any], float, Optional[Scene], str]],
+                    [(h, 1.0, None, "heuristic") for h in heuristic],
+                )
             else:
                 ctx.metadata["match_captions_fake"] = False
                 emb_model = ctx.metadata.get("embedding_model_name", _EMBEDDING_MODEL_NAME)
@@ -1181,11 +1168,15 @@ def _match_clips_impl(
                 f"embedding re-rank unavailable ({e}); using heuristic"
             )
             logger.debug("embedding re-rank failed", exc_info=True)
-            final = cast(List[Tuple[dict[str, Any], float, Optional[Scene], str]],
-                         [(h, 1.0, None, "heuristic") for h in heuristic])
+            final = cast(
+                List[Tuple[dict[str, Any], float, Optional[Scene], str]],
+                [(h, 1.0, None, "heuristic") for h in heuristic],
+            )
     else:
-        final = cast(List[Tuple[dict[str, Any], float, Optional[Scene], str]],
-                     [(h, 1.0, None, "heuristic") for h in heuristic])
+        final = cast(
+            List[Tuple[dict[str, Any], float, Optional[Scene], str]],
+            [(h, 1.0, None, "heuristic") for h in heuristic],
+        )
 
     # --- Build matched clips with speed clamp -------------------------------
     matched_clips = []
@@ -1242,7 +1233,8 @@ def _match_clips_impl(
     # more than match_max_scene_reuse times within match_diversity_window
     # segments, swap later occurrences to the nearest unused scene.
     diversity_swaps, diversity_swaps_log = _apply_diversity(
-        matched_clips, scenes,
+        matched_clips,
+        scenes,
         window=ctx.metadata.get("match_diversity_window", 3),
         max_reuse=ctx.metadata.get("match_max_scene_reuse", 2),
     )
@@ -1299,14 +1291,12 @@ def _match_clips_impl(
         if speed_factors:
             ctx.services.console.debug(
                 f"  speed factors: min={min(speed_factors):.2f}x max={max(speed_factors):.2f}x "
-                f"avg={sum(speed_factors)/len(speed_factors):.2f}x (clamp={clamp_min}~{clamp_max}x)"
+                f"avg={sum(speed_factors) / len(speed_factors):.2f}x (clamp={clamp_min}~{clamp_max}x)"
             )
 
     matches_path = output_dir / "matches.json"
     matches_path.write_text(
-        json.dumps(
-            [m.model_dump() for m in matched_clips], ensure_ascii=False, indent=2
-        ),
+        json.dumps([m.model_dump() for m in matched_clips], ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
 
@@ -1316,8 +1306,7 @@ def _match_clips_impl(
     # Schema per CORE_ENGINE_TREATMENT_PLAN §5.2.3.
     # Sources can be "embedding_topk", "embedding_top1", or "heuristic"
     embedding_count = sum(
-        1 for mc in matched_clips
-        if mc.source in ("embedding", "embedding_topk", "embedding_top1")
+        1 for mc in matched_clips if mc.source in ("embedding", "embedding_topk", "embedding_top1")
     )
     heuristic_count = sum(1 for mc in matched_clips if mc.source == "heuristic")
     topk_count = sum(1 for mc in matched_clips if mc.source == "embedding_topk")
@@ -1327,7 +1316,8 @@ def _match_clips_impl(
     # score stats: only for source==embedding clips that were adopted
     # (i.e. did NOT fall back to heuristic due to low score)
     adopted_embedding_scores = [
-        mc.score for mc in matched_clips
+        mc.score
+        for mc in matched_clips
         if mc.source in ("embedding", "embedding_topk", "embedding_top1")
     ]
 
@@ -1397,19 +1387,26 @@ def _match_clips_impl(
         },
         "timeline": {
             "mode": (
-                "beat_anchor" if use_beat_anchor
-                else "weighted_acts" if use_weighted_acts
+                "beat_anchor"
+                if use_beat_anchor
+                else "weighted_acts"
+                if use_weighted_acts
                 else "uniform"
             ),
             "beat_anchor": use_beat_anchor,
             "beat_anchored_count": (
                 sum(1 for bm in beats_meta if bm.get("approx_ratio") is not None)
-                if use_beat_anchor else 0
+                if use_beat_anchor
+                else 0
             ),
             "act_weights": act_weights if use_weighted_acts else None,
             "segments_per_act": (
-                [cast(list[int], act_assignments).count(a) for a in range(len(cast(list[float], act_weights)))]
-                if use_weighted_acts else None
+                [
+                    cast(list[int], act_assignments).count(a)
+                    for a in range(len(cast(list[float], act_weights)))
+                ]
+                if use_weighted_acts
+                else None
             ),
         },
         "topk": {
@@ -1419,10 +1416,7 @@ def _match_clips_impl(
             "top1_count": top1_count,
         },
         "rhythm_scoring": {
-            "enabled": any(
-                bm.get("rhythm_zone") is not None
-                for bm in beats_meta
-            ),
+            "enabled": any(bm.get("rhythm_zone") is not None for bm in beats_meta),
             "zones": {
                 z: sum(1 for bm in beats_meta if bm.get("rhythm_zone") == z)
                 for z in _RHYTHM_ZONE_TIMELINE_CENTER

--- a/src/movie_narrator/pipeline/preflight.py
+++ b/src/movie_narrator/pipeline/preflight.py
@@ -47,8 +47,9 @@ def _check_llm(ctx: Context) -> None:
         console.debug("  preflight: CI mode — skipping LLM probe")
         return
 
-    console.debug(f"  preflight: probing LLM at {settings.llm_base_url} "
-                  f"(model={settings.llm_model})")
+    console.debug(
+        f"  preflight: probing LLM at {settings.llm_base_url} (model={settings.llm_model})"
+    )
     try:
         with get_llm_client() as llm:
             llm.client.chat.completions.create(
@@ -89,6 +90,7 @@ def _check_tts(ctx: Context) -> None:
     # cost / latency — the provider will surface network errors at step 6.
     try:
         from ..tts import get_tts_provider
+
         get_tts_provider(settings)
     except ConfigError as e:
         raise PreflightError(

--- a/src/movie_narrator/pipeline/qa_gate.py
+++ b/src/movie_narrator/pipeline/qa_gate.py
@@ -52,9 +52,7 @@ def run_qa_gate(ctx: Context) -> Context:
     if script_qa:
         total = script_qa.get("total_issues", 0)
         if total > _MAX_SCRIPT_ISSUES:
-            gate_issues.append(
-                f"Script QA: {total} issues (max {_MAX_SCRIPT_ISSUES})"
-            )
+            gate_issues.append(f"Script QA: {total} issues (max {_MAX_SCRIPT_ISSUES})")
         elif total > 0:
             gate_warnings.append(f"Script QA: {total} minor issues")
 
@@ -62,10 +60,7 @@ def run_qa_gate(ctx: Context) -> Context:
     audio_qa = ctx.metadata.get("audio_quality")
     if audio_qa:
         segments = audio_qa.get("segments", [])
-        bad_segments = [
-            s for s in segments
-            if s.get("clipping_ratio", 0) > _MAX_CLIPPING_RATIO
-        ]
+        bad_segments = [s for s in segments if s.get("clipping_ratio", 0) > _MAX_CLIPPING_RATIO]
         if bad_segments:
             gate_issues.append(
                 f"Audio QA: {len(bad_segments)} segment(s) with severe clipping "
@@ -100,9 +95,7 @@ def run_qa_gate(ctx: Context) -> Context:
     # ── Translation QA check ──
     untranslated = ctx.metadata.get("untranslated_indices", [])
     if untranslated and len(untranslated) > len(ctx.timed_segments) * 0.3:
-        gate_issues.append(
-            f"Translation: {len(untranslated)} untranslated lines (>30% of total)"
-        )
+        gate_issues.append(f"Translation: {len(untranslated)} untranslated lines (>30% of total)")
 
     # Store gate results
     ctx.metadata["qa_gate"] = {

--- a/src/movie_narrator/pipeline/registry.py
+++ b/src/movie_narrator/pipeline/registry.py
@@ -106,8 +106,7 @@ class StepRegistry:
         """
         if name in self._entries:
             raise ValueError(
-                f"Step '{name}' is already registered. "
-                f"Use a different name or unregister first."
+                f"Step '{name}' is already registered. Use a different name or unregister first."
             )
 
         is_builtin = after is None and before is None

--- a/src/movie_narrator/pipeline/render.py
+++ b/src/movie_narrator/pipeline/render.py
@@ -41,7 +41,7 @@ _DEFAULT_MUX_TIMEOUT = 600
 # buttons) can cover the bottom 20-25% of the screen. These conservative
 # ratios push subtitles above the danger zone.
 _VERTICAL_BOTTOM_MARGIN_RATIO = 0.15  # vs 0.08 default for 16:9
-_VERTICAL_MAX_WIDTH_RATIO = 0.82      # vs 0.90 default for 16:9
+_VERTICAL_MAX_WIDTH_RATIO = 0.82  # vs 0.90 default for 16:9
 
 
 class _RenderProgressLogger(TqdmProgressBarLogger):
@@ -82,11 +82,7 @@ def _overlay_text(ctx: Context, idx: int, seg: TimedSegment) -> str:
     is shorter than `timed_segments` — falls back to the original.
     """
     mode = ctx.metadata.get("subtitle_mode", "original")
-    t = (
-        ctx.translated_texts[idx]
-        if idx < len(ctx.translated_texts)
-        else None
-    )
+    t = ctx.translated_texts[idx] if idx < len(ctx.translated_texts) else None
     if mode == "translated" and t:
         return t
     if mode == "bilingual" and t:
@@ -131,22 +127,31 @@ def _export_cover_image(
         return
 
     extract_cmd = [
-        ffmpeg_bin, "-y", "-loglevel", "error",
-        "-ss", f"{mid_ts:.2f}",
-        "-i", str(ctx.source_video_path),
-        "-frames:v", "1",
-        "-q:v", "2",
+        ffmpeg_bin,
+        "-y",
+        "-loglevel",
+        "error",
+        "-ss",
+        f"{mid_ts:.2f}",
+        "-i",
+        str(ctx.source_video_path),
+        "-frames:v",
+        "1",
+        "-q:v",
+        "2",
         str(cover_raw),
     ]
     try:
         proc = subprocess.run(
-            extract_cmd, capture_output=True, text=True,
-            encoding="utf-8", errors="replace", timeout=30,
+            extract_cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
         )
         if proc.returncode != 0 or not cover_raw.exists():
-            ctx.services.console.debug(
-                f"  cover: ffmpeg extract failed: {proc.stderr[:200]}"
-            )
+            ctx.services.console.debug(f"  cover: ffmpeg extract failed: {proc.stderr[:200]}")
             return
     except (OSError, subprocess.SubprocessError) as e:
         ctx.services.console.debug(f"  cover: extract error: {e}")
@@ -177,12 +182,14 @@ def _export_cover_image(
 
         # Draw movie name
         from ..utils.font import get_font
+
         font_size = max(28, int(w * 0.06))
         font = get_font(font_size)
         text = ctx.movie_name or ""
 
         # Wrap text
         from ..utils.text_image import _wrap_line
+
         lines = _wrap_line(text, draw, font, int(w * 0.85))
         line_height = font_size + 6
         total_text_h = len(lines) * line_height
@@ -243,8 +250,12 @@ def _create_watermark_image(text: str, size: tuple, fontsize: int = 36):
 
     # Semi-transparent white text with a faint black stroke for legibility.
     draw.text(
-        (x, y), text, fill=(255, 255, 255, 140), font=font,
-        stroke_width=1, stroke_fill=(0, 0, 0, 120),
+        (x, y),
+        text,
+        fill=(255, 255, 255, 140),
+        font=font,
+        stroke_width=1,
+        stroke_fill=(0, 0, 0, 120),
     )
     return np.array(img)
 
@@ -281,6 +292,7 @@ def render_video(ctx: Context) -> Context:
     preview_mode = ctx.metadata.get("render_preview_mode", False)
     if preview_mode:
         from ..utils.preview import get_preview_duration, truncate_segments_for_preview
+
         preview_sec = get_preview_duration(
             ctx.metadata.get("render_preview_sec", 10.0), total_duration
         )
@@ -291,9 +303,7 @@ def render_video(ctx: Context) -> Context:
         # Truncate timed segments so subtitle overlays respect the preview
         # window (segments beyond the cut are dropped; spanning segments are
         # clamped to end at the boundary).
-        ctx.timed_segments = truncate_segments_for_preview(
-            ctx.timed_segments, total_duration
-        )
+        ctx.timed_segments = truncate_segments_for_preview(ctx.timed_segments, total_duration)
 
     # Production-quality render knobs (spec §7.2).
     fit_mode = ctx.metadata.get("render_fit_mode", "cover")
@@ -317,7 +327,9 @@ def render_video(ctx: Context) -> Context:
     vertical_safe = ctx.metadata.get("render_vertical_safe_area", True)
     if vertical_safe and video_format == "9:16":
         safe_max_width = aspect_safe_area.get("max_width_ratio", _VERTICAL_MAX_WIDTH_RATIO)
-        safe_bottom_margin = aspect_safe_area.get("bottom_margin_ratio", _VERTICAL_BOTTOM_MARGIN_RATIO)
+        safe_bottom_margin = aspect_safe_area.get(
+            "bottom_margin_ratio", _VERTICAL_BOTTOM_MARGIN_RATIO
+        )
         max_width_ratio = min(max_width_ratio, safe_max_width)
         bottom_margin_ratio = max(bottom_margin_ratio, safe_bottom_margin)
         ctx.services.console.debug(
@@ -357,18 +369,24 @@ def render_video(ctx: Context) -> Context:
                 try:
                     subclip = source.subclipped(mc.src_start, mc.src_end)
                     if src_duration > 0:
-                        subclip = subclip.with_speed_scaled(factor=src_duration / max(seg_duration, _SEG_DURATION_FLOOR))
+                        subclip = subclip.with_speed_scaled(
+                            factor=src_duration / max(seg_duration, _SEG_DURATION_FLOOR)
+                        )
 
                     # Fit source frame onto the canvas (cover=crop+fill,
                     # contain=letterbox+center). Keeps footage from overflowing
                     # or distorting the output resolution.
                     box = compute_fit_box(
-                        (subclip.w, subclip.h), size, mode=fit_mode,
+                        (subclip.w, subclip.h),
+                        size,
+                        mode=fit_mode,
                     )
                     if fit_mode == "cover":
                         fitted = subclip.cropped(
-                            x1=box.crop_x, y1=box.crop_y,
-                            x2=box.crop_x + box.crop_w, y2=box.crop_y + box.crop_h,
+                            x1=box.crop_x,
+                            y1=box.crop_y,
+                            x2=box.crop_x + box.crop_w,
+                            y2=box.crop_y + box.crop_h,
                         ).resized((box.out_w, box.out_h))
                         fitted = fitted.with_position((0, 0))
                     else:  # contain
@@ -382,7 +400,7 @@ def render_video(ctx: Context) -> Context:
                     if transition_type != "none":
                         trans_dur = get_transition_duration(
                             mc.narr_end - mc.narr_start,
-                            ctx.metadata.get("render_transition_duration", 0.5)
+                            ctx.metadata.get("render_transition_duration", 0.5),
                         )
                         fitted = apply_transition(fitted, transition_type, trans_dur)
 
@@ -392,7 +410,9 @@ def render_video(ctx: Context) -> Context:
                     logger.debug("clip fallback for segment %d", mc.segment_index, exc_info=True)
                     img_array = _create_text_image(
                         _overlay_text(ctx, mc.segment_index, ctx.timed_segments[mc.segment_index]),
-                        size, fontsize=font_size, position=subtitle_position,
+                        size,
+                        fontsize=font_size,
+                        position=subtitle_position,
                         max_width_ratio=max_width_ratio,
                         bottom_margin_ratio=bottom_margin_ratio,
                     )
@@ -417,7 +437,9 @@ def render_video(ctx: Context) -> Context:
     # order which is deterministic).
     def _make_subtitle_image(i, seg, pos):
         img_array = _create_text_image(
-            _overlay_text(ctx, i, seg), size, fontsize=font_size,
+            _overlay_text(ctx, i, seg),
+            size,
+            fontsize=font_size,
             position=pos,
             max_width_ratio=max_width_ratio,
             bottom_margin_ratio=bottom_margin_ratio,
@@ -429,8 +451,7 @@ def render_video(ctx: Context) -> Context:
         text_anim_type = ctx.metadata.get("render_text_animation", "none")
         if text_anim_type != "none":
             anim_dur = get_animation_duration(
-                seg.end - seg.start,
-                ctx.metadata.get("render_text_animation_duration", 0.3)
+                seg.end - seg.start, ctx.metadata.get("render_text_animation_duration", 0.3)
             )
             img_clip = apply_text_animation(img_clip, text_anim_type, anim_dur)
 
@@ -462,7 +483,9 @@ def render_video(ctx: Context) -> Context:
     if title_card_sec and title_card_sec > 0 and title_card_text:
         title_font_size = int(font_size * 1.4)
         title_img = _create_text_image(
-            title_card_text, size, fontsize=title_font_size,
+            title_card_text,
+            size,
+            fontsize=title_font_size,
             position="center",
             max_width_ratio=0.85,
         )
@@ -471,14 +494,13 @@ def render_video(ctx: Context) -> Context:
         # Fade in/out for polish (graceful degradation if MoviePy fx unavailable)
         try:
             from moviepy.video.fx import FadeIn, FadeOut
+
             fade_dur = min(0.3, title_card_sec / 3)
             title_clip = title_clip.with_effects([FadeIn(fade_dur), FadeOut(fade_dur)])
         except (ImportError, ValueError):
             logger.debug("title card fade effect failed", exc_info=True)
         clips.append(title_clip)
-        ctx.services.console.debug(
-            f"  title card: {title_card_text} ({title_card_sec}s)"
-        )
+        ctx.services.console.debug(f"  title card: {title_card_text} ({title_card_sec}s)")
 
     # End card overlay — show end card text at the end of the
     # video (similar to the title card but at the closing).  Soft addition:
@@ -489,7 +511,9 @@ def render_video(ctx: Context) -> Context:
         end_card_sec = title_card_sec if (title_card_sec and title_card_sec > 0) else 1.0
         end_font_size = int(font_size * 1.4)
         end_img = _create_text_image(
-            end_card_text, size, fontsize=end_font_size,
+            end_card_text,
+            size,
+            fontsize=end_font_size,
             position="center",
             max_width_ratio=0.85,
         )
@@ -498,14 +522,13 @@ def render_video(ctx: Context) -> Context:
         end_clip = end_clip.with_duration(end_card_sec).with_start(end_start)
         try:
             from moviepy.video.fx import FadeIn, FadeOut
+
             fade_dur = min(0.3, end_card_sec / 3)
             end_clip = end_clip.with_effects([FadeIn(fade_dur), FadeOut(fade_dur)])
         except (ImportError, ValueError):
             logger.debug("end card fade effect failed", exc_info=True)
         clips.append(end_clip)
-        ctx.services.console.debug(
-            f"  end card: {end_card_text} ({end_card_sec}s)"
-        )
+        ctx.services.console.debug(f"  end card: {end_card_text} ({end_card_sec}s)")
 
     # Watermark overlay — small semi-transparent text in the
     # top-right corner, visible for the entire video duration.
@@ -513,14 +536,14 @@ def render_video(ctx: Context) -> Context:
     if watermark_template:
         watermark_text = _substitute_movie(watermark_template, ctx.movie_name)
         wm_img = _create_watermark_image(
-            watermark_text, size, fontsize=max(24, int(font_size * 0.36)),
+            watermark_text,
+            size,
+            fontsize=max(24, int(font_size * 0.36)),
         )
         wm_clip = ImageClip(wm_img, is_mask=False)
         wm_clip = wm_clip.with_duration(total_duration).with_start(0)
         clips.append(wm_clip)
-        ctx.services.console.debug(
-            f"  watermark: {watermark_text}"
-        )
+        ctx.services.console.debug(f"  watermark: {watermark_text}")
 
     # Disclaimer overlay — small text at the very bottom,
     # visible for the entire video duration.  Uses a smaller font and a
@@ -529,7 +552,9 @@ def render_video(ctx: Context) -> Context:
     if disclaimer_template:
         disclaimer_text = _substitute_movie(disclaimer_template, ctx.movie_name)
         disc_img = _create_text_image(
-            disclaimer_text, size, fontsize=max(20, int(font_size * 0.42)),
+            disclaimer_text,
+            size,
+            fontsize=max(20, int(font_size * 0.42)),
             position="bottom",
             max_width_ratio=0.9,
             bottom_margin_ratio=0.02,
@@ -537,9 +562,7 @@ def render_video(ctx: Context) -> Context:
         disc_clip = ImageClip(disc_img, is_mask=False)
         disc_clip = disc_clip.with_duration(total_duration).with_start(0)
         clips.append(disc_clip)
-        ctx.services.console.debug(
-            f"  disclaimer: {disclaimer_text}"
-        )
+        ctx.services.console.debug(f"  disclaimer: {disclaimer_text}")
 
     final_video = CompositeVideoClip(clips).with_audio(audio_clip)
     # Free clip references before encoding to reduce peak memory (v0.7.0).
@@ -553,7 +576,6 @@ def render_video(ctx: Context) -> Context:
     # render_output_name from the user always takes precedence.
     default_output_name = "preview.mp4" if preview_mode else "final.mp4"
     video_path = output_dir / ctx.metadata.get("render_output_name", default_output_name)
-
 
     tmp_dir = output_dir / ".tmp"
     tmp_dir.mkdir(exist_ok=True)
@@ -618,8 +640,7 @@ def render_video(ctx: Context) -> Context:
                 # unsupported option, etc.) — retry with CPU libx264 so the
                 # pipeline degrades gracefully instead of aborting.
                 ctx.services.console.inline_warn(
-                    f"GPU encoding ({gpu_codec}) failed: {gpu_err}. "
-                    f"Retrying with libx264 (CPU)."
+                    f"GPU encoding ({gpu_codec}) failed: {gpu_err}. Retrying with libx264 (CPU)."
                 )
                 logger.debug("GPU encoding failed, falling back to CPU", exc_info=True)
                 gpu_codec = "libx264"
@@ -670,13 +691,20 @@ def render_video(ctx: Context) -> Context:
     mux_cmd = [
         ffmpeg_bin,
         "-y",
-        "-loglevel", "error",
-        "-i", str(video_only_path),
-        "-i", str(audio_path),
-        "-map", "0:v:0",
-        "-map", "1:a:0",
-        "-c:v", "copy",
-        "-c:a", audio_codec if not audio_codec.startswith("lib") else audio_codec[3:],
+        "-loglevel",
+        "error",
+        "-i",
+        str(video_only_path),
+        "-i",
+        str(audio_path),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "copy",
+        "-c:a",
+        audio_codec if not audio_codec.startswith("lib") else audio_codec[3:],
     ]
     if faststart:
         mux_cmd += ["-movflags", "+faststart"]
@@ -693,9 +721,7 @@ def render_video(ctx: Context) -> Context:
                 timeout=ctx.metadata.get("render_ffmpeg_timeout", _DEFAULT_MUX_TIMEOUT),
             )
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"ffmpeg mux failed (exit={proc.returncode}): {proc.stderr}"
-            )
+            raise RuntimeError(f"ffmpeg mux failed (exit={proc.returncode}): {proc.stderr}")
     finally:
         # Clean up the .tmp directory (video_only.mp4 and any
         # other intermediates) to keep the output dir tidy.
@@ -733,9 +759,7 @@ def render_video(ctx: Context) -> Context:
     # post-pipeline script or use --strict with custom logic.
     total_segments = len(ctx.timed_segments)
     footage_segments_count = len(footage_segments)
-    coverage_ratio = (
-        footage_segments_count / total_segments if total_segments > 0 else 0.0
-    )
+    coverage_ratio = footage_segments_count / total_segments if total_segments > 0 else 0.0
     ctx.metadata["footage_coverage"] = {
         "total_segments": total_segments,
         "footage_segments": footage_segments_count,

--- a/src/movie_narrator/pipeline/research.py
+++ b/src/movie_narrator/pipeline/research.py
@@ -48,7 +48,9 @@ Do NOT add any text before or after the JSON.
 """
 
 
-def _write_envelope(output_dir: Path, status: str, error: str | None, research: dict | None) -> Path:
+def _write_envelope(
+    output_dir: Path, status: str, error: str | None, research: dict | None
+) -> Path:
     path = output_dir / "research.json"
     payload = {
         "status": status,
@@ -75,8 +77,8 @@ def _research_via_llm(ctx: Context, settings) -> ResearchInfo:
                 max_tokens=settings.research_max_tokens,
             )
         # v0.7.0: Record LLM cost for research
-        if ctx is not None and hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
-            if hasattr(response, 'usage') and response.usage:
+        if ctx is not None and hasattr(ctx, "cost_tracker") and ctx.cost_tracker is not None:
+            if hasattr(response, "usage") and response.usage:
                 ctx.cost_tracker.record_llm_call("research", llm.model, response.usage.model_dump())
         raw = response.choices[0].message.content or ""
         data = extract_json(raw)
@@ -110,6 +112,7 @@ def _research_via_llm(ctx: Context, settings) -> ResearchInfo:
         if card is not None:
             try:
                 from ..providers.tmdb import enrich_movie_card_with_tmdb
+
                 enriched = enrich_movie_card_with_tmdb(card, ctx, settings)
                 ctx.metadata["movie_card"] = enriched
             except Exception:  # noqa: BLE001

--- a/src/movie_narrator/pipeline/runner.py
+++ b/src/movie_narrator/pipeline/runner.py
@@ -15,7 +15,14 @@ from ..utils.environment import collect_environment
 from .align import align_audio
 from .assets import prepare_assets
 from .bgm import mix_bgm
-from .errors import PipelineCancelled, PipelinePaused, PipelineStrictError, RunController, StepAction, check_cancelled
+from .errors import (
+    PipelineCancelled,
+    PipelinePaused,
+    PipelineStrictError,
+    RunController,
+    StepAction,
+    check_cancelled,
+)
 from .export_clips import export_clips
 from .match import match_clips
 from .preflight import PreflightError, run_preflight
@@ -48,36 +55,69 @@ PARAM_WHITELIST: frozenset[str] = frozenset(JobParams.model_fields.keys())
 
 _BUILTIN_STEP_META = {
     # name: (func, soft, status_field, consequence)
-    "resolve_video":       (resolve_video,       False, None, ""),
-    "prepare_assets":      (prepare_assets,      False, None, ""),
-    "research_plot":       (research_plot,       True,  "research",
-        "research unavailable — script will use generic plot description"),
-    "generate_script":     (generate_script,     False, None, ""),
-    "export_script_md":    (export_script_md,    False, None, ""),
-    "generate_voice":      (generate_voice,      False, None, ""),
-    "align_audio":         (align_audio,         True,  "align",
-        "audio alignment skipped — subtitle timestamps may drift from actual speech"),
-    "detect_scenes":       (detect_scenes,       True,  "scene",
-        "scene detection skipped — clips will use fixed-duration segments"),
-    "match_clips":         (match_clips,         True,  "match",
-        "clip matching skipped — segments mapped to sequential clips without embedding search"),
-    "mix_bgm":             (mix_bgm,             True,  "bgm",
-        "BGM mixing failed — final video will have narration audio only, no background music"),
-    "translate_subtitles": (translate_subtitles, True,  "translate",
-        "translation failed — only original-language subtitles will be available"),
-    "generate_subtitle":   (generate_subtitle,   False, None, ""),
-    "run_qa_gate":         (run_qa_gate,         True,  "qa_gate",
-        "QA gate skipped — intermediate product validation not performed"),
-    "render_video":        (render_video,        False, None, ""),
-    "validate_deliverable":(validate_deliverable,False, None, ""),
-    "export_clips":        (export_clips,        True,  "export",
-        "clip export skipped — no standalone clip files will be produced"),
+    "resolve_video": (resolve_video, False, None, ""),
+    "prepare_assets": (prepare_assets, False, None, ""),
+    "research_plot": (
+        research_plot,
+        True,
+        "research",
+        "research unavailable — script will use generic plot description",
+    ),
+    "generate_script": (generate_script, False, None, ""),
+    "export_script_md": (export_script_md, False, None, ""),
+    "generate_voice": (generate_voice, False, None, ""),
+    "align_audio": (
+        align_audio,
+        True,
+        "align",
+        "audio alignment skipped — subtitle timestamps may drift from actual speech",
+    ),
+    "detect_scenes": (
+        detect_scenes,
+        True,
+        "scene",
+        "scene detection skipped — clips will use fixed-duration segments",
+    ),
+    "match_clips": (
+        match_clips,
+        True,
+        "match",
+        "clip matching skipped — segments mapped to sequential clips without embedding search",
+    ),
+    "mix_bgm": (
+        mix_bgm,
+        True,
+        "bgm",
+        "BGM mixing failed — final video will have narration audio only, no background music",
+    ),
+    "translate_subtitles": (
+        translate_subtitles,
+        True,
+        "translate",
+        "translation failed — only original-language subtitles will be available",
+    ),
+    "generate_subtitle": (generate_subtitle, False, None, ""),
+    "run_qa_gate": (
+        run_qa_gate,
+        True,
+        "qa_gate",
+        "QA gate skipped — intermediate product validation not performed",
+    ),
+    "render_video": (render_video, False, None, ""),
+    "validate_deliverable": (validate_deliverable, False, None, ""),
+    "export_clips": (
+        export_clips,
+        True,
+        "export",
+        "clip export skipped — no standalone clip files will be produced",
+    ),
 }
 
 for _name, (_func, _soft, _field, _consequence) in _BUILTIN_STEP_META.items():
     if not step_registry.contains(_name):
         step_registry.register(
-            _name, _func,
+            _name,
+            _func,
             soft=_soft,
             status_field=_field,
             consequence=_consequence,
@@ -96,8 +136,7 @@ STATUS_FIELD_FOR_STEP: Dict[str, str] = {
 }
 
 SOFT_STEP_CONSEQUENCES: Dict[str, str] = {
-    name: step_registry.consequence_for(name)
-    for name in SOFT_STATUS_STEPS
+    name: step_registry.consequence_for(name) for name in SOFT_STATUS_STEPS
 }
 
 # Safety: every soft step must have a status field mapping.
@@ -282,34 +321,38 @@ def build_context(
         services=services,
     )
     from ..utils.cost_tracker import CostTracker
+
     ctx.cost_tracker = CostTracker()
     ctx.metadata.update(
-        cast(MetadataDict, {
-            "voice": voice,
-            "video_format": video_format,
-            "keep_cache": keep_cache,
-            "video_arg": video,
-            "research_enabled": research_enabled,
-            "export_clips": (False if no_clips else True),
-            "strict": strict,
-            "bgm_request": bgm_request,
-            "version": __version__,
-            "environment": collect_environment(),
-            # Multi-language subtitle. Empty lang → feature off.
-            "subtitle_lang": (subtitle_lang or None),
-            "subtitle_mode": (subtitle_mode or "original"),
-            "translate_provider": (params or {}).get("translate_provider", "llm"),
-            "translate_retries": (params or {}).get("translate_retries", 3),
-            "research_provider": (params or {}).get("research_provider", "llm"),
-            # Single source of truth for narration language.
-            "lang": lang,
-            # v0.7.2: preview mode — render only the first N seconds for quick
-            # iteration.  OFF by default (backward compatible).  These keys are
-            # also propagated via PARAM_WHITELIST below when explicitly set;
-            # setting defaults here keeps them visible in metadata.json.
-            "render_preview_mode": (params or {}).get("render_preview_mode", False),
-            "render_preview_sec": (params or {}).get("render_preview_sec", 10.0),
-        })
+        cast(
+            MetadataDict,
+            {
+                "voice": voice,
+                "video_format": video_format,
+                "keep_cache": keep_cache,
+                "video_arg": video,
+                "research_enabled": research_enabled,
+                "export_clips": (False if no_clips else True),
+                "strict": strict,
+                "bgm_request": bgm_request,
+                "version": __version__,
+                "environment": collect_environment(),
+                # Multi-language subtitle. Empty lang → feature off.
+                "subtitle_lang": (subtitle_lang or None),
+                "subtitle_mode": (subtitle_mode or "original"),
+                "translate_provider": (params or {}).get("translate_provider", "llm"),
+                "translate_retries": (params or {}).get("translate_retries", 3),
+                "research_provider": (params or {}).get("research_provider", "llm"),
+                # Single source of truth for narration language.
+                "lang": lang,
+                # v0.7.2: preview mode — render only the first N seconds for quick
+                # iteration.  OFF by default (backward compatible).  These keys are
+                # also propagated via PARAM_WHITELIST below when explicitly set;
+                # setting defaults here keeps them visible in metadata.json.
+                "render_preview_mode": (params or {}).get("render_preview_mode", False),
+                "render_preview_sec": (params or {}).get("render_preview_sec", 10.0),
+            },
+        )
     )
 
     # Narration-language consistency check — warn if subtitle target language
@@ -331,6 +374,7 @@ def build_context(
     effective_params: Dict[str, Any] = {}
     if narration_preset:
         from ..presets import get_preset
+
         preset = get_preset(narration_preset)
         effective_params.update(preset.param_dict)
         ctx.metadata["narration_preset"] = narration_preset
@@ -347,7 +391,9 @@ def build_context(
     # When render_profile=draft, override render params for speed.
     # User-supplied params (via job.yaml or preset) always take precedence
     # over draft defaults — draft only fills gaps.
-    render_profile = (params or {}).get("render_profile") or (effective_params.get("render_profile"))
+    render_profile = (params or {}).get("render_profile") or (
+        effective_params.get("render_profile")
+    )
     if render_profile == "draft":
         _DRAFT_RENDER_DEFAULTS = {
             "render_crf": 28,
@@ -380,6 +426,7 @@ def _save_pipeline_state(ctx: Context, completed_step: str) -> Path:
         The path to the saved state file.
     """
     import json
+
     state = {
         "completed_step": completed_step,
         "context": ctx.model_dump(mode="json", exclude={"services"}),
@@ -401,6 +448,7 @@ def _load_pipeline_state(state_path: Path) -> tuple[Context, str]:
         callers should assign a real console if interactive output is needed.
     """
     import json
+
     data = json.loads(state_path.read_text(encoding="utf-8"))
     completed_step = data["completed_step"]
     ctx = Context(**data["context"])
@@ -497,6 +545,7 @@ def run_pipeline(
         # a faithful representation of the final output.
         if ctx.metadata.get("render_preview_mode"):
             from ..utils.preview import should_skip_step_for_preview
+
             if should_skip_step_for_preview(name, True):
                 ctx.step_state = StepState(
                     result=StepResult.SKIPPED, message="skipped in preview mode"
@@ -537,7 +586,8 @@ def run_pipeline(
                     if consequence:
                         msg = f"{msg} — {consequence}"
                     ctx.step_state = StepState(
-                        result=StepResult.WARNING, message=msg,
+                        result=StepResult.WARNING,
+                        message=msg,
                         step_retryable=is_retryable,
                     )
                     console.step_warn(name, ctx.step_state.message or "")
@@ -557,7 +607,8 @@ def run_pipeline(
                 elif action is StepAction.SKIP:
                     console.step_warn(name, f"skipped after {attempt} attempt(s): {e}")
                     ctx.step_state = StepState(
-                        result=StepResult.WARNING, message=f"skipped: {e}",
+                        result=StepResult.WARNING,
+                        message=f"skipped: {e}",
                         step_retryable=is_retryable,
                     )
                     break  # exit retry loop, continue to next step
@@ -601,7 +652,7 @@ def run_pipeline(
             console.inline_warn(
                 f"Pipeline paused after '{name}'. "
                 f"State saved to {state_path.name}. "
-                f"Resume with: mn resume --state \"{state_path}\""
+                f'Resume with: mn resume --state "{state_path}"'
             )
             raise PipelinePaused(name)
 
@@ -716,11 +767,7 @@ def _handle_step_error(
       the existing behavior.
     """
     is_retryable = bool(getattr(error, "retryable", False))
-    handler = (
-        getattr(controller, "on_step_error", None)
-        if controller is not None
-        else None
-    )
+    handler = getattr(controller, "on_step_error", None) if controller is not None else None
     retry_enabled = handler is not None
 
     if is_retryable and not retry_enabled:

--- a/src/movie_narrator/pipeline/scene_filter.py
+++ b/src/movie_narrator/pipeline/scene_filter.py
@@ -86,12 +86,17 @@ def _extract_mid_frame(
         result = subprocess.run(
             [
                 ffmpeg_bin,
-                "-y",           # overwrite
-                "-ss", str(timestamp),  # seek to timestamp
-                "-i", video_path,
-                "-frames:v", "1",      # extract exactly 1 frame
-                "-q:v", "2",            # high quality JPEG
-                "-f", "image2",
+                "-y",  # overwrite
+                "-ss",
+                str(timestamp),  # seek to timestamp
+                "-i",
+                video_path,
+                "-frames:v",
+                "1",  # extract exactly 1 frame
+                "-q:v",
+                "2",  # high quality JPEG
+                "-f",
+                "image2",
                 str(output_path),
             ],
             capture_output=True,
@@ -111,6 +116,7 @@ def _compute_mean_luma(image_path: Path) -> Optional[float]:
     """
     try:
         from PIL import Image
+
         img = Image.open(image_path).convert("L")
         # Small images: use histogram; for larger ones, downscale first
         if img.width > 64:
@@ -185,7 +191,9 @@ def filter_dark_scenes(
             dropped += 1
             logger.debug(
                 "  dark drop: scene %d (luma=%.1f < %.1f)",
-                scene.index, luma, luma_threshold,
+                scene.index,
+                luma,
+                luma_threshold,
             )
         else:
             kept.append(scene)
@@ -241,11 +249,13 @@ def apply_source_window(
         # Clip scene to window bounds
         new_start = max(scene.start, win_start)
         new_end = min(scene.end, win_end)
-        kept.append(Scene(
-            index=0,  # re-indexed below
-            start=new_start,
-            end=new_end,
-        ))
+        kept.append(
+            Scene(
+                index=0,  # re-indexed below
+                start=new_start,
+                end=new_end,
+            )
+        )
 
     if not kept:
         return scenes, 0

--- a/src/movie_narrator/pipeline/scenes.py
+++ b/src/movie_narrator/pipeline/scenes.py
@@ -73,6 +73,7 @@ def detect_scenes(ctx: Context) -> Context:
             except (AttributeError, TypeError, ValueError):
                 # Fallback: probe via ffprobe
                 from ..utils.deliverable_qa import probe_media
+
                 duration = probe_media(ctx.source_video_path).get("duration", 60.0)
             scenes = [Scene(index=0, start=0.0, end=duration)]
             ctx.metadata["scene_detection_degraded"] = True
@@ -86,14 +87,13 @@ def detect_scenes(ctx: Context) -> Context:
         try:
             output_dir = Path(ctx.output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
-            scenes_data = [
-                {"index": s.index, "start": s.start, "end": s.end}
-                for s in scenes
-            ]
+            scenes_data = [{"index": s.index, "start": s.start, "end": s.end} for s in scenes]
             with open(output_dir / "scenes.json", "w", encoding="utf-8") as f:
                 json.dump(
                     {"scene_count": len(scenes_data), "scenes": scenes_data},
-                    f, ensure_ascii=False, indent=2,
+                    f,
+                    ensure_ascii=False,
+                    indent=2,
                 )
         except Exception as e:
             # Best-effort: scenes.json is diagnostic, not critical.

--- a/src/movie_narrator/pipeline/script.py
+++ b/src/movie_narrator/pipeline/script.py
@@ -9,7 +9,20 @@ import re
 from ..config import get_settings
 from ..models import Context, ScriptSegment
 from ..utils.console import step_timing
-from ..utils.prompts import BEATS_PROMPT, EXPAND_PROMPT, JUDGE_PROMPT, build_cadence_hint, build_set_pieces_hint, build_hook_hint, build_platform_tone_hint, build_language_hint, build_perspective_hint, build_judge_feedback_hint, NARRATIVE_PRINCIPLES, ANTI_AI_TONE
+from ..utils.prompts import (
+    BEATS_PROMPT,
+    EXPAND_PROMPT,
+    JUDGE_PROMPT,
+    build_cadence_hint,
+    build_set_pieces_hint,
+    build_hook_hint,
+    build_platform_tone_hint,
+    build_language_hint,
+    build_perspective_hint,
+    build_judge_feedback_hint,
+    NARRATIVE_PRINCIPLES,
+    ANTI_AI_TONE,
+)
 from ..utils.llm import get_llm_client
 from ..utils.json_parser import extract_json
 from ..tts.base import is_ci
@@ -21,7 +34,7 @@ from time import sleep
 # LLM may ignore the max_chars prompt instruction. This post-processing
 # step hard-truncates any sentence exceeding the limit, cutting at the
 # last punctuation mark before the limit for natural breaks.
-_PUNCT_PATTERN = re.compile(r'[。！？；，、…\.,!?;]')
+_PUNCT_PATTERN = re.compile(r"[。！？；，、…\.,!?;]")
 
 
 def _truncate_to_max_chars(text: str, max_chars: int) -> str:
@@ -37,6 +50,7 @@ def _truncate_to_max_chars(text: str, max_chars: int) -> str:
         return truncated[: match.end()].rstrip()
     # No punctuation found — hard cut
     return truncated.rstrip()
+
 
 # CI-only fallback: used when LLM is unreachable in CI environment
 # to allow full pipeline testing. Never used for real users.
@@ -106,9 +120,7 @@ _RHYTHM_ZONES = frozenset({"hook", "rising", "peak", "settle"})
 _EMOTIONS = frozenset({"suspense", "laughter", "intense", "calm", "twist"})
 
 
-def _generate_plot_beats(
-    ctx: Context, settings, llm, target_count: int
-) -> List[str]:
+def _generate_plot_beats(ctx: Context, settings, llm, target_count: int) -> List[str]:
     """Phase 1: Extract exactly *target_count* plot beats from the movie.
 
     Uses low temperature (research_temperature) for structured extraction.
@@ -163,7 +175,12 @@ def _generate_plot_beats(
         max_tokens=scaled_max_tokens,
     )
     # v0.7.0: record LLM token usage for cost tracking
-    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None and hasattr(response, 'usage') and response.usage:
+    if (
+        hasattr(ctx, "cost_tracker")
+        and ctx.cost_tracker is not None
+        and hasattr(response, "usage")
+        and response.usage
+    ):
         ctx.cost_tracker.record_llm_call("script", llm.model, response.usage.model_dump())
     raw = response.choices[0].message.content or ""
     data = extract_json(raw)
@@ -174,9 +191,7 @@ def _generate_plot_beats(
     if len(beats) == 0:
         raise ValueError("Phase 1: LLM returned zero beats")
     if len(beats) != target_count:
-        raise ValueError(
-            f"Phase 1: expected {target_count} beats, got {len(beats)}"
-        )
+        raise ValueError(f"Phase 1: expected {target_count} beats, got {len(beats)}")
 
     # Filter out None / non-string / empty beats.
     # str(None) = "None" is truthy and would silently pass the old
@@ -217,13 +232,29 @@ def _generate_plot_beats(
             if not isinstance(emotion, str) or emotion not in _EMOTIONS:
                 emotion = None
             cleaned.append(text)
-            beats_meta.append({"text": text, "act": act, "approx_ratio": ratio, "rhythm_zone": rhythm_zone, "emotion": emotion})
+            beats_meta.append(
+                {
+                    "text": text,
+                    "act": act,
+                    "approx_ratio": ratio,
+                    "rhythm_zone": rhythm_zone,
+                    "emotion": emotion,
+                }
+            )
         else:
             text = str(b).strip()
             if not text or text.lower() == "none":
                 continue
             cleaned.append(text)
-            beats_meta.append({"text": text, "act": None, "approx_ratio": None, "rhythm_zone": None, "emotion": None})
+            beats_meta.append(
+                {
+                    "text": text,
+                    "act": None,
+                    "approx_ratio": None,
+                    "rhythm_zone": None,
+                    "emotion": None,
+                }
+            )
     if len(cleaned) != target_count:
         raise ValueError(
             f"Phase 1: after filtering None/empty beats, expected {target_count}, got {len(cleaned)}"
@@ -237,7 +268,11 @@ def _generate_plot_beats(
 
 
 def _expand_beats_to_script(
-    ctx: Context, settings, llm, beats: List[str], target_count: int,
+    ctx: Context,
+    settings,
+    llm,
+    beats: List[str],
+    target_count: int,
     prev_judge_scores: dict | None = None,
 ) -> List[ScriptSegment]:
     """Phase 2: Expand each beat into exactly one narration segment.
@@ -254,7 +289,7 @@ def _expand_beats_to_script(
     hook_seconds = ctx.metadata.get("prompt_hook_seconds", 3)
 
     # Format beats as a numbered list for the prompt
-    beats_text = "\n".join(f"{i+1}. {b}" for i, b in enumerate(beats))
+    beats_text = "\n".join(f"{i + 1}. {b}" for i, b in enumerate(beats))
 
     prompt = EXPAND_PROMPT.format(
         movie=ctx.movie_name,
@@ -288,7 +323,12 @@ def _expand_beats_to_script(
         max_tokens=settings.script_max_tokens,
     )
     # v0.7.0: record LLM token usage for cost tracking
-    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None and hasattr(response, 'usage') and response.usage:
+    if (
+        hasattr(ctx, "cost_tracker")
+        and ctx.cost_tracker is not None
+        and hasattr(response, "usage")
+        and response.usage
+    ):
         ctx.cost_tracker.record_llm_call("script", llm.model, response.usage.model_dump())
     raw = response.choices[0].message.content or ""
     data = extract_json(raw)
@@ -312,10 +352,12 @@ def _expand_beats_to_script(
             text = _truncate_to_max_chars(text, max_chars)
             if len(text) < original_len:
                 truncated_count += 1
-                truncated_details.append({
-                    "original_len": original_len,
-                    "truncated_len": len(text),
-                })
+                truncated_details.append(
+                    {
+                        "original_len": original_len,
+                        "truncated_len": len(text),
+                    }
+                )
             if text:
                 segments.append(ScriptSegment(text=text))
 
@@ -353,7 +395,10 @@ _DEFAULT_PASS_SCORE = {
 
 
 def judge_script(
-    segments: List[ScriptSegment], movie_name: str, llm, ctx=None,
+    segments: List[ScriptSegment],
+    movie_name: str,
+    llm,
+    ctx=None,
 ) -> dict:
     """Judge the expanded script on five quality dimensions.
 
@@ -382,9 +427,7 @@ def judge_script(
         return dict(_DEFAULT_PASS_SCORE)
 
     # Format the segments into a numbered script block for the judge.
-    script_text = "\n".join(
-        f"{i + 1}. {s.text}" for i, s in enumerate(segments)
-    )
+    script_text = "\n".join(f"{i + 1}. {s.text}" for i, s in enumerate(segments))
 
     prompt = JUDGE_PROMPT.format(movie=movie_name, script=script_text)
 
@@ -396,7 +439,13 @@ def judge_script(
         max_tokens=320,
     )
     # v0.7.0: record LLM token usage for cost tracking
-    if ctx is not None and hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None and hasattr(response, 'usage') and response.usage:
+    if (
+        ctx is not None
+        and hasattr(ctx, "cost_tracker")
+        and ctx.cost_tracker is not None
+        and hasattr(response, "usage")
+        and response.usage
+    ):
         ctx.cost_tracker.record_llm_call("script", llm.model, response.usage.model_dump())
     raw = response.choices[0].message.content or ""
     scores = extract_json(raw)
@@ -419,10 +468,13 @@ def judge_script(
     narrative = scores.get("narrative_adherence", 0)
     scores["verdict"] = (
         "pass"
-        if (_is_int_ge(hook, 6) and _is_int_le(spoiler, 7)
+        if (
+            _is_int_ge(hook, 6)
+            and _is_int_le(spoiler, 7)
             and _is_int_ge(accuracy, 6)
             and _is_int_ge(anti_ai, 6)
-            and _is_int_ge(narrative, 5))
+            and _is_int_ge(narrative, 5)
+        )
         else "retry"
     )
     return scores
@@ -457,7 +509,7 @@ def _char_bigrams(text: str) -> frozenset[str]:
     text = text.strip().lower()
     if len(text) < 2:
         return frozenset([text])
-    return frozenset(text[i:i + 2] for i in range(len(text) - 1))
+    return frozenset(text[i : i + 2] for i in range(len(text) - 1))
 
 
 def _jaccard_similarity(a: frozenset[str], b: frozenset[str]) -> float:
@@ -549,9 +601,7 @@ def validate_script_quality(
             issues.append(f"Segment {i + 1} is too short ({seg_len} chars)")
             too_short += 1
         elif seg_len > upper_bound:
-            issues.append(
-                f"Segment {i + 1} exceeds length limit ({seg_len} > {upper_bound})"
-            )
+            issues.append(f"Segment {i + 1} exceeds length limit ({seg_len} > {upper_bound})")
             too_long += 1
 
     # Diversity check: pairwise bigram similarity
@@ -562,8 +612,7 @@ def validate_script_quality(
             sim = _jaccard_similarity(seg_bigrams[i], seg_bigrams[j])
             if sim > _QA_DIVERSITY_THRESHOLD:
                 issues.append(
-                    f"Segments {i + 1} and {j + 1} are near-duplicates "
-                    f"(similarity {sim:.0%})"
+                    f"Segments {i + 1} and {j + 1} are near-duplicates (similarity {sim:.0%})"
                 )
                 duplicates += 1
 
@@ -572,8 +621,7 @@ def validate_script_quality(
         first = segments[0].text.strip()
         if len(first) < 4:
             issues.append(
-                f"First segment (hook) is too short ({len(first)} chars) "
-                f"— needs a stronger opening"
+                f"First segment (hook) is too short ({len(first)} chars) — needs a stronger opening"
             )
 
     ctx.metadata["script_qa"] = {
@@ -667,7 +715,11 @@ def generate_script(ctx: Context) -> Context:
                 # Phase 2: expand beats into narration segments
                 with step_timing(ctx.services.console, "llm_expand_script"):
                     segments = _expand_beats_to_script(
-                        ctx, settings, llm, beats, n,
+                        ctx,
+                        settings,
+                        llm,
+                        beats,
+                        n,
                         prev_judge_scores=prev_judge_scores,
                     )
 
@@ -701,8 +753,7 @@ def generate_script(ctx: Context) -> Context:
                     _qa_issues = validate_script_quality(segments, n, _max_chars, ctx)
                     if _qa_issues:
                         ctx.services.console.inline_warn(
-                            f"Script QA: {len(_qa_issues)} issue(s) found — "
-                            f"{_qa_issues[:3]}"
+                            f"Script QA: {len(_qa_issues)} issue(s) found — {_qa_issues[:3]}"
                         )
 
                     return ctx
@@ -740,8 +791,7 @@ def generate_script(ctx: Context) -> Context:
                 _qa_issues = validate_script_quality(segments, n, _max_chars, ctx)
                 if _qa_issues:
                     ctx.services.console.inline_warn(
-                        f"Script QA: {len(_qa_issues)} issue(s) found — "
-                        f"{_qa_issues[:3]}"
+                        f"Script QA: {len(_qa_issues)} issue(s) found — {_qa_issues[:3]}"
                     )
 
                 return ctx

--- a/src/movie_narrator/pipeline/subtitle.py
+++ b/src/movie_narrator/pipeline/subtitle.py
@@ -41,9 +41,7 @@ def _lang_tag_for_filename(lang: str) -> str:
     return lang.strip().lower()
 
 
-def _resolve_render_subtitle_path(
-    ctx: Context, paths: SubtitlePaths
-) -> str | None:
+def _resolve_render_subtitle_path(ctx: Context, paths: SubtitlePaths) -> str | None:
     """Pick the render-overlay subtitle path per `subtitle_mode` (spec §7.2 step 4).
 
     `mode == "original"` always picks the original. For `translated` /
@@ -94,9 +92,8 @@ def generate_subtitle(ctx: Context) -> Context:
     ctx.subtitle_path = str(original_path)
 
     # 2. Translated + bilingual — only when both sides are aligned.
-    has_translations = (
-        bool(ctx.translated_texts)
-        and len(ctx.translated_texts) == len(ctx.timed_segments)
+    has_translations = bool(ctx.translated_texts) and len(ctx.translated_texts) == len(
+        ctx.timed_segments
     )
     if has_translations:
         target_lang = ctx.metadata.get("subtitle_lang") or "translated"
@@ -106,15 +103,11 @@ def generate_subtitle(ctx: Context) -> Context:
 
         translated_cues: list[tuple[int, str, str, str]] = [
             (i, _format_time(seg.start), _format_time(seg.end), tr)
-            for i, (seg, tr) in enumerate(
-                zip(ctx.timed_segments, ctx.translated_texts), 1
-            )
+            for i, (seg, tr) in enumerate(zip(ctx.timed_segments, ctx.translated_texts), 1)
         ]
         bilingual_cues: list[tuple[int, str, str, str]] = [
             (i, _format_time(seg.start), _format_time(seg.end), f"{seg.text}\n{tr}")
-            for i, (seg, tr) in enumerate(
-                zip(ctx.timed_segments, ctx.translated_texts), 1
-            )
+            for i, (seg, tr) in enumerate(zip(ctx.timed_segments, ctx.translated_texts), 1)
         ]
         _write_srt(translated_path, translated_cues)
         _write_srt(bilingual_path, bilingual_cues)
@@ -156,11 +149,13 @@ def generate_subtitle(ctx: Context) -> Context:
                 is_vertical=is_vertical,
             )
             if not fits:
-                display_issues.append({
-                    "index": i,
-                    "estimated_lines": est_lines,
-                    "max_lines": max_lines,
-                })
+                display_issues.append(
+                    {
+                        "index": i,
+                        "estimated_lines": est_lines,
+                        "max_lines": max_lines,
+                    }
+                )
 
         if display_issues:
             ctx.metadata["subtitle_qa"]["display_fit_issues"] = display_issues
@@ -178,8 +173,7 @@ def generate_subtitle(ctx: Context) -> Context:
         overlap_count = qa_original.get("overlap_count", 0)
         if total_issues or overlap_count:
             console.inline_warn(
-                f"Subtitle QA: {total_issues} cue issue(s), "
-                f"{overlap_count} overlap(s) detected."
+                f"Subtitle QA: {total_issues} cue issue(s), {overlap_count} overlap(s) detected."
             )
 
     return ctx

--- a/src/movie_narrator/pipeline/translate.py
+++ b/src/movie_narrator/pipeline/translate.py
@@ -126,7 +126,7 @@ def _call_llm_chunk(
             max_tokens=get_settings().translate_max_tokens,
         )
         # v0.7.0: Record LLM cost for translation
-        if cost_tracker is not None and hasattr(resp, 'usage') and resp.usage:
+        if cost_tracker is not None and hasattr(resp, "usage") and resp.usage:
             cost_tracker.record_llm_call("translate", llm.model, resp.usage.model_dump())
     raw = (resp.choices[0].message.content or "").strip()
     parsed = extract_json(raw)
@@ -260,7 +260,7 @@ def translate_subtitles(ctx: Context) -> Context:
     # Use `lang` (single source of truth) as default source
     # language for translation, falling back to "zh" for backward compat.
     narration_lang = ctx.metadata.get("lang", "zh")
-    source_lang = (ctx.metadata.get("translate_source_lang") or narration_lang)
+    source_lang = ctx.metadata.get("translate_source_lang") or narration_lang
     ctx.metadata.setdefault("translate_source_lang", source_lang)
 
     # i18n (v0.9.6): record the full translation direction + both narration
@@ -296,7 +296,7 @@ def translate_subtitles(ctx: Context) -> Context:
             retries=retries,
             max_chars=max_chars,
             max_items=max_items,
-            cost_tracker=ctx.cost_tracker if hasattr(ctx, 'cost_tracker') else None,
+            cost_tracker=ctx.cost_tracker if hasattr(ctx, "cost_tracker") else None,
         )
     except _ChunkFailure as cf:
         # At least one chunk failed after retries. Fill failed slots

--- a/src/movie_narrator/pipeline/tts.py
+++ b/src/movie_narrator/pipeline/tts.py
@@ -31,7 +31,7 @@ _TTS_SEGMENT_RETRIES = 3
 _TTS_RETRY_DELAY = 1.0  # seconds
 
 # v0.5.9: V2 duration feedback — speed adjustment for overflow segments.
-_MAX_SPEEDUP = 1.15          # cap at 15% faster to avoid chipmunk effect
+_MAX_SPEEDUP = 1.15  # cap at 15% faster to avoid chipmunk effect
 _OVERFLOW_THRESHOLD_V2 = 1.10  # trigger v2 when >10% over target after v1
 
 
@@ -196,11 +196,13 @@ def generate_voice(ctx: Context) -> Context:
     # from the gather results (ordered by input segment), NOT collected as
     # a side-effect, so the flags stay aligned with ``ctx.segments`` even
     # when segments complete out of order under ``tts_max_concurrent``.
-    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
+    if hasattr(ctx, "cost_tracker") and ctx.cost_tracker is not None:
         provider_name = settings.tts_provider.value
         tts_model = (
-            settings.openai_tts_model if settings.tts_provider is TTSProviderType.OPENAI
-            else settings.mimo_tts_model if settings.tts_provider is TTSProviderType.MIMO
+            settings.openai_tts_model
+            if settings.tts_provider is TTSProviderType.OPENAI
+            else settings.mimo_tts_model
+            if settings.tts_provider is TTSProviderType.MIMO
             else ""
         )
         for i, seg in enumerate(ctx.segments):
@@ -227,13 +229,15 @@ def generate_voice(ctx: Context) -> Context:
             audio, _ = results[i]
             adjusted = apply_speed(audio, speed)
             results[i] = (adjusted, round(len(adjusted) / 1000.0, 3))
-        prosody_log.append({
-            "index": i, "emotion": emotion, "speed": round(speed, 3),
-        })
+        prosody_log.append(
+            {
+                "index": i,
+                "emotion": emotion,
+                "speed": round(speed, 3),
+            }
+        )
 
-    combined, timed_segments = _build_audio(
-        results, ctx.segments, pause_ms
-    )
+    combined, timed_segments = _build_audio(results, ctx.segments, pause_ms)
 
     # ── v1 duration pause feedback ─────────────────────
     # If narration exceeds target duration by >15%, try reducing pause_ms
@@ -258,14 +262,15 @@ def generate_voice(ctx: Context) -> Context:
                     f"(ratio {ratio:.2f}). Reducing pause {pause_ms}ms → {new_pause_ms}ms."
                 )
                 applied_pause_ms = new_pause_ms
-                combined, timed_segments = _build_audio(
-                    results, ctx.segments, new_pause_ms
-                )
+                combined, timed_segments = _build_audio(results, ctx.segments, new_pause_ms)
                 ctx.metadata["duration_metrics"] = {
                     "target_sec": target_duration,
                     "narration_sec": round(timed_segments[-1].end, 2) if timed_segments else 0,
                     "ratio_vs_target": round(
-                        (timed_segments[-1].end / target_duration) if timed_segments and target_duration else 0, 3
+                        (timed_segments[-1].end / target_duration)
+                        if timed_segments and target_duration
+                        else 0,
+                        3,
                     ),
                     "pause_ms_original": pause_ms,
                     "pause_ms_applied": new_pause_ms,
@@ -311,17 +316,15 @@ def generate_voice(ctx: Context) -> Context:
                     adj = apply_speed(audio, v2_speed)
                     adjusted_results.append((adj, round(len(adj) / 1000.0, 3)))
                 results = adjusted_results
-                combined, timed_segments = _build_audio(
-                    results, ctx.segments, applied_pause_ms
-                )
+                combined, timed_segments = _build_audio(results, ctx.segments, applied_pause_ms)
                 dm = ctx.metadata.get("duration_metrics", {})
                 dm["v2_speed_applied"] = round(v2_speed, 3)
-                dm["narration_sec_v2"] = round(
-                    timed_segments[-1].end, 2
-                ) if timed_segments else 0
+                dm["narration_sec_v2"] = round(timed_segments[-1].end, 2) if timed_segments else 0
                 dm["ratio_v2"] = round(
                     (timed_segments[-1].end / target_duration)
-                    if timed_segments and target_duration else 0, 3
+                    if timed_segments and target_duration
+                    else 0,
+                    3,
                 )
                 ctx.metadata["duration_metrics"] = dm
 

--- a/src/movie_narrator/plugin_loader.py
+++ b/src/movie_narrator/plugin_loader.py
@@ -107,9 +107,7 @@ def discover_plugins(*, group: str = ENTRY_POINT_GROUP) -> List[PluginLoadResult
         except Exception as exc:  # noqa: BLE001
             msg = f"Failed to load plugin '{ep.name}': {exc}"
             warnings.warn(msg, stacklevel=2)
-            results.append(
-                PluginLoadResult(name=ep.name, success=False, error=str(exc))
-            )
+            results.append(PluginLoadResult(name=ep.name, success=False, error=str(exc)))
 
     return results
 

--- a/src/movie_narrator/presets/base.py
+++ b/src/movie_narrator/presets/base.py
@@ -34,63 +34,65 @@ ALLOWED_PROMPT_TAGS: Dict[str, frozenset[str]] = {
 # registration time.  Single source of truth lives in runner.py;
 # this frozenset is intentionally a subset so presets can't set
 # infrastructure keys (whisperx_*, translate_*, async_*, video_sizes).
-ALLOWED_PARAM_KEYS: frozenset[str] = frozenset({
-    # Match / scene
-    "match_speed_clamp_min",
-    "match_speed_clamp_max",
-    "scene_merge_min_duration",
-    "match_drop_scene_min_duration",
-    "match_min_score",
-    # Scene filtering configuration
-    "match_skip_intro_sec",
-    "match_drop_dark_luma",
-    "match_source_window",
-    # BGM
-    "bgm_gain_db",
-    "bgm_duck_db",
-    "bgm_normalize",
-    "audio_target_dbfs",
-    "bgm_loudnorm",
-    # BGM emotion-based selection metadata file
-    "bgm_metadata_path",
-    # Render / subtitle
-    "render_subtitle_position",
-    "render_subtitle_max_width_ratio",
-    "render_subtitle_bottom_margin_ratio",
-    "render_font_size",
-    "render_fit_mode",
-    "render_crf",
-    "render_preset",
-    "render_faststart",
-    # TTS pacing
-    "tts_pause_ms",
-    # QA
-    "qa_enabled",
-    "qa_max_silence_db",
-    "qa_min_duration_ratio",
-    "qa_max_duration_ratio",
-    # Prompt shaping (new — added to whitelist in schema/load/runner)
-    "prompt_target_sentences",
-    "prompt_target_segment_duration",
-    "prompt_max_chars_per_sentence",
-    "prompt_hook_seconds",
-    # Hook templates and set pieces
-    "hook_templates",
-    "set_pieces",
-    # Title card, cover export, and vertical safe area
-    "render_title_card_sec",
-    "render_cover_export",
-    "render_vertical_safe_area",
-    # Target platform for tone adaptation
-    "target_platform",
-    # Narration language
-    "lang",
-    # Render template — per-preset styling dict
-    "render_template",
-    # Narrator perspective and character anchor
-    "narrator_perspective",
-    "focus_character",
-})
+ALLOWED_PARAM_KEYS: frozenset[str] = frozenset(
+    {
+        # Match / scene
+        "match_speed_clamp_min",
+        "match_speed_clamp_max",
+        "scene_merge_min_duration",
+        "match_drop_scene_min_duration",
+        "match_min_score",
+        # Scene filtering configuration
+        "match_skip_intro_sec",
+        "match_drop_dark_luma",
+        "match_source_window",
+        # BGM
+        "bgm_gain_db",
+        "bgm_duck_db",
+        "bgm_normalize",
+        "audio_target_dbfs",
+        "bgm_loudnorm",
+        # BGM emotion-based selection metadata file
+        "bgm_metadata_path",
+        # Render / subtitle
+        "render_subtitle_position",
+        "render_subtitle_max_width_ratio",
+        "render_subtitle_bottom_margin_ratio",
+        "render_font_size",
+        "render_fit_mode",
+        "render_crf",
+        "render_preset",
+        "render_faststart",
+        # TTS pacing
+        "tts_pause_ms",
+        # QA
+        "qa_enabled",
+        "qa_max_silence_db",
+        "qa_min_duration_ratio",
+        "qa_max_duration_ratio",
+        # Prompt shaping (new — added to whitelist in schema/load/runner)
+        "prompt_target_sentences",
+        "prompt_target_segment_duration",
+        "prompt_max_chars_per_sentence",
+        "prompt_hook_seconds",
+        # Hook templates and set pieces
+        "hook_templates",
+        "set_pieces",
+        # Title card, cover export, and vertical safe area
+        "render_title_card_sec",
+        "render_cover_export",
+        "render_vertical_safe_area",
+        # Target platform for tone adaptation
+        "target_platform",
+        # Narration language
+        "lang",
+        # Render template — per-preset styling dict
+        "render_template",
+        # Narrator perspective and character anchor
+        "narrator_perspective",
+        "focus_character",
+    }
+)
 
 # Safety: ALLOWED_PARAM_KEYS must be a subset of PARAM_WHITELIST.
 # This check is performed in registry._validate() at registration time

--- a/src/movie_narrator/presets/registry.py
+++ b/src/movie_narrator/presets/registry.py
@@ -137,9 +137,7 @@ def get_preset(name: str) -> PresetParam:
     reg = _get_registry()
     if name not in reg:
         available = ", ".join(sorted(reg))
-        raise KeyError(
-            f"Unknown narration preset '{name}'. Available: {available}"
-        )
+        raise KeyError(f"Unknown narration preset '{name}'. Available: {available}")
     return reg[name]
 
 

--- a/src/movie_narrator/providers/registry.py
+++ b/src/movie_narrator/providers/registry.py
@@ -125,8 +125,7 @@ class ProviderRegistry:
         if factory is None:
             available = sorted(self._factories.keys())
             raise ValueError(
-                f"Unknown {self._category} provider: {name!r}. "
-                f"Registered: {available}"
+                f"Unknown {self._category} provider: {name!r}. Registered: {available}"
             )
         instance = factory(*args, **kwargs)
         if self._protocol is not None and not isinstance(instance, self._protocol):

--- a/src/movie_narrator/providers/tmdb.py
+++ b/src/movie_narrator/providers/tmdb.py
@@ -213,12 +213,17 @@ def _search_movie(
     base_url: str, api_key: str, query: str, language: str
 ) -> Optional[Dict[str, Any]]:
     """Search TMDB for a movie by title. Returns the first result or None."""
-    data = _tmdb_get(base_url, _TMDB_SEARCH_PATH, api_key, {
-        "query": query,
-        "language": language,
-        "page": "1",
-        "include_adult": "false",
-    })
+    data = _tmdb_get(
+        base_url,
+        _TMDB_SEARCH_PATH,
+        api_key,
+        {
+            "query": query,
+            "language": language,
+            "page": "1",
+            "include_adult": "false",
+        },
+    )
     if not data or not isinstance(data, dict):
         return None
     results = data.get("results")
@@ -232,10 +237,15 @@ def _get_movie_details(
 ) -> Optional[Dict[str, Any]]:
     """Fetch detailed movie info from TMDB with credits appended."""
     path = _TMDB_MOVIE_PATH.format(movie_id=movie_id)
-    return _tmdb_get(base_url, path, api_key, {
-        "language": language,
-        "append_to_response": "credits",
-    })
+    return _tmdb_get(
+        base_url,
+        path,
+        api_key,
+        {
+            "language": language,
+            "append_to_response": "credits",
+        },
+    )
 
 
 def _extract_director(credits: Dict[str, Any]) -> Optional[str]:  # noqa: A002
@@ -338,13 +348,9 @@ def tmdb_research(ctx: Context, settings: Settings) -> ResearchInfo:
             settings.tmdb_base_url, api_key, ctx.movie_name, settings.tmdb_language
         )
     except (urllib.error.URLError, OSError) as e:
-        raise RuntimeError(
-            f"TMDB search failed for '{ctx.movie_name}': network error: {e}"
-        ) from e
+        raise RuntimeError(f"TMDB search failed for '{ctx.movie_name}': network error: {e}") from e
     if not search_result or not isinstance(search_result, dict):
-        raise RuntimeError(
-            f"Movie '{ctx.movie_name}' not found on TMDB"
-        )
+        raise RuntimeError(f"Movie '{ctx.movie_name}' not found on TMDB")
 
     movie_id = search_result.get("id")
     if not isinstance(movie_id, int):
@@ -372,9 +378,7 @@ def tmdb_research(ctx: Context, settings: Settings) -> ResearchInfo:
 # ── Card enrichment (cross-validation) ────────────────────
 
 
-def enrich_movie_card_with_tmdb(
-    card: MovieCard, ctx: Context, settings: Settings
-) -> MovieCard:
+def enrich_movie_card_with_tmdb(card: MovieCard, ctx: Context, settings: Settings) -> MovieCard:
     """Cross-validate and enrich an LLM-sourced MovieCard with TMDB data.
 
     When TMDB is available (API key configured and movie found), this
@@ -406,8 +410,7 @@ def enrich_movie_card_with_tmdb(
         )
     except (urllib.error.URLError, OSError) as e:
         logger.warning(
-            f"TMDB enrichment: network error while searching for "
-            f"'{ctx.movie_name}': {e}"
+            f"TMDB enrichment: network error while searching for '{ctx.movie_name}': {e}"
         )
         return card
     if not search_result or not isinstance(search_result, dict):
@@ -424,8 +427,7 @@ def enrich_movie_card_with_tmdb(
         )
     except (urllib.error.URLError, OSError) as e:
         logger.warning(
-            f"TMDB enrichment: network error while fetching details for "
-            f"movie ID {movie_id}: {e}"
+            f"TMDB enrichment: network error while fetching details for movie ID {movie_id}: {e}"
         )
         return card
     if not details or not isinstance(details, dict):
@@ -456,9 +458,7 @@ def enrich_movie_card_with_tmdb(
 
     if corrections:
         ctx.metadata["tmdb_corrections"] = corrections
-        logger.info(
-            f"TMDB enrichment corrected {len(corrections)} field(s): {corrections}"
-        )
+        logger.info(f"TMDB enrichment corrected {len(corrections)} field(s): {corrections}")
 
     ctx.metadata["movie_card_source"] = "tmdb_enriched"
     return enriched

--- a/src/movie_narrator/race.py
+++ b/src/movie_narrator/race.py
@@ -158,7 +158,7 @@ def generate_candidates(
         for i in range(min(n, len(presets))):
             candidates.append(
                 CandidateConfig(
-                    label=f"candidate-{i+1}",
+                    label=f"candidate-{i + 1}",
                     narration_preset=presets[i],
                     match_topk=topk_gradient[i % len(topk_gradient)],
                     match_topk_reuse_penalty=penalty_gradient[i % len(penalty_gradient)],
@@ -248,10 +248,7 @@ def score_candidate(metadata: Dict[str, Any]) -> tuple[float, Dict[str, float]]:
     }
 
     total = (
-        match_quality * 0.40
-        + duration_fit * 0.25
-        + diversity * 0.20
-        + scene_coverage * 0.15
+        match_quality * 0.40 + duration_fit * 0.25 + diversity * 0.20 + scene_coverage * 0.15
     ) * 100.0
 
     return round(total, 2), breakdown
@@ -303,7 +300,7 @@ def run_race(
     results: List[CandidateResult] = []
 
     for i, cand in enumerate(candidates):
-        cand_dir = output_base / f"candidate-{i+1}-{cand.label}"
+        cand_dir = output_base / f"candidate-{i + 1}-{cand.label}"
         cand_dir.mkdir(parents=True, exist_ok=True)
 
         result = CandidateResult(
@@ -312,28 +309,30 @@ def run_race(
         )
 
         try:
-            ctx = build_context(**common_build_kwargs(
-                movie=movie,
-                style=style,
-                duration=duration,
-                voice=voice,
-                video_format=video_format,
-                output_dir=cand_dir,
-                keep_cache=keep_cache,
-                video=video,
-                library_dir=library_dir,
-                research=research,
-                bgm=bgm,
-                no_bgm=no_bgm,
-                no_clips=no_clips,
-                strict=strict,
-                params=cand.to_params(),
-                config_path=config_path,
-                subtitle_lang=subtitle_lang,
-                subtitle_mode=subtitle_mode,
-                narration_preset=cand.narration_preset,
-                lang="zh",  # race mode defaults to Chinese
-            ))
+            ctx = build_context(
+                **common_build_kwargs(
+                    movie=movie,
+                    style=style,
+                    duration=duration,
+                    voice=voice,
+                    video_format=video_format,
+                    output_dir=cand_dir,
+                    keep_cache=keep_cache,
+                    video=video,
+                    library_dir=library_dir,
+                    research=research,
+                    bgm=bgm,
+                    no_bgm=no_bgm,
+                    no_clips=no_clips,
+                    strict=strict,
+                    params=cand.to_params(),
+                    config_path=config_path,
+                    subtitle_lang=subtitle_lang,
+                    subtitle_mode=subtitle_mode,
+                    narration_preset=cand.narration_preset,
+                    lang="zh",  # race mode defaults to Chinese
+                )
+            )
 
             ctx = run_pipeline(ctx)
 
@@ -347,7 +346,9 @@ def run_race(
             if footage_coverage:
                 ctx.metadata["footage_coverage"] = footage_coverage
 
-            result.score, result.score_breakdown = score_candidate(cast(Dict[str, Any], ctx.metadata))
+            result.score, result.score_breakdown = score_candidate(
+                cast(Dict[str, Any], ctx.metadata)
+            )
             result.metadata_path = cand_dir / "metadata.json"
 
         except PipelinePaused:
@@ -442,7 +443,9 @@ def format_race_report(results: List[CandidateResult]) -> str:
         f"{'Status':<10}"
     )
     lines.append(header)
-    lines.append(f"  {'-'*3} {'-'*14} {'-'*7}  {'-'*6}  {'-'*6}  {'-'*6}  {'-'*6}  {'-'*10}")
+    lines.append(
+        f"  {'-' * 3} {'-' * 14} {'-' * 7}  {'-' * 6}  {'-' * 6}  {'-' * 6}  {'-' * 6}  {'-' * 10}"
+    )
 
     for i, r in enumerate(results):
         bd = r.score_breakdown
@@ -456,7 +459,7 @@ def format_race_report(results: List[CandidateResult]) -> str:
         if i == 0:
             medal = " *"
         lines.append(
-            f"  {i+1:<3} {r.config.label:<14} {r.score:>6.1f}{medal}  "
+            f"  {i + 1:<3} {r.config.label:<14} {r.score:>6.1f}{medal}  "
             f"{match_v:>6}  {dur_v:>6}  {div_v:>6}  {cov_v:>6}  "
             f"{status:<10}"
         )
@@ -515,21 +518,23 @@ def save_race_report(
     }
 
     for i, r in enumerate(results):
-        report["candidates"].append({
-            "rank": i + 1,
-            "label": r.config.label,
-            "preset": r.config.narration_preset,
-            "match_topk": r.config.match_topk,
-            "reuse_penalty": r.config.match_topk_reuse_penalty,
-            "diversity_window": r.config.match_diversity_window,
-            "score": r.score,
-            "score_breakdown": r.score_breakdown,
-            "video_path": r.video_path,
-            "output_dir": str(r.output_dir),
-            "error": r.error,
-            "match_summary": r.match_summary,
-            "duration_metrics": r.duration_metrics,
-        })
+        report["candidates"].append(
+            {
+                "rank": i + 1,
+                "label": r.config.label,
+                "preset": r.config.narration_preset,
+                "match_topk": r.config.match_topk,
+                "reuse_penalty": r.config.match_topk_reuse_penalty,
+                "diversity_window": r.config.match_diversity_window,
+                "score": r.score,
+                "score_breakdown": r.score_breakdown,
+                "video_path": r.video_path,
+                "output_dir": str(r.output_dir),
+                "error": r.error,
+                "match_summary": r.match_summary,
+                "duration_metrics": r.duration_metrics,
+            }
+        )
 
     output_path.write_text(
         json.dumps(report, ensure_ascii=False, indent=2, default=str),

--- a/src/movie_narrator/reliability/circuit_breaker.py
+++ b/src/movie_narrator/reliability/circuit_breaker.py
@@ -416,6 +416,7 @@ def circuit_guard(
 
     def decorator(fn: Callable[..., _T]) -> Callable[..., _T]:
         """Register a decorator function."""
+
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> _T:
             """Wrapper function for the decorator pattern."""

--- a/src/movie_narrator/reliability/retry.py
+++ b/src/movie_narrator/reliability/retry.py
@@ -79,9 +79,7 @@ class RetryPolicy:
         """
         if self.should_retry is not None:
             return bool(self.should_retry(exc))
-        if self.retryable_exceptions is not None and not isinstance(
-            exc, self.retryable_exceptions
-        ):
+        if self.retryable_exceptions is not None and not isinstance(exc, self.retryable_exceptions):
             return False
         retryable_attr = getattr(exc, "retryable", False)
         return bool(retryable_attr) or is_network_error(exc)
@@ -162,6 +160,7 @@ def with_retry(policy: RetryPolicy) -> Callable[[Callable[..., _T]], Callable[..
 
     def decorator(fn: Callable[..., _T]) -> Callable[..., _T]:
         """Register a decorator function."""
+
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> _T:
             """Wrapper function for the decorator pattern."""
@@ -174,8 +173,7 @@ def with_retry(policy: RetryPolicy) -> Callable[[Callable[..., _T]], Callable[..
                         raise
                     delay = _sleep_delay(attempt + 1, policy)
                     logger.debug(
-                        "retry[%s]: attempt %d/%d failed with %s: %s; "
-                        "retrying in %.3fs",
+                        "retry[%s]: attempt %d/%d failed with %s: %s; retrying in %.3fs",
                         getattr(fn, "__name__", fn),
                         attempt + 1,
                         policy.max_attempts,
@@ -217,6 +215,7 @@ def with_async_retry(
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
         """Register a decorator function."""
+
         @wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             """(async) Wrapper function for the decorator pattern."""
@@ -229,8 +228,7 @@ def with_async_retry(
                         raise
                     delay = _sleep_delay(attempt + 1, policy)
                     logger.debug(
-                        "async_retry[%s]: attempt %d/%d failed with %s: %s; "
-                        "retrying in %.3fs",
+                        "async_retry[%s]: attempt %d/%d failed with %s: %s; retrying in %.3fs",
                         getattr(fn, "__name__", fn),
                         attempt + 1,
                         policy.max_attempts,

--- a/src/movie_narrator/tts/base.py
+++ b/src/movie_narrator/tts/base.py
@@ -87,5 +87,4 @@ class BaseTTSProvider(TTSProvider):
         audio.export(output_path, format="mp3")
 
     @abstractmethod
-    async def _real_synthesize(self, text: str, voice: str, output_path: Path) -> None:
-        ...
+    async def _real_synthesize(self, text: str, voice: str, output_path: Path) -> None: ...

--- a/src/movie_narrator/tts/cache.py
+++ b/src/movie_narrator/tts/cache.py
@@ -21,13 +21,13 @@ PROVIDER_CACHE_VERSIONS: dict[str, int] = {
 class TTSCacheKey:
     """Cache key for TTS audio results."""
 
-    schema_version: int   # currently 3; bumps when key shape changes
-    provider: str         # "edge" | "openai" | "mimo"
+    schema_version: int  # currently 3; bumps when key shape changes
+    provider: str  # "edge" | "openai" | "mimo"
     provider_version: int  # per-backend encoding version
-    model: str            # "" for Edge, "tts-1" for OpenAI
+    model: str  # "" for Edge, "tts-1" for OpenAI
     voice: str
     text: str
-    style_prompt: str     # ST-08: MiMo style_prompt affects audio; must be in key
+    style_prompt: str  # ST-08: MiMo style_prompt affects audio; must be in key
 
 
 def cache_path_for(root: Path, key: TTSCacheKey) -> Path:

--- a/src/movie_narrator/tts/factory.py
+++ b/src/movie_narrator/tts/factory.py
@@ -20,16 +20,19 @@ from .protocol import TTSProvider
 
 def _make_edge(settings: Settings) -> TTSProvider:
     from .edge import EdgeTTSProvider
+
     return EdgeTTSProvider()
 
 
 def _make_openai(settings: Settings) -> TTSProvider:
     from .openai_provider import OpenAITTSProvider
+
     return OpenAITTSProvider(settings)
 
 
 def _make_mimo(settings: Settings) -> TTSProvider:
     from .mimo_provider import MimoTTSProvider
+
     return MimoTTSProvider(settings)
 
 
@@ -68,6 +71,5 @@ def get_tts_provider(settings: Settings) -> TTSProvider:
         return tts_registry.create(provider_name, settings)
 
     raise ConfigError(
-        f"Unsupported TTS provider: {settings.tts_provider!r}. "
-        f"Registered: {tts_registry.names()}"
+        f"Unsupported TTS provider: {settings.tts_provider!r}. Registered: {tts_registry.names()}"
     )

--- a/src/movie_narrator/tts/mimo_provider.py
+++ b/src/movie_narrator/tts/mimo_provider.py
@@ -44,9 +44,7 @@ class MimoTTSProvider(BaseTTSProvider):
     def __init__(self, settings: Settings):
         api_key = settings.mimo_api_key or settings.llm_api_key
         if not api_key:
-            raise ConfigError(
-                "MiMo TTS requires MN_MIMO_API_KEY or MN_LLM_API_KEY set."
-            )
+            raise ConfigError("MiMo TTS requires MN_MIMO_API_KEY or MN_LLM_API_KEY set.")
         # Lazy import keeps startup lighter and allows future optional packaging.
         from openai import OpenAI
 
@@ -71,19 +69,14 @@ class MimoTTSProvider(BaseTTSProvider):
             audio_param = {"format": "wav", "optimize_text_preview": True}
         else:
             raise ConfigError(
-                f"Unsupported MiMo TTS model: {self._model!r}. "
-                f"Supported: {sorted(_MIMO_MODELS)}"
+                f"Unsupported MiMo TTS model: {self._model!r}. Supported: {sorted(_MIMO_MODELS)}"
             )
 
-        completion = await asyncio.to_thread(
-            self._call_api, text, user_content, audio_param
-        )
+        completion = await asyncio.to_thread(self._call_api, text, user_content, audio_param)
 
         message = completion.choices[0].message
         if not getattr(message, "audio", None) or not message.audio.data:
-            raise RuntimeError(
-                f"MiMo TTS returned no audio data (model={self._model})"
-            )
+            raise RuntimeError(f"MiMo TTS returned no audio data (model={self._model})")
 
         raw = base64.b64decode(message.audio.data)
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -109,9 +102,7 @@ class MimoTTSProvider(BaseTTSProvider):
         if voice_path not in self._voice_b64_cache:
             p = Path(voice_path)
             if not p.exists():
-                raise ConfigError(
-                    f"Voice clone file not found: {voice_path}"
-                )
+                raise ConfigError(f"Voice clone file not found: {voice_path}")
             b64 = base64.b64encode(p.read_bytes()).decode("utf-8")
             self._voice_b64_cache[voice_path] = f"data:audio/wav;base64,{b64}"
         return self._voice_b64_cache[voice_path]

--- a/src/movie_narrator/tts/openai_provider.py
+++ b/src/movie_narrator/tts/openai_provider.py
@@ -23,9 +23,7 @@ class OpenAITTSProvider(BaseTTSProvider):
         api_key = settings.openai_tts_api_key or settings.llm_api_key
         base_url = settings.openai_tts_base_url or settings.llm_base_url
         if not api_key:
-            raise ConfigError(
-                "OpenAI TTS requires MN_OPENAI_TTS_API_KEY or MN_LLM_API_KEY set."
-            )
+            raise ConfigError("OpenAI TTS requires MN_OPENAI_TTS_API_KEY or MN_LLM_API_KEY set.")
         # Lazy import keeps startup lighter and allows future optional packaging.
         from openai import OpenAI
 

--- a/src/movie_narrator/utils/alignment_qa.py
+++ b/src/movie_narrator/utils/alignment_qa.py
@@ -92,12 +92,14 @@ def extract_word_segments(
         word = ws.get("word", "").strip()
         if not word:
             continue
-        extracted.append({
-            "word": word,
-            "start": float(ws.get("start", 0.0)),
-            "end": float(ws.get("end", 0.0)),
-            "score": float(ws.get("score", 0.0)),
-        })
+        extracted.append(
+            {
+                "word": word,
+                "start": float(ws.get("start", 0.0)),
+                "end": float(ws.get("end", 0.0)),
+                "score": float(ws.get("score", 0.0)),
+            }
+        )
     return extracted
 
 
@@ -138,12 +140,14 @@ def assign_words_to_segments(
             ws = word_segments[ptr]
             # Include word if it overlaps with the segment's time range
             if ws["end"] >= ts.start and ws["start"] <= ts.end:
-                ts_words.append(WordSegment(
-                    word=ws["word"],
-                    start=ws["start"],
-                    end=ws["end"],
-                    score=ws["score"],
-                ))
+                ts_words.append(
+                    WordSegment(
+                        word=ws["word"],
+                        start=ws["start"],
+                        end=ws["end"],
+                        score=ws["score"],
+                    )
+                )
             ptr += 1
 
         if ts_words:
@@ -301,10 +305,7 @@ def validate_alignment(
         total_segments=len(timed_segments),
     )
 
-    confidences = [
-        ts.confidence for ts in timed_segments
-        if ts.confidence > 0
-    ]
+    confidences = [ts.confidence for ts in timed_segments if ts.confidence > 0]
 
     metrics.segments_with_words = len(confidences)
     metrics.word_level_available = len(confidences) > 0

--- a/src/movie_narrator/utils/audio_mix.py
+++ b/src/movie_narrator/utils/audio_mix.py
@@ -147,7 +147,7 @@ def duck_bgm(
 
     # Apply gain to raw samples
     raw = np.array(bgm_base.get_array_of_samples(), dtype=np.float64)
-    raw *= per_sample[:len(raw)]
+    raw *= per_sample[: len(raw)]
     raw = np.clip(raw, np.iinfo(np.int16).min, np.iinfo(np.int16).max)
     raw = raw.astype(np.int16)
 

--- a/src/movie_narrator/utils/audio_qa.py
+++ b/src/movie_narrator/utils/audio_qa.py
@@ -95,7 +95,7 @@ def estimate_snr(audio: AudioSegment, silence_threshold_dbfs: float = -50.0) -> 
     rms_values = []
     for i in range(n_windows):
         chunk = samples[i * window_samples : (i + 1) * window_samples]
-        rms = np.sqrt(np.mean(chunk ** 2))
+        rms = np.sqrt(np.mean(chunk**2))
         rms_values.append(rms)
 
     rms_arr = np.array(rms_values)
@@ -139,7 +139,7 @@ def check_silence(audio: AudioSegment, silence_threshold_dbfs: float = -50.0) ->
     max_val = float(np.iinfo(np.int16).max)
     for i in range(n_windows):
         chunk = samples[i * window_samples : (i + 1) * window_samples]
-        rms = np.sqrt(np.mean(chunk ** 2))
+        rms = np.sqrt(np.mean(chunk**2))
         rms_db = 20 * np.log10(max(rms / max_val, 1e-10))
         if rms_db <= silence_threshold_dbfs:
             silent_count += 1
@@ -174,14 +174,10 @@ def analyze_segment(
     issues: list[str] = []
 
     if clipping_ratio > max_clipping_ratio:
-        issues.append(
-            f"clipping detected: {clipping_ratio:.2%} samples near max amplitude"
-        )
+        issues.append(f"clipping detected: {clipping_ratio:.2%} samples near max amplitude")
 
     if silence_ratio > max_silence_ratio:
-        issues.append(
-            f"high silence ratio: {silence_ratio:.1%} of segment is silent"
-        )
+        issues.append(f"high silence ratio: {silence_ratio:.1%} of segment is silent")
 
     if snr_db is not None and snr_db < min_snr_db:
         issues.append(f"low SNR: {snr_db:.1f}dB < {min_snr_db}dB threshold")
@@ -209,9 +205,8 @@ def aggregate_metrics(metrics: list[SegmentAudioMetrics]) -> dict:
     total_issues = sum(len(m.issues) for m in metrics)
     segments_with_issues = sum(1 for m in metrics if m.issues)
     avg_duration = sum(m.duration_s for m in metrics) / len(metrics)
-    avg_snr = (
-        sum(m.snr_db for m in metrics if m.snr_db is not None)
-        / max(1, sum(1 for m in metrics if m.snr_db is not None))
+    avg_snr = sum(m.snr_db for m in metrics if m.snr_db is not None) / max(
+        1, sum(1 for m in metrics if m.snr_db is not None)
     )
     max_clipping = max(m.clipping_ratio for m in metrics)
     avg_silence = sum(m.silence_ratio for m in metrics) / len(metrics)

--- a/src/movie_narrator/utils/console.py
+++ b/src/movie_narrator/utils/console.py
@@ -453,8 +453,7 @@ def build_console(
     existing = [
         h
         for h in logger._logger.handlers
-        if isinstance(h, logging.FileHandler)
-        and Path(h.baseFilename).name == "latest.log"
+        if isinstance(h, logging.FileHandler) and Path(h.baseFilename).name == "latest.log"
     ]
     for h in existing:
         logger._logger.removeHandler(h)

--- a/src/movie_narrator/utils/cost_tracker.py
+++ b/src/movie_narrator/utils/cost_tracker.py
@@ -22,7 +22,7 @@ from typing import Any, Dict
 # built-in TTS providers. They are NOT precise billing values and are
 # always flagged as ``estimated`` in the summary so downstream readers
 # do not mistake them for authoritative numbers.
-_LLM_PROMPT_COST_PER_1K = 0.002   # USD per 1K prompt tokens
+_LLM_PROMPT_COST_PER_1K = 0.002  # USD per 1K prompt tokens
 _LLM_COMPLETION_COST_PER_1K = 0.006  # USD per 1K completion tokens
 
 # TTS cost per 1K characters. ``edge`` and ``mimo`` are free.
@@ -37,7 +37,7 @@ _TTS_COST_PER_1K_CHARS: Dict[str, float] = {
 class LLMCallRecord:
     """Single LLM API call record."""
 
-    step: str          # "script" | "research" | "translate"
+    step: str  # "script" | "research" | "translate"
     model: str
     prompt_tokens: int = 0
     completion_tokens: int = 0
@@ -48,7 +48,7 @@ class LLMCallRecord:
 class TTSCallRecord:
     """Single TTS call record."""
 
-    provider: str      # "edge" | "openai" | "mimo"
+    provider: str  # "edge" | "openai" | "mimo"
     model: str = ""
     characters: int = 0
     segments: int = 1
@@ -124,8 +124,7 @@ class CostTracker:
         for rec in calls:
             bucket = by_step.setdefault(
                 rec.step,
-                {"calls": 0, "prompt_tokens": 0,
-                 "completion_tokens": 0, "total_tokens": 0},
+                {"calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
             )
             bucket["calls"] += 1
             bucket["prompt_tokens"] += rec.prompt_tokens
@@ -141,8 +140,7 @@ class CostTracker:
         for rec in calls:
             bucket = by_provider.setdefault(
                 rec.provider,
-                {"calls": 0, "segments": 0, "characters": 0,
-                 "cached_segments": 0},
+                {"calls": 0, "segments": 0, "characters": 0, "cached_segments": 0},
             )
             bucket["calls"] += 1
             bucket["segments"] += rec.segments

--- a/src/movie_narrator/utils/deliverable_qa.py
+++ b/src/movie_narrator/utils/deliverable_qa.py
@@ -89,9 +89,13 @@ def _probe_with_ffprobe(path: str) -> Optional[dict]:
     try:
         proc = _run(
             [
-                ffprobe, "-v", "quiet",
-                "-print_format", "json",
-                "-show_format", "-show_streams",
+                ffprobe,
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                "-show_streams",
                 path,
             ],
             timeout=30,
@@ -110,7 +114,9 @@ def _probe_with_ffprobe(path: str) -> Optional[dict]:
 
     duration = 0.0
     try:
-        duration = float(fmt.get("duration") or (v_stream.get("duration") if v_stream else None) or 0.0)
+        duration = float(
+            fmt.get("duration") or (v_stream.get("duration") if v_stream else None) or 0.0
+        )
     except (TypeError, ValueError):
         duration = 0.0
 
@@ -151,7 +157,7 @@ def _probe_with_ffmpeg(path: str) -> dict:
     if m:
         parts = m.group(1).split(":")
         try:
-            duration = sum(float(p) * (60 ** i) for i, p in enumerate(reversed(parts)))
+            duration = sum(float(p) * (60**i) for i, p in enumerate(reversed(parts)))
         except ValueError:
             duration = 0.0
 
@@ -261,24 +267,30 @@ def evaluate_deliverable(
     if expected_duration > 0 and duration > 0:
         ratio = duration / expected_duration
         if ratio < min_duration_ratio:
-            issues.append(QAIssue(
-                "too_short",
-                f"duration {duration:.2f}s is {ratio:.2%} of expected {expected_duration:.2f}s "
-                f"(min {min_duration_ratio:.0%})",
-            ))
+            issues.append(
+                QAIssue(
+                    "too_short",
+                    f"duration {duration:.2f}s is {ratio:.2%} of expected {expected_duration:.2f}s "
+                    f"(min {min_duration_ratio:.0%})",
+                )
+            )
         elif ratio > max_duration_ratio:
-            issues.append(QAIssue(
-                "too_long",
-                f"duration {duration:.2f}s is {ratio:.2%} of expected {expected_duration:.2f}s "
-                f"(max {max_duration_ratio:.0%})",
-            ))
+            issues.append(
+                QAIssue(
+                    "too_long",
+                    f"duration {duration:.2f}s is {ratio:.2%} of expected {expected_duration:.2f}s "
+                    f"(max {max_duration_ratio:.0%})",
+                )
+            )
 
     mean_vol = metrics.get("mean_volume")
     if mean_vol is not None and mean_vol <= max_silence_db:
-        issues.append(QAIssue(
-            "silent_audio",
-            f"mean volume {mean_vol:.1f}dB <= silence floor {max_silence_db:.1f}dB",
-        ))
+        issues.append(
+            QAIssue(
+                "silent_audio",
+                f"mean volume {mean_vol:.1f}dB <= silence floor {max_silence_db:.1f}dB",
+            )
+        )
 
     # ── AQ-05: fail-closed for unknown volume ──
     # If the file claims to have audio but volumedetect failed to parse
@@ -288,16 +300,20 @@ def evaluate_deliverable(
     # Fix: treat as a warning issue so the pipeline at least surfaces it.
     has_audio = metrics.get("has_audio", False)
     if mean_vol is None and has_audio:
-        issues.append(QAIssue(
-            "volume_unknown",
-            "audio stream present but volumedetect failed — cannot verify "
-            "audio is not silent (ffmpeg may lack decoder or file may be corrupt)",
-        ))
+        issues.append(
+            QAIssue(
+                "volume_unknown",
+                "audio stream present but volumedetect failed — cannot verify "
+                "audio is not silent (ffmpeg may lack decoder or file may be corrupt)",
+            )
+        )
 
     if metrics.get("width", 0) <= 0 or metrics.get("height", 0) <= 0:
-        issues.append(QAIssue(
-            "bad_resolution",
-            f"invalid dimensions {metrics.get('width')}x{metrics.get('height')}",
-        ))
+        issues.append(
+            QAIssue(
+                "bad_resolution",
+                f"invalid dimensions {metrics.get('width')}x{metrics.get('height')}",
+            )
+        )
 
     return QAReport(ok=len(issues) == 0, issues=issues, metrics=metrics)

--- a/src/movie_narrator/utils/font.py
+++ b/src/movie_narrator/utils/font.py
@@ -12,10 +12,7 @@ from PIL import ImageFont
 def get_font(fontsize: int = 100) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     """Get the path to a usable font file."""
     project_font = (
-        Path(__file__).parent.parent.parent.parent
-        / "assets"
-        / "fonts"
-        / "NotoSansSC-Regular.otf"
+        Path(__file__).parent.parent.parent.parent / "assets" / "fonts" / "NotoSansSC-Regular.otf"
     )
     if project_font.exists():
         try:

--- a/src/movie_narrator/utils/glossary.py
+++ b/src/movie_narrator/utils/glossary.py
@@ -73,9 +73,7 @@ class GlossaryEntry:
         """
         return {
             "source_term": self.source_term,
-            "translations": {
-                tr: indices for tr, indices in self.translations.items()
-            },
+            "translations": {tr: indices for tr, indices in self.translations.items()},
             "is_consistent": self.is_consistent,
             "translation_count": self.translation_count,
             "total_occurrences": self.total_occurrences,
@@ -221,10 +219,10 @@ def _find_translation_for_term(
 
     # 2. Check if the term was quoted in the source — if so, look for
     #    quoted text in the translation at the same relative position.
-    quote_pairs = [('"', '"'), ('「', '」'), ('『', '』'), ('"', '"')]
+    quote_pairs = [('"', '"'), ("「", "」"), ("『", "』"), ('"', '"')]
     for open_q, close_q in quote_pairs:
         before = source_text[:pos]
-        after = source_text[pos + len(term):]
+        after = source_text[pos + len(term) :]
         if before.endswith(open_q) and after.startswith(close_q):
             # Extract all quoted phrases from the translation
             tr_quoted = _extract_quoted_phrases(translated_text)
@@ -249,7 +247,7 @@ def _find_translation_for_term(
         first_space = window.find(" ")
         last_space = window.rfind(" ")
         if first_space > 0 and last_space > first_space:
-            result = window[first_space:last_space + 1].strip()
+            result = window[first_space : last_space + 1].strip()
             if result and len(result) <= _MAX_TERM_LEN:
                 return result
 

--- a/src/movie_narrator/utils/json_parser.py
+++ b/src/movie_narrator/utils/json_parser.py
@@ -214,7 +214,7 @@ def extract_json(raw_text: str) -> dict:
     first = raw_text.find("{")
     last = raw_text.rfind("}")
     if first != -1 and last > first:
-        candidates.append(raw_text[first:last + 1])
+        candidates.append(raw_text[first : last + 1])
     elif first != -1:
         # No closing } — JSON is likely truncated. Try from first { to
         # end so truncation recovery can work without prefix noise

--- a/src/movie_narrator/utils/log.py
+++ b/src/movie_narrator/utils/log.py
@@ -43,9 +43,7 @@ class _JsonFormatter(logging.Formatter):
             Formatted log string.
         """
         log_entry = {
-            "ts": datetime.fromtimestamp(record.created).strftime(
-                "%Y-%m-%d %H:%M:%S.%f"
-            )[:-3],
+            "ts": datetime.fromtimestamp(record.created).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
             "level": record.levelname,
             "message": record.getMessage(),
             "logger": record.name,

--- a/src/movie_narrator/utils/logging_config.py
+++ b/src/movie_narrator/utils/logging_config.py
@@ -189,12 +189,33 @@ class CorrelationIdFilter(logging.Filter):
 
 #: Attributes present on every ``LogRecord``; anything else a caller
 #: passed via ``extra=`` is emitted as a top-level JSON field.
-_RESERVED_ATTRS = frozenset({
-    "args", "asctime", "created", "exc_info", "exc_text", "filename",
-    "funcName", "levelname", "levelno", "lineno", "message", "module",
-    "msecs", "msg", "name", "pathname", "process", "processName",
-    "relativeCreated", "stack_info", "taskName", "thread", "threadName",
-})
+_RESERVED_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
 
 
 def _isoformat_utc(timestamp: float) -> str:
@@ -230,12 +251,14 @@ def _dumps(payload: Dict[str, Any]) -> str:
     try:
         return json.dumps(safe, ensure_ascii=False, default=repr)
     except (TypeError, ValueError):
-        return json.dumps({
-            "ts": payload.get("ts", ""),
-            "level": payload.get("level", "ERROR"),
-            "logger": payload.get("logger", ""),
-            "msg": "<unserializable log record>",
-        })
+        return json.dumps(
+            {
+                "ts": payload.get("ts", ""),
+                "level": payload.get("level", "ERROR"),
+                "logger": payload.get("logger", ""),
+                "msg": "<unserializable log record>",
+            }
+        )
 
 
 def _safe_message(record: logging.LogRecord) -> str:
@@ -414,9 +437,7 @@ def configure_logging(
         The managed handler, so callers can attach extra filters.
     """
     resolved_json = _resolve_json_mode(json_mode)
-    resolved_level = _resolve_level(
-        level if level is not None else os.environ.get(ENV_LOG_LEVEL)
-    )
+    resolved_level = _resolve_level(level if level is not None else os.environ.get(ENV_LOG_LEVEL))
 
     with _config_lock:
         root = logging.getLogger()

--- a/src/movie_narrator/utils/match_quality.py
+++ b/src/movie_narrator/utils/match_quality.py
@@ -239,22 +239,10 @@ def aggregate_match_quality(
     """
     summary = MatchQualitySummary(total_clips=len(matched_clips))
 
-    composites = [
-        mc.composite_score for mc in matched_clips
-        if mc.composite_score is not None
-    ]
-    embeddings = [
-        mc.embedding_score for mc in matched_clips
-        if mc.embedding_score is not None
-    ]
-    rhythms = [
-        mc.rhythm_score for mc in matched_clips
-        if mc.rhythm_score is not None
-    ]
-    diversities = [
-        mc.diversity_score for mc in matched_clips
-        if mc.diversity_score is not None
-    ]
+    composites = [mc.composite_score for mc in matched_clips if mc.composite_score is not None]
+    embeddings = [mc.embedding_score for mc in matched_clips if mc.embedding_score is not None]
+    rhythms = [mc.rhythm_score for mc in matched_clips if mc.rhythm_score is not None]
+    diversities = [mc.diversity_score for mc in matched_clips if mc.diversity_score is not None]
 
     summary.clips_with_composite = len(composites)
 

--- a/src/movie_narrator/utils/metadata_export.py
+++ b/src/movie_narrator/utils/metadata_export.py
@@ -41,18 +41,13 @@ def build_metadata_json(ctx: Context) -> Dict[str, Any]:
             "tts_provider": ctx.metadata.get("tts_provider"),
         },
         "segments_count": len(ctx.timed_segments),
-        "segments": [
-            {"text": s.text, "start": s.start, "end": s.end}
-            for s in ctx.timed_segments
-        ],
+        "segments": [{"text": s.text, "start": s.start, "end": s.end} for s in ctx.timed_segments],
         # Multi-language subtitle (v0.3).
         "content_language": content_language,
         "subtitle_mode": ctx.metadata.get("subtitle_mode", "original"),
         "translate_provider": ctx.metadata.get("translate_provider"),
         "subtitle_paths": (
-            ctx.subtitle_paths.model_dump()
-            if ctx.subtitle_paths is not None
-            else None
+            ctx.subtitle_paths.model_dump() if ctx.subtitle_paths is not None else None
         ),
         "render_subtitle_path": ctx.render_subtitle_path,
         "warnings": ctx.metadata.get("warnings", []),
@@ -83,7 +78,7 @@ def build_metadata_json(ctx: Context) -> Dict[str, Any]:
     }
 
     # v0.7.0: cost tracking summary
-    if hasattr(ctx, 'cost_tracker') and ctx.cost_tracker is not None:
+    if hasattr(ctx, "cost_tracker") and ctx.cost_tracker is not None:
         meta["cost"] = ctx.cost_tracker.summary()
 
     return meta

--- a/src/movie_narrator/utils/preview.py
+++ b/src/movie_narrator/utils/preview.py
@@ -16,12 +16,14 @@ from typing import List
 # all SOFT steps whose output is not required to validate the first N
 # seconds of a render.  Hard steps (generate_script, generate_voice,
 # render_video, etc.) must always run.
-_PREVIEW_SKIPPABLE_STEPS = frozenset({
-    "research_plot",
-    "translate_subtitles",
-    "run_qa_gate",
-    "export_clips",
-})
+_PREVIEW_SKIPPABLE_STEPS = frozenset(
+    {
+        "research_plot",
+        "translate_subtitles",
+        "run_qa_gate",
+        "export_clips",
+    }
+)
 
 # Clamping bounds for the preview duration, in seconds.  The lower bound
 # avoids uselessly short previews; the upper bound caps cost so a typo

--- a/src/movie_narrator/utils/prompts.py
+++ b/src/movie_narrator/utils/prompts.py
@@ -47,7 +47,7 @@ PLATFORM_TONE: dict[str, str] = {
         "- Scroll-stop energy — the first 3 seconds are do-or-die; open with a jolt.\n"
         "- Use internet-native slang and trending expressions naturally (not forced).\n"
         "- Cliffhanger endings — leave the viewer wanting more, not a tidy summary.\n"
-        '- Speak TO the viewer (\u201c你敢信？\u201d \u201c注意看\u201d) — second-person engagement.'
+        "- Speak TO the viewer (\u201c你敢信？\u201d \u201c注意看\u201d) — second-person engagement."
     ),
     "bilibili": (
         "Platform tone (B站/Bilibili — mid-length horizontal video):\n"
@@ -55,7 +55,7 @@ PLATFORM_TONE: dict[str, str] = {
         "- Measured pacing — let ideas breathe; don't rush through points.\n"
         "- Analytical angle — offer a perspective or interpretation, not just a recap.\n"
         "- Respect the audience's intelligence — avoid over-explaining obvious plot points.\n"
-        '- Use B\u5360-style asides (\u201c这里有个细节\u201d \u201c考据一下\u201d) for depth signals.'
+        "- Use B\u5360-style asides (\u201c这里有个细节\u201d \u201c考据一下\u201d) for depth signals."
     ),
     "youtube": (
         "Platform tone (YouTube — global, polished):\n"
@@ -121,6 +121,7 @@ def build_language_hint(lang: str = "") -> str:
 # existing behaviour is unchanged.  Generic narrative technique,
 # independently authored.
 
+
 def build_perspective_hint(perspective: str = "", focus_character: str = "") -> str:
     """Build the {perspective_hint} block for EXPAND_PROMPT.
 
@@ -167,6 +168,7 @@ def build_perspective_hint(perspective: str = "", focus_character: str = "") -> 
 # Builds a targeted feedback hint from the previous judge scores
 # so that retry attempts fix the identified problems instead of
 # blindly re-running with the same prompt.
+
 
 def build_judge_feedback_hint(prev_scores: dict | None) -> str:
     """Build the {judge_feedback} block for EXPAND_PROMPT on retry.
@@ -259,9 +261,8 @@ def build_judge_feedback_hint(prev_scores: dict | None) -> str:
     if not parts:
         return ""
 
-    return (
-        "IMPROVEMENT DIRECTIVE (fix these problems from the previous attempt):\n"
-        + "\n".join(parts)
+    return "IMPROVEMENT DIRECTIVE (fix these problems from the previous attempt):\n" + "\n".join(
+        parts
     )
 
 
@@ -339,6 +340,7 @@ def select_script_prompt(lang: str = "") -> str:
     if lang == "zh":
         return SCRIPT_PROMPT_ZH
     return SCRIPT_PROMPT
+
 
 # ── Two-phase script generation (v0.4.16+) ─────────────────
 # Phase 1: extract exactly N plot beats (low temperature, structured task)
@@ -445,8 +447,8 @@ _CADENCE_HINTS = {
 }
 
 _CONNECTOR_HINTS = {
-    "interjection": '7. Tone: conversational — use interjections like \u201c哦？\u201d \u201c等等\u201d \u201c注意这里\u201d to engage the viewer.',
-    "narrative": '7. Tone: narrative — use connecting phrases like \u201c话说\u201d \u201c你知道吗\u201d for smooth flow.',
+    "interjection": "7. Tone: conversational — use interjections like \u201c哦？\u201d \u201c等等\u201d \u201c注意这里\u201d to engage the viewer.",
+    "narrative": "7. Tone: narrative — use connecting phrases like \u201c话说\u201d \u201c你知道吗\u201d for smooth flow.",
     "none": "",
 }
 
@@ -500,11 +502,15 @@ def build_hook_hint(hook_templates: list[str] | None, movie: str) -> str:
     templates = hook_templates if hook_templates else DEFAULT_HOOK_TEMPLATES
     if not templates:
         return ""
-    lines = ["6. Hook templates for the FIRST sentence (pick one or write inspired by one — fill {movie} with the actual title):"]
+    lines = [
+        "6. Hook templates for the FIRST sentence (pick one or write inspired by one — fill {movie} with the actual title):"
+    ]
     for i, tmpl in enumerate(templates, 1):
         filled = tmpl.replace("{movie}", movie)
         lines.append(f"   {i}. {filled}")
-    lines.append("   The first sentence MUST be a scroll-stopping hook. Do NOT copy verbatim — adapt to the plot.")
+    lines.append(
+        "   The first sentence MUST be a scroll-stopping hook. Do NOT copy verbatim — adapt to the plot."
+    )
     return "\n".join(lines)
 
 

--- a/src/movie_narrator/utils/qa_report.py
+++ b/src/movie_narrator/utils/qa_report.py
@@ -50,12 +50,14 @@ def generate_qa_report_dict(
     all_issues: list[dict] = []
     for dim in dashboard_dict.get("dimensions", []):
         if dim.get("issues_count", 0) > 0:
-            all_issues.append({
-                "dimension": dim["name"],
-                "label": dim["label"],
-                "issues_count": dim["issues_count"],
-                "score": dim["score"],
-            })
+            all_issues.append(
+                {
+                    "dimension": dim["name"],
+                    "label": dim["label"],
+                    "issues_count": dim["issues_count"],
+                    "score": dim["score"],
+                }
+            )
 
     # Collect recommendations from video_qa
     video_qa = metadata.get("video_qa", {})
@@ -176,7 +178,9 @@ def format_qa_report_text(report_dict: dict) -> str:
         lines.append(f"  Summary: {regression.get('summary', 'unknown')}")
         deltas = regression.get("deltas", [])
         if deltas:
-            lines.append(f"  {'Dimension':<20} {'Current':>8} {'Baseline':>10} {'Delta':>8} {'Direction':<12}")
+            lines.append(
+                f"  {'Dimension':<20} {'Current':>8} {'Baseline':>10} {'Delta':>8} {'Direction':<12}"
+            )
             lines.append(f"  {'-' * 20} {'-' * 8} {'-' * 10} {'-' * 8} {'-' * 12}")
             for d in deltas:
                 lines.append(

--- a/src/movie_narrator/utils/quality_dashboard.py
+++ b/src/movie_narrator/utils/quality_dashboard.py
@@ -219,11 +219,15 @@ def _extract_alignment_score(meta: dict) -> Optional[tuple[float, int, dict]]:
         return None
     # Score: ratio of non-low-confidence segments
     score = (total - low_conf) / total
-    return score, low_conf, {
-        "total_segments": total,
-        "low_confidence_count": low_conf,
-        "avg_confidence": aq.get("avg_confidence"),
-    }
+    return (
+        score,
+        low_conf,
+        {
+            "total_segments": total,
+            "low_confidence_count": low_conf,
+            "avg_confidence": aq.get("avg_confidence"),
+        },
+    )
 
 
 def _extract_match_score(meta: dict) -> Optional[tuple[float, int, dict]]:
@@ -238,12 +242,16 @@ def _extract_match_score(meta: dict) -> Optional[tuple[float, int, dict]]:
     avg_composite = mq.get("avg_composite", 0.0)
     # Score: use avg_composite directly (already 0.0–1.0)
     score = avg_composite
-    return score, low_q, {
-        "total_clips": total,
-        "low_quality_count": low_q,
-        "avg_composite": round(avg_composite, 4),
-        "diversity_penalty_count": mq.get("diversity_penalty_count", 0),
-    }
+    return (
+        score,
+        low_q,
+        {
+            "total_clips": total,
+            "low_quality_count": low_q,
+            "avg_composite": round(avg_composite, 4),
+            "diversity_penalty_count": mq.get("diversity_penalty_count", 0),
+        },
+    )
 
 
 def _extract_subtitle_score(meta: dict) -> Optional[tuple[float, int, dict]]:
@@ -264,11 +272,15 @@ def _extract_subtitle_score(meta: dict) -> Optional[tuple[float, int, dict]]:
         return None
     # Score: ratio of cues without issues
     score = max(0.0, (total_cues - total_issues) / total_cues)
-    return score, total_issues, {
-        "total_cues": total_cues,
-        "total_issues": total_issues,
-        "display_fit_issues": len(sq.get("display_fit_issues", [])),
-    }
+    return (
+        score,
+        total_issues,
+        {
+            "total_cues": total_cues,
+            "total_issues": total_issues,
+            "display_fit_issues": len(sq.get("display_fit_issues", [])),
+        },
+    )
 
 
 def _extract_translation_score(meta: dict) -> Optional[tuple[float, int, dict]]:
@@ -319,12 +331,16 @@ def _extract_video_encoding_score(meta: dict) -> Optional[tuple[float, int, dict
     # Score: 1.0 when ok, 0.5 when issues exist
     score = 1.0 if ok else max(0.0, 1.0 - issue_count * 0.15)
     metrics = vq.get("metrics", {})
-    return score, issue_count, {
-        "ok": ok,
-        "codec": metrics.get("codec"),
-        "resolution": f"{metrics.get('width', 0)}x{metrics.get('height', 0)}",
-        "bitrate_kbps": metrics.get("bitrate_kbps"),
-    }
+    return (
+        score,
+        issue_count,
+        {
+            "ok": ok,
+            "codec": metrics.get("codec"),
+            "resolution": f"{metrics.get('width', 0)}x{metrics.get('height', 0)}",
+            "bitrate_kbps": metrics.get("bitrate_kbps"),
+        },
+    )
 
 
 # Registry of dimension extractors
@@ -362,13 +378,15 @@ def collect_quality_dimensions(
         if result is None:
             continue
         score, issues, details = result
-        dimensions.append(QualityDimension(
-            name=name,
-            score=score,
-            weight=weights.get(name, 0.0),
-            issues_count=issues,
-            details=details,
-        ))
+        dimensions.append(
+            QualityDimension(
+                name=name,
+                score=score,
+                weight=weights.get(name, 0.0),
+                issues_count=issues,
+                details=details,
+            )
+        )
     return dimensions
 
 
@@ -455,10 +473,12 @@ def _compare_with_baseline(
     for dim in current_dims:
         if dim.name in baseline_dims:
             baseline_score = baseline_dims[dim.name]
-            deltas.append(RegressionDelta(
-                name=dim.name,
-                current=dim.score,
-                baseline=baseline_score,
-                delta=dim.score - baseline_score,
-            ))
+            deltas.append(
+                RegressionDelta(
+                    name=dim.name,
+                    current=dim.score,
+                    baseline=baseline_score,
+                    delta=dim.score - baseline_score,
+                )
+            )
     return deltas

--- a/src/movie_narrator/utils/sanitize.py
+++ b/src/movie_narrator/utils/sanitize.py
@@ -11,7 +11,10 @@ from here.
 import re
 
 _RESERVED_NAMES = {
-    "CON", "PRN", "AUX", "NUL",
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
     *(f"COM{i}" for i in range(1, 10)),
     *(f"LPT{i}" for i in range(1, 10)),
 }

--- a/src/movie_narrator/utils/subtitle_qa.py
+++ b/src/movie_narrator/utils/subtitle_qa.py
@@ -29,7 +29,7 @@ _MAX_CPS_CJK = 15.0
 
 # Line length (characters per displayed line)
 _MAX_CHARS_PER_LINE_LATIN = 42  # Netflix guideline for Latin scripts
-_MAX_CHARS_PER_LINE_CJK = 18    # Common CJK guideline
+_MAX_CHARS_PER_LINE_CJK = 18  # Common CJK guideline
 
 # Minimum display duration (seconds) — Netflix: 0.5s minimum
 _MIN_DURATION_S = 0.5
@@ -41,12 +41,12 @@ _MAX_GAP_S = 5.0
 # ── CJK detection ─────────────────────────────────────────
 
 _CJK_RANGES = [
-    (0x4E00, 0x9FFF),    # CJK Unified Ideographs
-    (0x3400, 0x4DBF),    # CJK Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0x3400, 0x4DBF),  # CJK Extension A
     (0x20000, 0x2A6DF),  # CJK Extension B
-    (0x3040, 0x309F),    # Hiragana
-    (0x30A0, 0x30FF),    # Katakana
-    (0xAC00, 0xD7AF),    # Hangul Syllables
+    (0x3040, 0x309F),  # Hiragana
+    (0x30A0, 0x30FF),  # Katakana
+    (0xAC00, 0xD7AF),  # Hangul Syllables
 ]
 
 
@@ -233,11 +233,13 @@ def check_overlaps(
         cur = segments[i]
         nxt = segments[i + 1]
         if cur.end > nxt.start:
-            overlaps.append(SubtitleOverlap(
-                index_a=i,
-                index_b=i + 1,
-                overlap_s=round(cur.end - nxt.start, 3),
-            ))
+            overlaps.append(
+                SubtitleOverlap(
+                    index_a=i,
+                    index_b=i + 1,
+                    overlap_s=round(cur.end - nxt.start, 3),
+                )
+            )
     return overlaps
 
 
@@ -335,19 +337,13 @@ def analyze_cue(
 
     if cps_high:
         threshold = _MAX_CPS_CJK if is_cjk else _MAX_CPS_LATIN
-        issues.append(
-            f"high CPS: {cps:.1f} > {threshold:.0f} (text may be hard to read)"
-        )
+        issues.append(f"high CPS: {cps:.1f} > {threshold:.0f} (text may be hard to read)")
 
     if line_too_long:
-        issues.append(
-            f"line too long: exceeds {max_line_chars} chars/line"
-        )
+        issues.append(f"line too long: exceeds {max_line_chars} chars/line")
 
     if duration_s < _MIN_DURATION_S:
-        issues.append(
-            f"duration too short: {duration_s:.3f}s < {_MIN_DURATION_S}s"
-        )
+        issues.append(f"duration too short: {duration_s:.3f}s < {_MIN_DURATION_S}s")
 
     if char_count == 0:
         issues.append("empty text (no non-space characters)")
@@ -377,10 +373,7 @@ def validate_subtitles(
     Returns:
         A dict suitable for ``ctx.metadata["subtitle_qa"]``.
     """
-    use_translated = (
-        translated_texts is not None
-        and len(translated_texts) == len(segments)
-    )
+    use_translated = translated_texts is not None and len(translated_texts) == len(segments)
 
     cue_metrics: list[SubtitleCueMetrics] = []
     for i, seg in enumerate(segments):
@@ -398,11 +391,13 @@ def validate_subtitles(
     for i in range(len(segments) - 1):
         gap = segments[i + 1].start - segments[i].end
         if gap > _MAX_GAP_S:
-            gaps.append({
-                "index_a": i,
-                "index_b": i + 1,
-                "gap_s": round(gap, 3),
-            })
+            gaps.append(
+                {
+                    "index_a": i,
+                    "index_b": i + 1,
+                    "gap_s": round(gap, 3),
+                }
+            )
 
     return aggregate_cue_metrics(cue_metrics, overlaps, gaps, use_translated)
 
@@ -416,9 +411,8 @@ def aggregate_cue_metrics(
     """Aggregate per-cue metrics into a summary dict for metadata.json."""
     total_issues = sum(len(m.issues) for m in metrics)
     cues_with_issues = sum(1 for m in metrics if m.issues)
-    avg_cps = (
-        sum(m.cps for m in metrics if m.cps > 0)
-        / max(1, sum(1 for m in metrics if m.cps > 0))
+    avg_cps = sum(m.cps for m in metrics if m.cps > 0) / max(
+        1, sum(1 for m in metrics if m.cps > 0)
     )
     max_cps = max((m.cps for m in metrics), default=0.0)
     avg_duration = sum(m.duration_s for m in metrics) / max(1, len(metrics))
@@ -435,9 +429,6 @@ def aggregate_cue_metrics(
         "overlap_count": len(overlaps),
         "gaps": gaps,
         "gap_count": len(gaps),
-        "all_issues": [
-            {"index": m.index, "issues": m.issues}
-            for m in metrics if m.issues
-        ],
+        "all_issues": [{"index": m.index, "issues": m.issues} for m in metrics if m.issues],
         "cues": [m.to_dict() for m in metrics],
     }

--- a/src/movie_narrator/utils/text_anim.py
+++ b/src/movie_narrator/utils/text_anim.py
@@ -60,6 +60,7 @@ def _import_fade_effect():
     """
     try:
         from moviepy.video.fx import FadeIn
+
         return FadeIn
     except Exception:  # noqa: BLE001 — broad on purpose, see docstring
         logger.debug("Failed to import FadeIn effect", exc_info=True)
@@ -149,8 +150,7 @@ def apply_text_animation(
             return clip
 
         if animation_type in ("slide_up", "slide_left"):
-            slid = _apply_slide_entrance(clip, animation_type, anim_dur,
-                                         clip_duration, FadeIn)
+            slid = _apply_slide_entrance(clip, animation_type, anim_dur, clip_duration, FadeIn)
             if slid is not None:
                 return slid
             # Fallback: fade.

--- a/src/movie_narrator/utils/text_image.py
+++ b/src/movie_narrator/utils/text_image.py
@@ -76,7 +76,7 @@ def _balance_lines(lines: list[str], max_lines: int) -> list[str]:
     pos = 0
     for i in range(n):
         take = per_line + (1 if i < remainder else 0)
-        balanced.append(all_chars[pos:pos + take])
+        balanced.append(all_chars[pos : pos + take])
         pos += take
 
     return balanced
@@ -115,7 +115,9 @@ def create_text_image(
 
     if position == "bottom":
         return _render_bottom(
-            text, size, fontsize,
+            text,
+            size,
+            fontsize,
             max_width_ratio=max_width_ratio,
             bottom_margin_ratio=bottom_margin_ratio,
             max_lines=max_lines,
@@ -146,8 +148,12 @@ def create_text_image(
     for line, (w, h) in zip(lines, line_metrics):
         x = (size[0] - w) // 2
         draw.text(
-            (x, y), line, fill=(255, 255, 255, 255), font=font,
-            stroke_width=2, stroke_fill=(0, 0, 0, 255),
+            (x, y),
+            line,
+            fill=(255, 255, 255, 255),
+            font=font,
+            stroke_width=2,
+            stroke_fill=(0, 0, 0, 255),
         )
         y += h + line_spacing
     return np.array(img)
@@ -229,9 +235,9 @@ def _render_bottom(
 
     # Compute bounding box enclosing all line metrics for the backdrop bar.
     widest = max(m[0] for m in line_metrics)
-    bar_left = (width - widest) // 2 - 16   # 16 px horizontal padding
+    bar_left = (width - widest) // 2 - 16  # 16 px horizontal padding
     bar_right = bar_left + widest + 32
-    bar_top = max(0, block_top - 12)        # 12 px vertical padding above first line
+    bar_top = max(0, block_top - 12)  # 12 px vertical padding above first line
     bar_bottom = height - bottom_margin + 12
     # Clamp bar inside frame, then draw semi-transparent black backdrop.
     bar_left = max(0, bar_left)
@@ -247,8 +253,12 @@ def _render_bottom(
     for line, (w, _h) in zip(wrapped, line_metrics):
         x = (width - w) // 2
         draw.text(
-            (x, y), line, fill=(255, 255, 255, 255), font=font,
-            stroke_width=4, stroke_fill=(0, 0, 0, 255),
+            (x, y),
+            line,
+            fill=(255, 255, 255, 255),
+            font=font,
+            stroke_width=4,
+            stroke_fill=(0, 0, 0, 255),
         )
         # advance by font height + spacing (use bbox ascent reliably)
         bbox = draw.textbbox((0, 0), line, font=font)

--- a/src/movie_narrator/utils/transitions.py
+++ b/src/movie_narrator/utils/transitions.py
@@ -63,6 +63,7 @@ def _import_fade_effects():
     """
     try:
         from moviepy.video.fx import FadeIn, FadeOut
+
         return FadeIn, FadeOut
     except Exception:  # noqa: BLE001 — broad on purpose, see docstring
         logger.debug("Failed to import FadeIn/FadeOut effects", exc_info=True)
@@ -131,8 +132,7 @@ def apply_transition(
             # Attempt a simple x-offset slide. If the clip does not
             # support with_position / with_effects (e.g. test mocks),
             # fall back to a fade so the transition is still applied.
-            slid = _apply_slide(clip, trans_dur, position, clip_duration,
-                                FadeIn, FadeOut)
+            slid = _apply_slide(clip, trans_dur, position, clip_duration, FadeIn, FadeOut)
             if slid is not None:
                 return slid
             # Fallback: fade.
@@ -237,8 +237,7 @@ def _apply_slide(
             x = base[0] + offset * (1.0 - progress)
         elif out_dur > 0 and t > (clip_duration - out_dur):
             # Exit: ease from base to -offset.
-            progress = max(0.0, min(1.0,
-                                     (t - (clip_duration - out_dur)) / out_dur))
+            progress = max(0.0, min(1.0, (t - (clip_duration - out_dur)) / out_dur))
             x = base[0] - offset * progress
         return (x, base[1])
 

--- a/src/movie_narrator/utils/video_qa.py
+++ b/src/movie_narrator/utils/video_qa.py
@@ -126,9 +126,13 @@ def _run_ffprobe(path: str, timeout: int = 30) -> Optional[dict]:
     try:
         proc = subprocess.run(
             [
-                ffprobe, "-v", "quiet",
-                "-print_format", "json",
-                "-show_format", "-show_streams",
+                ffprobe,
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                "-show_streams",
                 path,
             ],
             capture_output=True,
@@ -226,9 +230,7 @@ def check_encoding_quality(
             f"video codec '{metrics.codec}' is not in accepted list "
             f"({', '.join(sorted(_ACCEPTABLE_CODECS))})"
         )
-        recommendations.append(
-            "Re-encode with H.264 (libx264) for maximum platform compatibility"
-        )
+        recommendations.append("Re-encode with H.264 (libx264) for maximum platform compatibility")
 
     # ── Resolution check ──
     if metrics.width > 0 and metrics.height > 0:
@@ -237,9 +239,7 @@ def check_encoding_quality(
                 f"resolution {metrics.width}x{metrics.height} is below "
                 f"minimum {min_width}x{min_height}"
             )
-            recommendations.append(
-                f"Re-render at {min_width}x{min_height} or higher"
-            )
+            recommendations.append(f"Re-render at {min_width}x{min_height} or higher")
 
         # Aspect ratio check
         actual_ratio = metrics.width / metrics.height
@@ -250,8 +250,7 @@ def check_encoding_quality(
                 break
         if not matched:
             issues.append(
-                f"aspect ratio {actual_ratio:.3f} is not standard "
-                f"({', '.join(_STANDARD_RATIOS)})"
+                f"aspect ratio {actual_ratio:.3f} is not standard ({', '.join(_STANDARD_RATIOS)})"
             )
             recommendations.append(
                 "Use 16:9 (landscape) or 9:16 (portrait) for platform compatibility"
@@ -260,8 +259,7 @@ def check_encoding_quality(
     # ── Bitrate check ──
     if metrics.bitrate_kbps > 0 and metrics.bitrate_kbps < min_bitrate_kbps:
         issues.append(
-            f"video bitrate {metrics.bitrate_kbps} kbps is below "
-            f"minimum {min_bitrate_kbps} kbps"
+            f"video bitrate {metrics.bitrate_kbps} kbps is below minimum {min_bitrate_kbps} kbps"
         )
         recommendations.append(
             "Increase video bitrate or use a slower encoding preset for better quality"
@@ -270,14 +268,10 @@ def check_encoding_quality(
     # ── Frame rate check ──
     if metrics.fps > 0:
         if metrics.fps < min_fps:
-            issues.append(
-                f"frame rate {metrics.fps:.1f} fps is below minimum {min_fps:.1f} fps"
-            )
+            issues.append(f"frame rate {metrics.fps:.1f} fps is below minimum {min_fps:.1f} fps")
             recommendations.append("Use 24, 25, or 30 fps")
         elif metrics.fps > max_fps:
-            issues.append(
-                f"frame rate {metrics.fps:.1f} fps is above maximum {max_fps:.1f} fps"
-            )
+            issues.append(f"frame rate {metrics.fps:.1f} fps is above maximum {max_fps:.1f} fps")
 
     # ── Audio codec check ──
     if metrics.audio_codec and metrics.audio_codec not in _ACCEPTABLE_AUDIO_CODECS:
@@ -289,9 +283,7 @@ def check_encoding_quality(
 
     # ── Pixel format check ──
     if metrics.pixel_format and metrics.pixel_format not in ("yuv420p", "yuv422p", "yuv444p"):
-        issues.append(
-            f"pixel format '{metrics.pixel_format}' may cause compatibility issues"
-        )
+        issues.append(f"pixel format '{metrics.pixel_format}' may cause compatibility issues")
         recommendations.append("Use yuv420p for maximum compatibility")
 
     report.issues = issues

--- a/src/movie_narrator/vision/factory.py
+++ b/src/movie_narrator/vision/factory.py
@@ -17,11 +17,13 @@ from .protocol import VisionCaptioner
 
 def _make_stub(**kwargs) -> VisionCaptioner:
     from .stub import StubVisionCaptioner
+
     return StubVisionCaptioner()
 
 
 def _make_vlm(**kwargs) -> VisionCaptioner:
     from .vlm import VLMCaptioner
+
     return VLMCaptioner(**kwargs)
 
 

--- a/src/movie_narrator/vision/stub.py
+++ b/src/movie_narrator/vision/stub.py
@@ -33,7 +33,4 @@ class StubVisionCaptioner(VisionCaptioner):
         video_path: Optional[str] = None,
     ) -> List[str]:
         """Generate captions for video scenes."""
-        return [
-            f"scene {s.index} from {s.start:.1f}s to {s.end:.1f}s"
-            for s in scenes
-        ]
+        return [f"scene {s.index} from {s.start:.1f}s to {s.end:.1f}s" for s in scenes]

--- a/src/movie_narrator/vision/vlm.py
+++ b/src/movie_narrator/vision/vlm.py
@@ -65,8 +65,7 @@ class VLMCaptioner(VisionCaptioner):
         self._api_key = api_key or os.environ.get("MN_VLM_API_KEY", "")
         self._model = model or os.environ.get("MN_VLM_MODEL", "gpt-4o")
         self._base_url = (
-            base_url
-            or os.environ.get("MN_VLM_BASE_URL", "https://api.openai.com/v1")
+            base_url or os.environ.get("MN_VLM_BASE_URL", "https://api.openai.com/v1")
         ).rstrip("/")
         self._timeout = timeout or int(os.environ.get("MN_VLM_TIMEOUT", "30"))
         self._language = language or os.environ.get("MN_VLM_LANGUAGE", "en")
@@ -138,18 +137,22 @@ class VLMCaptioner(VisionCaptioner):
 
         # Extract frame using ffmpeg
         cmd = [
-            "ffmpeg", "-y",
-            "-ss", f"{mid_time:.2f}",
-            "-i", video_path,
-            "-frames:v", "1",
-            "-q:v", "2",  # JPEG quality (2 = high quality)
-            "-vf", "scale=512:-1",  # Resize to 512px wide for API efficiency
+            "ffmpeg",
+            "-y",
+            "-ss",
+            f"{mid_time:.2f}",
+            "-i",
+            video_path,
+            "-frames:v",
+            "1",
+            "-q:v",
+            "2",  # JPEG quality (2 = high quality)
+            "-vf",
+            "scale=512:-1",  # Resize to 512px wide for API efficiency
             frame_path,
         ]
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0 or not Path(frame_path).exists():
             raise RuntimeError(
                 f"ffmpeg frame extraction failed for scene {scene.index}: "
@@ -244,10 +247,7 @@ class VLMCaptioner(VisionCaptioner):
                     result = json.loads(resp.read().decode("utf-8"))
 
                 content = (
-                    result.get("choices", [{}])[0]
-                    .get("message", {})
-                    .get("content", "")
-                    .strip()
+                    result.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
                 )
                 if content:
                     return content
@@ -256,7 +256,7 @@ class VLMCaptioner(VisionCaptioner):
             except urllib.error.HTTPError as e:
                 last_error = f"HTTP {e.code}: {e.reason}"
                 if e.code == 429:  # Rate limit — wait and retry
-                    time.sleep(2 ** attempt)
+                    time.sleep(2**attempt)
                 elif e.code >= 500:  # Server error — retry
                     time.sleep(1)
                 else:  # Client error — don't retry

--- a/src/movie_narrator/workflow/load.py
+++ b/src/movie_narrator/workflow/load.py
@@ -50,9 +50,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
     except yaml.YAMLError as e:
         mark = getattr(e, "problem_mark", None)
         if mark is not None:
-            raise JobConfigError(
-                f"invalid YAML: {e.problem} (line {mark.line + 1})"
-            ) from e
+            raise JobConfigError(f"invalid YAML: {e.problem} (line {mark.line + 1})") from e
         raise JobConfigError(f"invalid YAML: {e}") from e
 
     if data is None:
@@ -76,9 +74,7 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
 
     unknown = [k for k in data.keys() if k not in _ALLOWED_TOP]
     if unknown:
-        raise JobConfigError(
-            f"unknown key: '{unknown[0]}' (allowed: {', '.join(_ALLOWED_TOP)})"
-        )
+        raise JobConfigError(f"unknown key: '{unknown[0]}' (allowed: {', '.join(_ALLOWED_TOP)})")
 
     if "steps" in data and data["steps"] is not None:
         if not isinstance(data["steps"], dict):
@@ -95,55 +91,92 @@ def load_job_config(path: Union[str, Path]) -> JobConfig:
             raise JobConfigError("params must be a mapping")
         allowed_params = {
             # Scene detection
-            "scene_threshold", "scene_frame_skip",
+            "scene_threshold",
+            "scene_frame_skip",
             # Match
-            "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration", "embedding_model_name",
+            "match_min_score",
+            "match_speed_clamp_min",
+            "match_speed_clamp_max",
+            "scene_merge_min_duration",
+            "embedding_model_name",
             "match_drop_scene_min_duration",
-            "match_diversity_window", "match_max_scene_reuse",
-            "match_timeline_mode", "match_act_weights",
-            "match_topk", "match_topk_reuse_penalty",
+            "match_diversity_window",
+            "match_max_scene_reuse",
+            "match_timeline_mode",
+            "match_act_weights",
+            "match_topk",
+            "match_topk_reuse_penalty",
             # Vision (VLM caption provider)
             "vision_captioner",
             # BGM + loudness
-            "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
+            "bgm_gain_db",
+            "bgm_duck_db",
+            "bgm_normalize",
+            "audio_target_dbfs",
             # TTS pacing
-            "tts_pause_ms", "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
+            "tts_pause_ms",
+            "tts_max_concurrent",
+            "tts_audio_format",
+            "tts_audio_bitrate",
             # Translate
-            "translate_source_lang", "translate_provider", "translate_retries",
-            "translate_chunk_chars", "translate_chunk_size",
+            "translate_source_lang",
+            "translate_provider",
+            "translate_retries",
+            "translate_chunk_chars",
+            "translate_chunk_size",
             # Research
             "research_provider",
             # WhisperX
-            "whisperx_device", "whisperx_model", "whisperx_language",
+            "whisperx_device",
+            "whisperx_model",
+            "whisperx_language",
             "align_backend",
             # Render
-            "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
-            "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
+            "render_fps",
+            "render_video_codec",
+            "render_audio_codec",
+            "render_threads",
+            "render_bg_color",
+            "render_font_size",
+            "render_output_name",
+            "render_ffmpeg_timeout",
             # Render production quality
-            "render_fit_mode", "render_crf", "render_preset", "render_faststart",
-            "render_subtitle_position", "render_subtitle_max_width_ratio",
+            "render_fit_mode",
+            "render_crf",
+            "render_preset",
+            "render_faststart",
+            "render_subtitle_position",
+            "render_subtitle_max_width_ratio",
             "render_subtitle_bottom_margin_ratio",
-            "render_require_footage", "render_min_footage_coverage",
-            "render_profile", "render_title_card_sec",
-            "render_cover_export", "render_vertical_safe_area",
+            "render_require_footage",
+            "render_min_footage_coverage",
+            "render_profile",
+            "render_title_card_sec",
+            "render_cover_export",
+            "render_vertical_safe_area",
             "bgm_loudnorm",
             # BGM emotion-based selection metadata file
             "bgm_metadata_path",
             # Deliverable QA
-            "qa_enabled", "qa_max_silence_db",
-            "qa_min_duration_ratio", "qa_max_duration_ratio",
+            "qa_enabled",
+            "qa_max_silence_db",
+            "qa_min_duration_ratio",
+            "qa_max_duration_ratio",
             # Prompt shaping (preset-driven)
-            "prompt_target_sentences", "prompt_target_segment_duration",
+            "prompt_target_sentences",
+            "prompt_target_segment_duration",
             "prompt_max_chars_per_sentence",
             "prompt_hook_seconds",
-            "hook_templates", "set_pieces",
+            "hook_templates",
+            "set_pieces",
             # Async
-            "async_timeout", "async_max_workers",
+            "async_timeout",
+            "async_max_workers",
             # Video sizes
             "video_sizes",
             # Platform + language
-            "target_platform", "lang",
+            "target_platform",
+            "lang",
             # Render template styling
             "render_template",
             # Narrator perspective and character anchor

--- a/src/movie_narrator/workflow/merge.py
+++ b/src/movie_narrator/workflow/merge.py
@@ -53,8 +53,10 @@ def merge_job(
         """Pick a value with a default fallback."""
         if has_job and yaml_val is not None and cli_val == typer_default:
             return yaml_val
-        return cli_val if cli_val is not None else (
-            yaml_val if yaml_val is not None else typer_default
+        return (
+            cli_val
+            if cli_val is not None
+            else (yaml_val if yaml_val is not None else typer_default)
         )
 
     movie = pick_optional(cli.get("movie"), yaml_get("movie"), "")
@@ -99,44 +101,82 @@ def merge_job(
     if job is not None and job.params is not None:
         for key in (
             # Scene detection
-            "scene_threshold", "scene_frame_skip",
+            "scene_threshold",
+            "scene_frame_skip",
             # Match
-            "match_min_score", "match_speed_clamp_min", "match_speed_clamp_max",
-            "scene_merge_min_duration", "match_drop_scene_min_duration",
-            "match_diversity_window", "match_max_scene_reuse",
-            "match_timeline_mode", "match_act_weights",
-            "match_topk", "match_topk_reuse_penalty",
+            "match_min_score",
+            "match_speed_clamp_min",
+            "match_speed_clamp_max",
+            "scene_merge_min_duration",
+            "match_drop_scene_min_duration",
+            "match_diversity_window",
+            "match_max_scene_reuse",
+            "match_timeline_mode",
+            "match_act_weights",
+            "match_topk",
+            "match_topk_reuse_penalty",
             "embedding_model_name",
             # BGM
-            "bgm_gain_db", "bgm_duck_db", "bgm_normalize", "audio_target_dbfs",
+            "bgm_gain_db",
+            "bgm_duck_db",
+            "bgm_normalize",
+            "audio_target_dbfs",
             # TTS pacing
-            "tts_pause_ms", "tts_max_concurrent", "tts_audio_format", "tts_audio_bitrate",
+            "tts_pause_ms",
+            "tts_max_concurrent",
+            "tts_audio_format",
+            "tts_audio_bitrate",
             # Translate
-            "translate_source_lang", "translate_provider", "translate_retries",
-            "translate_chunk_chars", "translate_chunk_size",
+            "translate_source_lang",
+            "translate_provider",
+            "translate_retries",
+            "translate_chunk_chars",
+            "translate_chunk_size",
             # Research
             "research_provider",
             # WhisperX
-            "whisperx_device", "whisperx_model", "whisperx_language",
+            "whisperx_device",
+            "whisperx_model",
+            "whisperx_language",
             "align_backend",
             # Render
-            "render_fps", "render_video_codec", "render_audio_codec", "render_threads",
-            "render_bg_color", "render_font_size", "render_output_name", "render_ffmpeg_timeout",
-            "render_fit_mode", "render_crf", "render_preset", "render_faststart",
-            "render_subtitle_position", "render_subtitle_max_width_ratio",
+            "render_fps",
+            "render_video_codec",
+            "render_audio_codec",
+            "render_threads",
+            "render_bg_color",
+            "render_font_size",
+            "render_output_name",
+            "render_ffmpeg_timeout",
+            "render_fit_mode",
+            "render_crf",
+            "render_preset",
+            "render_faststart",
+            "render_subtitle_position",
+            "render_subtitle_max_width_ratio",
             "render_subtitle_bottom_margin_ratio",
-            "render_require_footage", "render_min_footage_coverage",
-            "render_profile", "render_title_card_sec",
-            "render_cover_export", "render_vertical_safe_area",
+            "render_require_footage",
+            "render_min_footage_coverage",
+            "render_profile",
+            "render_title_card_sec",
+            "render_cover_export",
+            "render_vertical_safe_area",
             "bgm_loudnorm",
             # QA
-            "qa_enabled", "qa_max_silence_db", "qa_min_duration_ratio", "qa_max_duration_ratio",
+            "qa_enabled",
+            "qa_max_silence_db",
+            "qa_min_duration_ratio",
+            "qa_max_duration_ratio",
             # Prompt shaping (preset-driven, but also YAML-configurable)
-            "prompt_target_sentences", "prompt_target_segment_duration",
-            "prompt_max_chars_per_sentence", "prompt_hook_seconds",
-            "hook_templates", "set_pieces",
+            "prompt_target_sentences",
+            "prompt_target_segment_duration",
+            "prompt_max_chars_per_sentence",
+            "prompt_hook_seconds",
+            "hook_templates",
+            "set_pieces",
             # Async
-            "async_timeout", "async_max_workers",
+            "async_timeout",
+            "async_max_workers",
             # Video sizes
             "video_sizes",
             # Render template styling
@@ -150,9 +190,9 @@ def merge_job(
     subtitle_lang = pick_optional(cli.get("subtitle_lang"), yaml_get("subtitle_lang"), None)
     if subtitle_lang is not None:
         subtitle_lang = str(subtitle_lang).strip() or None
-    subtitle_mode = pick_optional(
-        cli.get("subtitle_mode"), yaml_get("subtitle_mode"), None
-    ) or "original"
+    subtitle_mode = (
+        pick_optional(cli.get("subtitle_mode"), yaml_get("subtitle_mode"), None) or "original"
+    )
     if subtitle_mode not in VALID_SUBTITLE_MODES:
         raise JobConfigError(
             f"subtitle_mode must be one of {sorted(VALID_SUBTITLE_MODES)}, got {subtitle_mode!r}"

--- a/src/movie_narrator/workflow/schema.py
+++ b/src/movie_narrator/workflow/schema.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
-
 class JobSteps(BaseModel):
     """Job step configuration."""
 
@@ -44,16 +43,24 @@ class JobParams(BaseModel):
     match_timeline_mode: Optional[str] = None  # "uniform" (default) | "weighted_acts"
     match_act_weights: Optional[list] = None  # e.g. [0.15, 0.25, 0.40, 0.20]
     match_topk: Optional[int] = None  # Top-K rerank (default 5, 0/1 = top-1)
-    match_topk_reuse_penalty: Optional[float] = None  # Score deduction for recently used scenes (default 0.15)
+    match_topk_reuse_penalty: Optional[float] = (
+        None  # Score deduction for recently used scenes (default 0.15)
+    )
     embedding_model_name: Optional[str] = None
     # ── Vision ──
     # "none" (default) | "stub" | plugin-registered providers (via register_vision)
     vision_captioner: Optional[str] = None
     # ── Scene filtering ──
     # intro skip, dark frame drop, highlight window (all opt-in, default off)
-    match_skip_intro_sec: Optional[float] = None  # drop scenes ending before this offset (default 0)
-    match_drop_dark_luma: Optional[float] = None  # mean luma threshold for dark frame drop (default 0 = disabled; try 16-30)
-    match_source_window: Optional[list] = None  # [start_ratio, end_ratio] highlight window (default [0.0, 1.0])
+    match_skip_intro_sec: Optional[float] = (
+        None  # drop scenes ending before this offset (default 0)
+    )
+    match_drop_dark_luma: Optional[float] = (
+        None  # mean luma threshold for dark frame drop (default 0 = disabled; try 16-30)
+    )
+    match_source_window: Optional[list] = (
+        None  # [start_ratio, end_ratio] highlight window (default [0.0, 1.0])
+    )
     # ── BGM ──
     bgm_gain_db: Optional[float] = None
     bgm_duck_db: Optional[float] = None
@@ -211,9 +218,7 @@ class JobConfig(BaseModel):
     @classmethod
     def _check_subtitle_mode(cls, v: Optional[str]) -> Optional[str]:
         if v is not None and v not in VALID_SUBTITLE_MODES:
-            raise ValueError(
-                f"subtitle_mode must be one of {sorted(VALID_SUBTITLE_MODES)}"
-            )
+            raise ValueError(f"subtitle_mode must be one of {sorted(VALID_SUBTITLE_MODES)}")
         return v
 
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -38,8 +38,14 @@ def test_align_disabled_without_whisperx(tmp_path):
 def test_align_skipped_no_audio(tmp_path):
     ctx = _make_ctx(tmp_path, audio=False)
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         align_audio(ctx)
     assert ctx.status.align == "skipped"
 
@@ -64,8 +70,14 @@ def test_align_success_with_mocked_whisperx(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -169,8 +181,14 @@ def test_align_faster_whisper_path(tmp_path, monkeypatch):
     fake_fw.WhisperModel = MagicMock(return_value=fake_model)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "faster_whisper" else (False, ""))
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "faster_whisper" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "faster_whisper" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "faster_whisper" else (False, ""),
+        )
         m.setitem(sys.modules, "faster_whisper", fake_fw)
         align_audio(ctx)
 
@@ -212,8 +230,8 @@ def test_align_backward_jump_extreme_skips_segment(tmp_path):
         movie_name="m",
         output_dir=str(tmp_path),
         timed_segments=[
-            TimedSegment(text="first", start=9.0, end=11.0),   # midpoint=10
-            TimedSegment(text="second", start=4.0, end=5.0),    # midpoint=4.5
+            TimedSegment(text="first", start=9.0, end=11.0),  # midpoint=10
+            TimedSegment(text="second", start=4.0, end=5.0),  # midpoint=4.5
         ],
     )
     ctx.audio_path = str(tmp_path / "narration.mp3")
@@ -239,8 +257,14 @@ def test_align_backward_jump_extreme_skips_segment(tmp_path):
     original_seg2_end = ctx.timed_segments[1].end
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -268,7 +292,7 @@ def test_align_backward_jump_small_clamp_keeps_segment(tmp_path):
         movie_name="m",
         output_dir=str(tmp_path),
         timed_segments=[
-            TimedSegment(text="first", start=8.5, end=9.5),    # midpoint=9
+            TimedSegment(text="first", start=8.5, end=9.5),  # midpoint=9
             TimedSegment(text="second", start=10.5, end=11.5),  # midpoint=11
         ],
     )
@@ -291,8 +315,14 @@ def test_align_backward_jump_small_clamp_keeps_segment(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -323,8 +353,14 @@ def test_align_no_backward_jumps_zero_skipped(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -357,8 +393,14 @@ def test_align_midpoint_distance_when_no_containment(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -395,8 +437,14 @@ def test_align_unequal_segment_counts(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -416,7 +464,7 @@ def test_align_unequal_segment_counts(tmp_path):
         # A skipped segment keeps its original TTS start time, which may
         # be < prev.end. We can't directly detect skip here, but we can
         # verify positive duration always holds.
-        assert curr.end > curr.start    # always positive duration
+        assert curr.end > curr.start  # always positive duration
         # Monotonic should hold for most segments; if it doesn't, the
         # segment was likely skipped by backward-jump detection (backward jump > 50%).
         if not is_monotonic:
@@ -443,8 +491,14 @@ def test_align_empty_whisperx_segments_warns(tmp_path):
     fake_wx.load_model = MagicMock(return_value=fake_model)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -485,8 +539,14 @@ def test_align_fallback_sets_status_failed(tmp_path):
     fake_wx.align = MagicMock()
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -530,8 +590,14 @@ def test_align_single_segment_drift_skips(tmp_path):
     original_ends = [ts.end for ts in ctx.timed_segments]
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 
@@ -562,8 +628,14 @@ def test_align_single_segment_no_drift_succeeds(tmp_path):
     fake_wx.align = MagicMock(return_value=mock_result)
 
     with pytest.MonkeyPatch.context() as m:
-        m.setattr("movie_narrator.pipeline.align.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
-        m.setattr("movie_narrator.pipeline._align_backend.probe", lambda name: (True, "") if name == "whisperx" else (False, ""))
+        m.setattr(
+            "movie_narrator.pipeline.align.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
+        m.setattr(
+            "movie_narrator.pipeline._align_backend.probe",
+            lambda name: (True, "") if name == "whisperx" else (False, ""),
+        )
         m.setitem(sys.modules, "whisperx", fake_wx)
         align_audio(ctx)
 

--- a/tests/test_audio_mix.py
+++ b/tests/test_audio_mix.py
@@ -12,7 +12,7 @@ def _tone(ms: int = 500, freq: int = 440, gain_db: float = 0.0) -> AudioSegment:
     """Generate a sine-wave tone AudioSegment."""
     sample_rate = 44100
     n = int(sample_rate * ms / 1000.0)
-    amp = int((2 ** 15 - 1) * (10 ** (gain_db / 20.0)))
+    amp = int((2**15 - 1) * (10 ** (gain_db / 20.0)))
     data = bytearray()
     for i in range(n):
         val = int(amp * math.sin(2.0 * math.pi * freq * i / sample_rate))

--- a/tests/test_audit_integration.py
+++ b/tests/test_audit_integration.py
@@ -98,8 +98,7 @@ def test_diversity_swaps_log_triggered_with_small_scene_pool(tmp_path, monkeypat
     # P2: swaps must be > 0 — 10 segments over 3 scenes with max_reuse=1
     # forces at least some swaps in windows of 3.
     assert diversity["swaps"] > 0, (
-        "Expected diversity swaps > 0 with 10 segments over 3 scenes "
-        "and max_reuse=1, but got 0"
+        "Expected diversity swaps > 0 with 10 segments over 3 scenes and max_reuse=1, but got 0"
     )
 
     # swaps_log must be a non-empty list with correct schema
@@ -131,10 +130,7 @@ def test_diversity_swaps_zero_with_large_scene_pool(tmp_path, monkeypatch):
     (tmp_path / "video.mp4").write_bytes(b"00")
 
     # 20 scenes — ample for 5 segments
-    ctx.scenes = [
-        Scene(index=i, start=float(i * 5), end=float(i * 5 + 5))
-        for i in range(20)
-    ]
+    ctx.scenes = [Scene(index=i, start=float(i * 5), end=float(i * 5 + 5)) for i in range(20)]
     ctx.timed_segments = [
         TimedSegment(text=f"segment {i}", start=float(i * 3), end=float(i * 3 + 2.5))
         for i in range(5)
@@ -202,10 +198,10 @@ def test_script_truncated_audit_field_populated(tmp_path):
 
     # LLM returns 4 segments, all exceeding max_chars=5
     long_texts = [
-        "这是一句很长的中文句子",   # 11 chars
-        "另一段超长的旁白内容",     # 10 chars
-        "第三段也超过了限制",       # 9 chars
-        "最后一段同样很长",         # 8 chars
+        "这是一句很长的中文句子",  # 11 chars
+        "另一段超长的旁白内容",  # 10 chars
+        "第三段也超过了限制",  # 9 chars
+        "最后一段同样很长",  # 8 chars
     ]
     seg_json = json.dumps(
         {"segments": [{"text": t} for t in long_texts]},
@@ -217,7 +213,9 @@ def test_script_truncated_audit_field_populated(tmp_path):
     with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
         with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
             segments = _expand_beats_to_script(
-                ctx, _mock_settings(), mock_cm.__enter__(),
+                ctx,
+                _mock_settings(),
+                mock_cm.__enter__(),
                 beats=["beat1", "beat2", "beat3", "beat4"],
                 target_count=4,
             )
@@ -268,7 +266,9 @@ def test_script_truncated_absent_when_no_truncation(tmp_path):
     with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
         with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
             segments = _expand_beats_to_script(
-                ctx, _mock_settings(), mock_cm.__enter__(),
+                ctx,
+                _mock_settings(),
+                mock_cm.__enter__(),
                 beats=["beat1", "beat2", "beat3", "beat4"],
                 target_count=4,
             )

--- a/tests/test_bgm.py
+++ b/tests/test_bgm.py
@@ -28,9 +28,10 @@ def _write_tone_mp3(path: Path, ms: int = 500, freq: int = 440):
     """Write a sine-wave tone so gain is actually applied (non-silent)."""
     import math
     import struct
+
     sample_rate = 44100
     n_samples = int(sample_rate * ms / 1000.0)
-    amplitude = 2 ** 15 - 1
+    amplitude = 2**15 - 1
     sine_wave = bytearray()
     for i in range(n_samples):
         val = int(amplitude * math.sin(2.0 * math.pi * freq * i / sample_rate))
@@ -188,9 +189,7 @@ def test_mix_bgm_ambient_ducking_applied(tmp_path):
     narr = _write_tone_mp3(tmp_path / "narration.mp3", 800, freq=440)
     ambient = _write_tone_mp3(tmp_path / "ambient.mp3", 400, freq=220)
 
-    base_mixed = AudioSegment.from_file(narr).overlay(
-        AudioSegment.from_file(ambient).apply_gain(0)
-    )
+    base_mixed = AudioSegment.from_file(narr).overlay(AudioSegment.from_file(ambient).apply_gain(0))
     ducked_mixed, info = _mix_ambient_track(
         AudioSegment.from_file(narr),
         str(ambient),

--- a/tests/test_bgm_emotion.py
+++ b/tests/test_bgm_emotion.py
@@ -89,7 +89,9 @@ class TestScoreBgmCandidate:
         profile = {"intense": 0.7, "calm": 0.3}
         sample_intense = {"mood": "intense"}
         sample_calm = {"mood": "calm"}
-        assert _score_bgm_candidate(sample_intense, profile) > _score_bgm_candidate(sample_calm, profile)
+        assert _score_bgm_candidate(sample_intense, profile) > _score_bgm_candidate(
+            sample_calm, profile
+        )
 
     def test_mood_not_in_profile_returns_zero(self):
         profile = {"calm": 1.0}
@@ -102,6 +104,7 @@ class TestSelectBgmByEmotion:
         """Build a mock ctx with BGM metadata file."""
         metadata_path = Path(tmpdir) / "bgm_metadata.yaml"
         import yaml
+
         metadata_path.write_text(
             yaml.dump({"bgm_samples": samples}),
             encoding="utf-8",

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -37,7 +37,10 @@ def test_create_with_config_uses_yaml_movie(tmp_path, monkeypatch):
     job.write_text("movie: FromYAML\nstyle: YAMLStyle\n", encoding="utf-8")
 
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
         result = runner.invoke(app, ["create", "--config", str(job)])
     assert result.exit_code == 0, result.output
     kwargs = bc.call_args.kwargs
@@ -52,10 +55,11 @@ def test_create_cli_movie_overrides_yaml(tmp_path, monkeypatch):
     job.write_text("movie: FromYAML\n", encoding="utf-8")
 
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
-        result = runner.invoke(
-            app, ["create", "--config", str(job), "--movie", "FromCLI"]
-        )
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
+        result = runner.invoke(app, ["create", "--config", str(job), "--movie", "FromCLI"])
     assert result.exit_code == 0, result.output
     assert bc.call_args.kwargs["movie"] == "FromCLI"
 
@@ -65,10 +69,16 @@ def test_create_config_missing_movie_errors(tmp_path, monkeypatch):
     job = tmp_path / "job.yaml"
     job.write_text("style: only\n", encoding="utf-8")
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
         result = runner.invoke(app, ["create", "--config", str(job)])
     assert result.exit_code != 0
-    assert "movie is required" in result.output.lower() or "movie is required" in str(result.exception).lower()
+    assert (
+        "movie is required" in result.output.lower()
+        or "movie is required" in str(result.exception).lower()
+    )
     bc.assert_not_called()
     rp.assert_not_called()
 
@@ -78,7 +88,10 @@ def test_create_invalid_yaml_exits_before_pipeline(tmp_path, monkeypatch):
     job = tmp_path / "job.yaml"
     job.write_text("movie: [bad\n", encoding="utf-8")
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
         result = runner.invoke(app, ["create", "--config", str(job)])
     assert result.exit_code != 0
     bc.assert_not_called()
@@ -91,7 +104,10 @@ def test_create_unknown_key_exits_before_pipeline(tmp_path, monkeypatch):
     job = tmp_path / "job.yaml"
     job.write_text("movie: X\nnot_a_key: 1\n", encoding="utf-8")
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
         result = runner.invoke(app, ["create", "--config", str(job)])
     assert result.exit_code != 0
     bc.assert_not_called()
@@ -116,7 +132,10 @@ def test_create_passes_workflow_steps_and_params(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
         result = runner.invoke(app, ["create", "--config", str(job)])
     assert result.exit_code == 0, result.output
     kwargs = bc.call_args.kwargs
@@ -132,7 +151,10 @@ def test_create_no_config_backward_compatible_kwargs(tmp_path, monkeypatch):
     # verifies the pure-CLI path (no YAML at all).
     monkeypatch.setattr("movie_narrator.cli._EXAMPLE_YAML", tmp_path / "nonexistent.yaml")
     bc, rp = _patch_pipeline(tmp_path)
-    with patch("movie_narrator.cli.build_context", bc), patch("movie_narrator.cli.run_pipeline", rp):
+    with (
+        patch("movie_narrator.cli.build_context", bc),
+        patch("movie_narrator.cli.run_pipeline", rp),
+    ):
         result = runner.invoke(app, ["create", "--movie", "OnlyCLI", "--duration", "12"])
     assert result.exit_code == 0, result.output
     kwargs = bc.call_args.kwargs

--- a/tests/test_cli_debug.py
+++ b/tests/test_cli_debug.py
@@ -57,7 +57,9 @@ def test_mn_scenes_exits_nonzero_when_dep_missing(tmp_path, monkeypatch):
     _make_missing_probe(monkeypatch, "scenedetect")
     fake_video = tmp_path / "v.mp4"
     fake_video.write_bytes(b"00")
-    result = runner.invoke(app, ["scenes", "--video", str(fake_video), "--output", str(tmp_path / "out")])
+    result = runner.invoke(
+        app, ["scenes", "--video", str(fake_video), "--output", str(tmp_path / "out")]
+    )
     assert result.exit_code != 0
     assert "[media]" in result.output or "media" in result.output.lower()
 
@@ -66,7 +68,9 @@ def test_mn_align_exits_nonzero_when_dep_missing(tmp_path, monkeypatch):
     _make_missing_probe(monkeypatch, "whisperx")
     fake_audio = tmp_path / "a.wav"
     fake_audio.write_bytes(b"00")
-    result = runner.invoke(app, ["align", "--audio", str(fake_audio), "--output", str(tmp_path / "out")])
+    result = runner.invoke(
+        app, ["align", "--audio", str(fake_audio), "--output", str(tmp_path / "out")]
+    )
     assert result.exit_code != 0
     assert "[ml]" in result.output or "ml" in result.output.lower()
 
@@ -74,12 +78,13 @@ def test_mn_align_exits_nonzero_when_dep_missing(tmp_path, monkeypatch):
 def test_mn_clips_exits_nonzero_when_dep_missing(tmp_path, monkeypatch):
     # export_clips.py uses probe("scenedetect"); patch there.
     import movie_narrator.pipeline.export_clips as export_module
+
     monkeypatch.setattr(
         export_module,
         "probe",
         lambda name: (
             False,
-            'pip install "movie-narrator[media]"' if name == "scenedetect" else (True, "")
+            'pip install "movie-narrator[media]"' if name == "scenedetect" else (True, ""),
         ),
     )
     fake_video = tmp_path / "v.mp4"
@@ -88,7 +93,15 @@ def test_mn_clips_exits_nonzero_when_dep_missing(tmp_path, monkeypatch):
     scenes_json.write_text(json.dumps([{"index": 0, "start": 0.0, "end": 1.0}]), encoding="utf-8")
     result = runner.invoke(
         app,
-        ["clips", "--video", str(fake_video), "--scenes", str(scenes_json), "--output", str(tmp_path / "out")],
+        [
+            "clips",
+            "--video",
+            str(fake_video),
+            "--scenes",
+            str(scenes_json),
+            "--output",
+            str(tmp_path / "out"),
+        ],
     )
     assert result.exit_code != 0
     assert "[media]" in result.output or "media" in result.output.lower()
@@ -101,7 +114,9 @@ def test_mn_scenes_zero_scenes_no_dep_exit_zero(tmp_path, monkeypatch):
     fake_video.write_bytes(b"00")
     # Don't override probe; use the real one (probe("scenedetect") may be
     # available in this env, but ensure we don't crash even when zero scenes).
-    result = runner.invoke(app, ["scenes", "--video", str(fake_video), "--output", str(tmp_path / "out")])
+    result = runner.invoke(
+        app, ["scenes", "--video", str(fake_video), "--output", str(tmp_path / "out")]
+    )
     # Either 0 (probably missing media here) or 1 (degraded path) — both fine.
     # The point is: don't crash with Traceback.
     assert result.exception is None or "Traceback" not in (result.output or "")

--- a/tests/test_cli_resolve.py
+++ b/tests/test_cli_resolve.py
@@ -10,7 +10,9 @@ runner = CliRunner()
 
 def test_resolve_json_shape(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path), "--json"])
+    result = runner.invoke(
+        app, ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path), "--json"]
+    )
     parsed = json.loads(result.output.strip())
     assert "matched" in parsed
     assert "path" in parsed
@@ -53,8 +55,15 @@ def test_resolve_output_dir_option_writes_to_user_dir(tmp_path, monkeypatch):
     custom_dir = tmp_path / "my-custom-output"
     result = runner.invoke(
         app,
-        ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path),
-         "--output-dir", str(custom_dir)],
+        [
+            "resolve",
+            "--movie",
+            "Inception",
+            "--library-dir",
+            str(tmp_path),
+            "--output-dir",
+            str(custom_dir),
+        ],
     )
     assert result.exit_code == 0
     # Custom directory should exist (created by the command)
@@ -69,8 +78,7 @@ def test_resolve_output_dir_short_option(tmp_path, monkeypatch):
     custom_dir = tmp_path / "short-opt-out"
     result = runner.invoke(
         app,
-        ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path),
-         "-o", str(custom_dir)],
+        ["resolve", "--movie", "Inception", "--library-dir", str(tmp_path), "-o", str(custom_dir)],
     )
     assert result.exit_code == 0
     assert custom_dir.exists()

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -109,23 +109,42 @@ class TestAllCompleteness:
     def test_all_names_in_all(self):
         """Key public names are in __all__."""
         expected = {
-            "BaseConsole", "Console", "SilentConsole",
-            "PipelineCancelled", "PipelineStrictError",
-            "RunController", "StepAction", "check_cancelled",
-            "PARAM_WHITELIST", "build_context", "run_pipeline",
-            "sanitize_filename", "PipelineResult",
+            "BaseConsole",
+            "Console",
+            "SilentConsole",
+            "PipelineCancelled",
+            "PipelineStrictError",
+            "RunController",
+            "StepAction",
+            "check_cancelled",
+            "PARAM_WHITELIST",
+            "build_context",
+            "run_pipeline",
+            "sanitize_filename",
+            "PipelineResult",
             # M1/M2 symbols (v0.5+)
             "CONTRACT_VERSION",
-            "StepRegistry", "step_registry",
-            "ProviderRegistry", "tts_registry", "vision_registry",
-            "llm_registry", "research_registry",
-            "register_step", "step",
-            "register_tts", "register_vision",
-            "register_llm", "register_research",
-            "Plugin", "PluginContext",
-            "load_plugin", "discover_plugins", "list_available_plugins",
+            "StepRegistry",
+            "step_registry",
+            "ProviderRegistry",
+            "tts_registry",
+            "vision_registry",
+            "llm_registry",
+            "research_registry",
+            "register_step",
+            "step",
+            "register_tts",
+            "register_vision",
+            "register_llm",
+            "register_research",
+            "Plugin",
+            "PluginContext",
+            "load_plugin",
+            "discover_plugins",
+            "list_available_plugins",
             "Step",
-            "list_presets", "get_preset",
+            "list_presets",
+            "get_preset",
         }
         assert expected.issubset(set(contract.__all__))
 
@@ -198,8 +217,7 @@ class TestContractIsolation:
         }
         contract_provided = set(contract.__all__)
         assert web_needed.issubset(contract_provided), (
-            f"web package needs {web_needed - contract_provided} "
-            f"which are not in contract.__all__"
+            f"web package needs {web_needed - contract_provided} which are not in contract.__all__"
         )
 
 
@@ -235,18 +253,32 @@ class TestContractVersion:
 class TestSDKSymbolExports:
     """M1/M2 SDK symbols are accessible from the contract module."""
 
-    @pytest.mark.parametrize("name", [
-        "StepRegistry", "step_registry",
-        "ProviderRegistry", "tts_registry", "vision_registry",
-        "llm_registry", "research_registry",
-        "register_step", "step",
-        "register_tts", "register_vision",
-        "register_llm", "register_research",
-        "Plugin", "PluginContext",
-        "load_plugin", "discover_plugins", "list_available_plugins",
-        "Step",
-        "list_presets", "get_preset",
-    ])
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "StepRegistry",
+            "step_registry",
+            "ProviderRegistry",
+            "tts_registry",
+            "vision_registry",
+            "llm_registry",
+            "research_registry",
+            "register_step",
+            "step",
+            "register_tts",
+            "register_vision",
+            "register_llm",
+            "register_research",
+            "Plugin",
+            "PluginContext",
+            "load_plugin",
+            "discover_plugins",
+            "list_available_plugins",
+            "Step",
+            "list_presets",
+            "get_preset",
+        ],
+    )
     def test_symbol_accessible(self, name):
         """Each M1/M2 symbol is accessible on the contract module."""
         assert hasattr(contract, name), f"{name!r} not accessible from contract module"
@@ -254,61 +286,73 @@ class TestSDKSymbolExports:
     def test_step_registry_is_global_instance(self):
         """step_registry is the global StepRegistry instance."""
         from movie_narrator.pipeline.registry import step_registry as _step_registry
+
         assert contract.step_registry is _step_registry
 
     def test_tts_registry_is_global_instance(self):
         """tts_registry is the global ProviderRegistry instance for TTS."""
         from movie_narrator.providers.registry import tts_registry as _tts_registry
+
         assert contract.tts_registry is _tts_registry
 
     def test_vision_registry_is_global_instance(self):
         """vision_registry is the global ProviderRegistry instance for vision."""
         from movie_narrator.providers.registry import vision_registry as _vision_registry
+
         assert contract.vision_registry is _vision_registry
 
     def test_register_step_identity(self):
         """register_step is the same function as in pipeline.registry."""
         from movie_narrator.pipeline.registry import register_step as _register_step
+
         assert contract.register_step is _register_step
 
     def test_register_tts_identity(self):
         """register_tts is the same function as in providers.registry."""
         from movie_narrator.providers.registry import register_tts as _register_tts
+
         assert contract.register_tts is _register_tts
 
     def test_register_vision_identity(self):
         """register_vision is the same function as in providers.registry."""
         from movie_narrator.providers.registry import register_vision as _register_vision
+
         assert contract.register_vision is _register_vision
 
     def test_llm_registry_is_global_instance(self):
         """llm_registry is the global ProviderRegistry instance for LLM."""
         from movie_narrator.providers.registry import llm_registry as _llm_registry
+
         assert contract.llm_registry is _llm_registry
 
     def test_research_registry_is_global_instance(self):
         """research_registry is the global ProviderRegistry instance for research."""
         from movie_narrator.providers.registry import research_registry as _research_registry
+
         assert contract.research_registry is _research_registry
 
     def test_register_llm_identity(self):
         """register_llm is the same function as in providers.registry."""
         from movie_narrator.providers.registry import register_llm as _register_llm
+
         assert contract.register_llm is _register_llm
 
     def test_register_research_identity(self):
         """register_research is the same function as in providers.registry."""
         from movie_narrator.providers.registry import register_research as _register_research
+
         assert contract.register_research is _register_research
 
     def test_load_plugin_identity(self):
         """load_plugin is the same function as in plugin_loader."""
         from movie_narrator.plugin_loader import load_plugin as _load_plugin
+
         assert contract.load_plugin is _load_plugin
 
     def test_discover_plugins_identity(self):
         """discover_plugins is the same function as in plugin_loader."""
         from movie_narrator.plugin_loader import discover_plugins as _discover_plugins
+
         assert contract.discover_plugins is _discover_plugins
 
     def test_list_presets_callable(self):

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -43,11 +43,15 @@ def test_cost_tracker_has_lock():
 def test_record_llm_call_basic():
     """A single LLM call is appended to llm_calls."""
     tracker = CostTracker()
-    tracker.record_llm_call("script", "gpt-4o-mini", {
-        "prompt_tokens": 100,
-        "completion_tokens": 50,
-        "total_tokens": 150,
-    })
+    tracker.record_llm_call(
+        "script",
+        "gpt-4o-mini",
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        },
+    )
     assert len(tracker.llm_calls) == 1
     rec = tracker.llm_calls[0]
     assert rec.step == "script"
@@ -70,11 +74,15 @@ def test_record_llm_call_missing_keys_default_zero():
 def test_record_llm_call_none_values_default_zero():
     """None values in the usage dict are coerced to 0."""
     tracker = CostTracker()
-    tracker.record_llm_call("translate", "m", {
-        "prompt_tokens": None,
-        "completion_tokens": None,
-        "total_tokens": None,
-    })
+    tracker.record_llm_call(
+        "translate",
+        "m",
+        {
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "total_tokens": None,
+        },
+    )
     rec = tracker.llm_calls[0]
     assert rec.prompt_tokens == 0
     assert rec.completion_tokens == 0
@@ -93,9 +101,15 @@ def test_record_llm_call_multiple_accumulate():
     """Multiple calls all accumulate in the list."""
     tracker = CostTracker()
     for i in range(5):
-        tracker.record_llm_call("script", "m", {
-            "prompt_tokens": i, "completion_tokens": i, "total_tokens": 2 * i,
-        })
+        tracker.record_llm_call(
+            "script",
+            "m",
+            {
+                "prompt_tokens": i,
+                "completion_tokens": i,
+                "total_tokens": 2 * i,
+            },
+        )
     assert len(tracker.llm_calls) == 5
 
 
@@ -118,8 +132,7 @@ def test_record_tts_call_basic():
 def test_record_tts_call_cached():
     """cached=True is recorded correctly."""
     tracker = CostTracker()
-    tracker.record_tts_call("openai", model="tts-1",
-                            characters=500, segments=3, cached=True)
+    tracker.record_tts_call("openai", model="tts-1", characters=500, segments=3, cached=True)
     rec = tracker.tts_calls[0]
     assert rec.cached is True
     assert rec.segments == 3
@@ -151,9 +164,15 @@ def test_summary_returns_correct_top_level_keys():
 def test_summary_llm_structure():
     """The 'llm' sub-dict has all required fields."""
     tracker = CostTracker()
-    tracker.record_llm_call("script", "m", {
-        "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150,
-    })
+    tracker.record_llm_call(
+        "script",
+        "m",
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        },
+    )
     llm = tracker.summary()["llm"]
     assert llm["total_calls"] == 1
     assert llm["total_prompt_tokens"] == 100
@@ -179,15 +198,33 @@ def test_summary_tts_structure():
 def test_summary_by_step_grouping():
     """LLM calls are grouped by step name."""
     tracker = CostTracker()
-    tracker.record_llm_call("script", "m", {
-        "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150,
-    })
-    tracker.record_llm_call("script", "m", {
-        "prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300,
-    })
-    tracker.record_llm_call("research", "m", {
-        "prompt_tokens": 50, "completion_tokens": 25, "total_tokens": 75,
-    })
+    tracker.record_llm_call(
+        "script",
+        "m",
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        },
+    )
+    tracker.record_llm_call(
+        "script",
+        "m",
+        {
+            "prompt_tokens": 200,
+            "completion_tokens": 100,
+            "total_tokens": 300,
+        },
+    )
+    tracker.record_llm_call(
+        "research",
+        "m",
+        {
+            "prompt_tokens": 50,
+            "completion_tokens": 25,
+            "total_tokens": 75,
+        },
+    )
 
     by_step = tracker.summary()["llm"]["by_step"]
     assert "script" in by_step
@@ -230,9 +267,15 @@ def test_summary_by_provider_grouping():
 def test_summary_llm_estimated_cost():
     """LLM estimated cost = prompt*0.002/1K + completion*0.006/1K."""
     tracker = CostTracker()
-    tracker.record_llm_call("script", "m", {
-        "prompt_tokens": 1000, "completion_tokens": 500, "total_tokens": 1500,
-    })
+    tracker.record_llm_call(
+        "script",
+        "m",
+        {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "total_tokens": 1500,
+        },
+    )
     cost = tracker.summary()["llm"]["estimated_cost_usd"]
     # 1000/1000 * 0.002 + 500/1000 * 0.006 = 0.002 + 0.003 = 0.005
     assert abs(cost - 0.005) < 1e-9
@@ -296,11 +339,15 @@ def test_thread_safe_concurrent_llm_calls():
 
     def worker():
         for _ in range(calls_per_thread):
-            tracker.record_llm_call("script", "m", {
-                "prompt_tokens": 1,
-                "completion_tokens": 1,
-                "total_tokens": 2,
-            })
+            tracker.record_llm_call(
+                "script",
+                "m",
+                {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            )
 
     threads = [threading.Thread(target=worker) for _ in range(n_threads)]
     for t in threads:
@@ -340,9 +387,15 @@ def test_thread_safe_mixed_calls():
 
     def llm_worker():
         for _ in range(calls_per_thread):
-            tracker.record_llm_call("script", "m", {
-                "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2,
-            })
+            tracker.record_llm_call(
+                "script",
+                "m",
+                {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            )
 
     def tts_worker():
         for _ in range(calls_per_thread):
@@ -375,9 +428,15 @@ def test_thread_safe_summary_during_writes():
     def writer():
         try:
             for i in range(100):
-                tracker.record_llm_call("script", "m", {
-                    "prompt_tokens": i, "completion_tokens": i, "total_tokens": 2 * i,
-                })
+                tracker.record_llm_call(
+                    "script",
+                    "m",
+                    {
+                        "prompt_tokens": i,
+                        "completion_tokens": i,
+                        "total_tokens": 2 * i,
+                    },
+                )
                 tracker.record_tts_call("edge", characters=i, segments=1)
         except Exception as e:
             errors.append(e)

--- a/tests/test_deliverable_qa.py
+++ b/tests/test_deliverable_qa.py
@@ -28,12 +28,19 @@ def test_probe_media_uses_ffprobe(tmp_path):
 
     def fake_run(cmd, **kw):
         if "ffprobe" in str(cmd[0]):
-            return type("P", (), {"returncode": 0, "stdout": json.dumps(_ffprobe_json(12.0)), "stderr": ""})()
+            return type(
+                "P", (), {"returncode": 0, "stdout": json.dumps(_ffprobe_json(12.0)), "stderr": ""}
+            )()
         # volumedetect call
         return type("P", (), {"returncode": 0, "stdout": "", "stderr": "mean_volume: -16.0 dB"})()
 
-    with patch("movie_narrator.utils.deliverable_qa.shutil.which", lambda x: "/usr/bin/" + x if x in ("ffprobe", "ffmpeg") else None), \
-         patch("movie_narrator.utils.deliverable_qa.subprocess.run", side_effect=fake_run):
+    with (
+        patch(
+            "movie_narrator.utils.deliverable_qa.shutil.which",
+            lambda x: "/usr/bin/" + x if x in ("ffprobe", "ffmpeg") else None,
+        ),
+        patch("movie_narrator.utils.deliverable_qa.subprocess.run", side_effect=fake_run),
+    ):
         result = probe_media(str(f))
 
     assert result["duration"] == 12.0
@@ -58,9 +65,11 @@ def test_probe_media_falls_back_to_ffmpeg(tmp_path):
     def fake_run(cmd, **kw):
         return type("P", (), {"returncode": 1, "stdout": "", "stderr": stderr})()
 
-    with patch("movie_narrator.utils.deliverable_qa.shutil.which", lambda x: None), \
-         patch("movie_narrator.utils.deliverable_qa.subprocess.run", side_effect=fake_run), \
-         patch("movie_narrator.utils.deliverable_qa._ffmpeg_bin", return_value="ffmpeg"):
+    with (
+        patch("movie_narrator.utils.deliverable_qa.shutil.which", lambda x: None),
+        patch("movie_narrator.utils.deliverable_qa.subprocess.run", side_effect=fake_run),
+        patch("movie_narrator.utils.deliverable_qa._ffmpeg_bin", return_value="ffmpeg"),
+    ):
         result = probe_media(str(f))
 
     assert result["duration"] == 15.0
@@ -80,10 +89,18 @@ def test_evaluate_missing_file():
 def test_evaluate_all_pass(tmp_path):
     f = tmp_path / "good.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 10.0, "has_video": True, "has_audio": True,
-        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -14.0,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 10.0,
+            "has_video": True,
+            "has_audio": True,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": -14.0,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0)
     assert report.ok is True
     assert report.issues == []
@@ -92,10 +109,18 @@ def test_evaluate_all_pass(tmp_path):
 def test_evaluate_too_short(tmp_path):
     f = tmp_path / "short.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 5.0, "has_video": True, "has_audio": True,
-        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -14.0,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 5.0,
+            "has_video": True,
+            "has_audio": True,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": -14.0,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0)
     assert report.ok is False
     assert any(i.code == "too_short" for i in report.issues)
@@ -104,10 +129,18 @@ def test_evaluate_too_short(tmp_path):
 def test_evaluate_too_long(tmp_path):
     f = tmp_path / "long.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 20.0, "has_video": True, "has_audio": True,
-        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -14.0,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 20.0,
+            "has_video": True,
+            "has_audio": True,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": -14.0,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0)
     assert report.ok is False
     assert any(i.code == "too_long" for i in report.issues)
@@ -116,10 +149,18 @@ def test_evaluate_too_long(tmp_path):
 def test_evaluate_silent_audio(tmp_path):
     f = tmp_path / "silent.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 10.0, "has_video": True, "has_audio": True,
-        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": -60.0,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 10.0,
+            "has_video": True,
+            "has_audio": True,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": -60.0,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0, max_silence_db=-50.0)
     assert report.ok is False
     assert any(i.code == "silent_audio" for i in report.issues)
@@ -128,10 +169,18 @@ def test_evaluate_silent_audio(tmp_path):
 def test_evaluate_no_audio_stream(tmp_path):
     f = tmp_path / "noaudio.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 10.0, "has_video": True, "has_audio": False,
-        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": None,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 10.0,
+            "has_video": True,
+            "has_audio": False,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": None,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0)
     assert report.ok is False
     assert any(i.code == "no_audio_stream" for i in report.issues)
@@ -140,10 +189,18 @@ def test_evaluate_no_audio_stream(tmp_path):
 def test_evaluate_tiny_file(tmp_path):
     f = tmp_path / "tiny.mp4"
     f.write_bytes(b"x" * 100)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 10.0, "has_video": True, "has_audio": True,
-        "width": 1920, "height": 1080, "size_bytes": 100, "mean_volume": -14.0,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 10.0,
+            "has_video": True,
+            "has_audio": True,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 100,
+            "mean_volume": -14.0,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0, min_size_bytes=10000)
     assert report.ok is False
     assert any(i.code == "tiny_file" for i in report.issues)
@@ -160,11 +217,18 @@ def test_evaluate_volume_unknown_with_audio_streams(tmp_path):
     """
     f = tmp_path / "broken.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 10.0, "has_video": True, "has_audio": True,
-        "width": 1920, "height": 1080, "size_bytes": 50000,
-        "mean_volume": None,  # volumedetect failed to parse
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 10.0,
+            "has_video": True,
+            "has_audio": True,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": None,  # volumedetect failed to parse
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0)
     # Should report volume_unknown (not silently pass)
     assert any(i.code == "volume_unknown" for i in report.issues)
@@ -175,10 +239,18 @@ def test_evaluate_volume_unknown_not_triggered_when_no_audio(tmp_path):
     """AQ-05: no audio stream → no volume_unknown issue (no_audio_stream covers it)."""
     f = tmp_path / "noaudio.mp4"
     f.write_bytes(b"x" * 50000)
-    with patch("movie_narrator.utils.deliverable_qa.probe_media", return_value={
-        "duration": 10.0, "has_video": True, "has_audio": False,
-        "width": 1920, "height": 1080, "size_bytes": 50000, "mean_volume": None,
-    }):
+    with patch(
+        "movie_narrator.utils.deliverable_qa.probe_media",
+        return_value={
+            "duration": 10.0,
+            "has_video": True,
+            "has_audio": False,
+            "width": 1920,
+            "height": 1080,
+            "size_bytes": 50000,
+            "mean_volume": None,
+        },
+    ):
         report = evaluate_deliverable(str(f), expected_duration=10.0)
     # Should report no_audio_stream, NOT volume_unknown
     assert any(i.code == "no_audio_stream" for i in report.issues)

--- a/tests/test_e2e_smoke.py
+++ b/tests/test_e2e_smoke.py
@@ -47,7 +47,9 @@ def _ffmpeg_has_mp3_encoder() -> bool:
     try:
         result = subprocess.run(
             [ffmpeg, "-hide_banner", "-encoders"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         return "libmp3lame" in result.stdout or " mp3 " in result.stdout
     except Exception:
@@ -247,14 +249,18 @@ def test_e2e_dynamic_count_with_preset(ci_env, output_dir):
 
     # Mock LLM to return exactly target beats + segments
     beats_resp = _mock_llm_response(_json.dumps({"beats": [f"beat{i}" for i in range(target)]}))
-    seg_resp = _mock_llm_response(_json.dumps({"segments": [{"text": f"旁白{i}"} for i in range(target)]}))
+    seg_resp = _mock_llm_response(
+        _json.dumps({"segments": [{"text": f"旁白{i}"} for i in range(target)]})
+    )
     mock_cm = _mock_llm_cm(side_effect=[beats_resp, seg_resp])
 
     with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
         with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
             # Patch research_plot's LLM too (it runs before generate_script)
             with patch("movie_narrator.pipeline.research.get_llm_client", return_value=mock_cm):
-                with patch("movie_narrator.pipeline.research.get_settings", return_value=_mock_settings()):
+                with patch(
+                    "movie_narrator.pipeline.research.get_settings", return_value=_mock_settings()
+                ):
                     result = run_pipeline(ctx)
 
     # script_target_count should be 8 (calculated from 60/7.5)

--- a/tests/test_ep1_weighted_acts.py
+++ b/tests/test_ep1_weighted_acts.py
@@ -138,8 +138,7 @@ def _make_ctx(tmp_path, n_scenes=20, n_segments=18, mode="weighted_acts", weight
     (tmp_path / "video.mp4").write_bytes(b"00")
 
     ctx.scenes = [
-        Scene(index=i, start=float(i * 20), end=float(i * 20 + 20))
-        for i in range(n_scenes)
+        Scene(index=i, start=float(i * 20), end=float(i * 20 + 20)) for i in range(n_scenes)
     ]
     ctx.timed_segments = [
         TimedSegment(text=f"segment {i}", start=float(i * 3), end=float(i * 3 + 2.5))
@@ -152,9 +151,8 @@ def _make_ctx(tmp_path, n_scenes=20, n_segments=18, mode="weighted_acts", weight
 
     # Disable embedding path — isolate weighted_acts heuristic
     import unittest.mock as mock
-    ctx._mock_patch = mock.patch(
-        "movie_narrator.pipeline.match.probe", lambda name: (False, "")
-    )
+
+    ctx._mock_patch = mock.patch("movie_narrator.pipeline.match.probe", lambda name: (False, ""))
     return ctx
 
 
@@ -162,8 +160,7 @@ def test_weighted_acts_produces_act_constrained_heuristic(tmp_path):
     """18 segments over 20 scenes with weighted_acts → src_start distribution
     should be non-uniform, concentrated in act 2 (weight=0.40).
     """
-    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=18,
-                    weights=[0.15, 0.25, 0.40, 0.20])
+    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=18, weights=[0.15, 0.25, 0.40, 0.20])
     with ctx._mock_patch:
         match_clips(ctx)
 
@@ -181,10 +178,15 @@ def test_weighted_acts_produces_act_constrained_heuristic(tmp_path):
 
     # Verify src_start distribution: act 2 segments should map to scenes 10-14
     # (act 2 covers 200-300s out of 0-400s total)
-    act2_segs = [mc for i, mc in enumerate(ctx.matched_clips)
-                 if i < timeline["segments_per_act"][0] + timeline["segments_per_act"][1]
-                 + timeline["segments_per_act"][2]
-                 and i >= timeline["segments_per_act"][0] + timeline["segments_per_act"][1]]
+    act2_segs = [
+        mc
+        for i, mc in enumerate(ctx.matched_clips)
+        if i
+        < timeline["segments_per_act"][0]
+        + timeline["segments_per_act"][1]
+        + timeline["segments_per_act"][2]
+        and i >= timeline["segments_per_act"][0] + timeline["segments_per_act"][1]
+    ]
     for mc in act2_segs:
         # Scene index should be in act 2 range (10-14) or adjacent overflow (5-19)
         assert 5 <= mc.scene_index <= 19, (
@@ -195,8 +197,7 @@ def test_weighted_acts_produces_act_constrained_heuristic(tmp_path):
 
 def test_weighted_acts_disabled_with_few_scenes(tmp_path):
     """Fewer than 8 scenes → falls back to uniform, mode in metadata = "uniform"."""
-    ctx = _make_ctx(tmp_path, n_scenes=5, n_segments=10,
-                    weights=[0.15, 0.25, 0.40, 0.20])
+    ctx = _make_ctx(tmp_path, n_scenes=5, n_segments=10, weights=[0.15, 0.25, 0.40, 0.20])
     with ctx._mock_patch:
         match_clips(ctx)
 
@@ -207,8 +208,7 @@ def test_weighted_acts_disabled_with_few_scenes(tmp_path):
 
 def test_weighted_acts_disabled_with_few_segments(tmp_path):
     """Fewer than 4 segments → falls back to uniform."""
-    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=3,
-                    weights=[0.15, 0.25, 0.40, 0.20])
+    ctx = _make_ctx(tmp_path, n_scenes=20, n_segments=3, weights=[0.15, 0.25, 0.40, 0.20])
     with ctx._mock_patch:
         match_clips(ctx)
 
@@ -229,8 +229,7 @@ def test_uniform_mode_default(tmp_path):
 
 def test_weighted_acts_different_weights(tmp_path):
     """Custom weights → segment counts match weight ratios."""
-    ctx = _make_ctx(tmp_path, n_scenes=40, n_segments=20,
-                    weights=[0.10, 0.20, 0.50, 0.20])
+    ctx = _make_ctx(tmp_path, n_scenes=40, n_segments=20, weights=[0.10, 0.20, 0.50, 0.20])
     with ctx._mock_patch:
         match_clips(ctx)
 
@@ -250,8 +249,7 @@ def test_weighted_acts_src_start_not_uniform(tmp_path):
     """With weighted_acts, src_start values should NOT be uniformly distributed
     across the full timeline — they should cluster in act 2 (the heaviest act).
     """
-    ctx = _make_ctx(tmp_path, n_scenes=40, n_segments=20,
-                    weights=[0.10, 0.20, 0.50, 0.20])
+    ctx = _make_ctx(tmp_path, n_scenes=40, n_segments=20, weights=[0.10, 0.20, 0.50, 0.20])
     with ctx._mock_patch:
         match_clips(ctx)
 

--- a/tests/test_ep5_completion.py
+++ b/tests/test_ep5_completion.py
@@ -41,6 +41,7 @@ class TestEP5ParamWhitelistSync:
 
     def test_params_in_schema(self):
         from movie_narrator.workflow.schema import JobParams
+
         fields = JobParams.model_fields
         assert "render_cover_export" in fields
         assert "render_vertical_safe_area" in fields
@@ -48,6 +49,7 @@ class TestEP5ParamWhitelistSync:
     def test_params_in_load(self):
         """load.py uses a local allowed_params set — inspect source."""
         from movie_narrator.workflow import load
+
         source = inspect.getsource(load.load_job_config)
         assert "render_cover_export" in source
         assert "render_vertical_safe_area" in source
@@ -55,6 +57,7 @@ class TestEP5ParamWhitelistSync:
     def test_params_in_merge(self):
         """merge.py uses an inline tuple — inspect source."""
         from movie_narrator.workflow import merge
+
         source = inspect.getsource(merge.merge_job)
         assert "render_cover_export" in source
         assert "render_vertical_safe_area" in source
@@ -68,27 +71,32 @@ class TestEP5PresetInjection:
 
     def test_douyin_fast_has_cover_export(self):
         from movie_narrator.presets.douyin_fast import DouyinFastPreset
+
         params = DouyinFastPreset().params()
         assert params.get("render_cover_export") is True
 
     def test_douyin_fast_has_vertical_safe_area(self):
         from movie_narrator.presets.douyin_fast import DouyinFastPreset
+
         params = DouyinFastPreset().params()
         assert params.get("render_vertical_safe_area") is True
 
     def test_bilibili_long_has_cover_export(self):
         from movie_narrator.presets.bilibili_long import BilibiliLongPreset
+
         params = BilibiliLongPreset().params()
         assert params.get("render_cover_export") is True
 
     def test_bilibili_long_has_vertical_safe_area(self):
         from movie_narrator.presets.bilibili_long import BilibiliLongPreset
+
         params = BilibiliLongPreset().params()
         assert params.get("render_vertical_safe_area") is True
 
     def test_mainstream_dry_does_not_have_cover_export(self):
         """mainstream-dry should NOT auto-inject cover export (not in its preset)."""
         from movie_narrator.presets.mainstream_dry import MainstreamDryPreset
+
         params = MainstreamDryPreset().params()
         # mainstream-dry doesn't define it — defaults to False
         assert params.get("render_cover_export") is None
@@ -105,8 +113,9 @@ class TestVerticalSafeArea:
             _VERTICAL_BOTTOM_MARGIN_RATIO,
             _VERTICAL_MAX_WIDTH_RATIO,
         )
+
         assert _VERTICAL_BOTTOM_MARGIN_RATIO > 0.08  # more than 16:9 default
-        assert _VERTICAL_MAX_WIDTH_RATIO < 0.90      # less than 16:9 default
+        assert _VERTICAL_MAX_WIDTH_RATIO < 0.90  # less than 16:9 default
 
     def test_vertical_safe_area_logic(self):
         """Verify the min/max clamp logic for 9:16 format."""
@@ -207,10 +216,18 @@ class TestCoverExport:
 
         ctx = self._make_ctx(tmp_path)
         ctx.source_video_path = None
-        clips = [MatchedClip(
-            segment_index=0, text="test", narr_start=0, narr_end=1,
-            src_start=0, src_end=1, score=0.8, source="embedding",
-        )]
+        clips = [
+            MatchedClip(
+                segment_index=0,
+                text="test",
+                narr_start=0,
+                narr_end=1,
+                src_start=0,
+                src_end=1,
+                score=0.8,
+                source="embedding",
+            )
+        ]
         _export_cover_image(ctx, clips, tmp_path)
 
         assert not (tmp_path / "cover.jpg").exists()
@@ -219,10 +236,18 @@ class TestCoverExport:
         from movie_narrator.pipeline.render import _export_cover_image
 
         ctx = self._make_ctx(tmp_path)
-        clips = [MatchedClip(
-            segment_index=0, text="test", narr_start=0, narr_end=1,
-            src_start=0, src_end=1, score=0.0, source="heuristic",
-        )]
+        clips = [
+            MatchedClip(
+                segment_index=0,
+                text="test",
+                narr_start=0,
+                narr_end=1,
+                src_start=0,
+                src_end=1,
+                score=0.0,
+                source="heuristic",
+            )
+        ]
         _export_cover_image(ctx, clips, tmp_path)
 
         assert not (tmp_path / "cover.jpg").exists()
@@ -231,10 +256,18 @@ class TestCoverExport:
         from movie_narrator.pipeline.render import _export_cover_image
 
         ctx = self._make_ctx(tmp_path)
-        clips = [MatchedClip(
-            segment_index=0, text="test", narr_start=0, narr_end=1,
-            src_start=5.0, src_end=10.0, score=0.85, source="embedding",
-        )]
+        clips = [
+            MatchedClip(
+                segment_index=0,
+                text="test",
+                narr_start=0,
+                narr_end=1,
+                src_start=5.0,
+                src_end=10.0,
+                score=0.85,
+                source="embedding",
+            )
+        ]
 
         with patch("movie_narrator.pipeline.render.shutil.which", return_value=None):
             _export_cover_image(ctx, clips, tmp_path)
@@ -248,16 +281,34 @@ class TestCoverExport:
         ctx = self._make_ctx(tmp_path, movie_name="最佳封面")
         clips = [
             MatchedClip(
-                segment_index=0, text="low", narr_start=0, narr_end=1,
-                src_start=0.0, src_end=5.0, score=0.3, source="embedding",
+                segment_index=0,
+                text="low",
+                narr_start=0,
+                narr_end=1,
+                src_start=0.0,
+                src_end=5.0,
+                score=0.3,
+                source="embedding",
             ),
             MatchedClip(
-                segment_index=1, text="high", narr_start=1, narr_end=2,
-                src_start=100.0, src_end=110.0, score=0.92, source="embedding",
+                segment_index=1,
+                text="high",
+                narr_start=1,
+                narr_end=2,
+                src_start=100.0,
+                src_end=110.0,
+                score=0.92,
+                source="embedding",
             ),
             MatchedClip(
-                segment_index=2, text="mid", narr_start=2, narr_end=3,
-                src_start=50.0, src_end=55.0, score=0.6, source="embedding",
+                segment_index=2,
+                text="mid",
+                narr_start=2,
+                narr_end=3,
+                src_start=50.0,
+                src_end=55.0,
+                score=0.6,
+                source="embedding",
             ),
         ]
 

--- a/tests/test_gpu_detect.py
+++ b/tests/test_gpu_detect.py
@@ -42,14 +42,14 @@ def test_detect_returns_none_when_ffmpeg_missing():
 def test_detect_returns_none_in_ci_environment(monkeypatch):
     """CI env var set -> detection skips even when ffmpeg has GPU encoders."""
     monkeypatch.setenv("CI", "1")
-    fake_stdout = (
-        " V..... h264_nvenc            NVIDIA NVENC H.264 encoder (codec h264)\n"
-    )
-    with patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value="/usr/bin/ffmpeg"), \
-         patch(
-             f"{_GPU_DETECT_MOD}.subprocess.run",
-             return_value=_fake_proc(stdout=fake_stdout),
-         ):
+    fake_stdout = " V..... h264_nvenc            NVIDIA NVENC H.264 encoder (codec h264)\n"
+    with (
+        patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch(
+            f"{_GPU_DETECT_MOD}.subprocess.run",
+            return_value=_fake_proc(stdout=fake_stdout),
+        ),
+    ):
         assert detect_gpu_encoder() is None
 
 
@@ -61,11 +61,13 @@ def test_detect_returns_nvenc_when_available():
         " V..... h264_nvenc            NVIDIA NVENC H.264 encoder (codec h264)\n"
         " V....D libx264               libx264 H.264 / AVC (codec h264)\n"
     )
-    with patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value="/usr/bin/ffmpeg"), \
-         patch(
-             f"{_GPU_DETECT_MOD}.subprocess.run",
-             return_value=_fake_proc(stdout=fake_stdout),
-         ):
+    with (
+        patch(f"{_GPU_DETECT_MOD}.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch(
+            f"{_GPU_DETECT_MOD}.subprocess.run",
+            return_value=_fake_proc(stdout=fake_stdout),
+        ),
+    ):
         assert detect_gpu_encoder() == "h264_nvenc"
 
 

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -82,9 +82,7 @@ def test_truncation_nested_array_with_cut_inner_element():
 
 def test_truncation_with_escaped_quotes_in_earlier_strings():
     """Earlier elements may contain escaped quotes; they must not confuse the scan."""
-    raw = (
-        r'{"translations": ["he said \"hi\"", "fully closed", "truncated mid'
-    )
+    raw = r'{"translations": ["he said \"hi\"", "fully closed", "truncated mid'
     out = extract_json(raw)
     assert out == {"translations": [r'he said "hi"', "fully closed"]}
 
@@ -141,7 +139,7 @@ def test_is_balanced_braces_handles_strings():
     assert _is_balanced_braces('{"a": [1, 2]}') is True
     assert _is_balanced_braces('{"a": "}in string{}"}') is True
     assert _is_balanced_braces('{"a": [1, 2]') is False
-    assert _is_balanced_braces('{{}}') is True
+    assert _is_balanced_braces("{{}}") is True
     # Half-open string at the end → not balanced
     assert _is_balanced_braces('{"a": "unterminated') is False
 

--- a/tests/test_judge_feedback.py
+++ b/tests/test_judge_feedback.py
@@ -119,6 +119,7 @@ class TestExpandBeatsAcceptsPrevScores:
         """Verify _expand_beats_to_script has prev_judge_scores parameter."""
         import inspect
         from movie_narrator.pipeline.script import _expand_beats_to_script
+
         sig = inspect.signature(_expand_beats_to_script)
         assert "prev_judge_scores" in sig.parameters
         assert sig.parameters["prev_judge_scores"].default is None

--- a/tests/test_m5_community.py
+++ b/tests/test_m5_community.py
@@ -36,14 +36,17 @@ class TestCheckVersion:
 
     def test_check_version_exported_from_contract(self):
         from movie_narrator.contract import check_version as _cv
+
         assert _cv is check_version
 
     def test_check_version_exported_from_init(self):
         from movie_narrator import check_version as _cv
+
         assert _cv is check_version
 
     def test_check_version_in_all(self):
         from movie_narrator import contract
+
         assert "check_version" in contract.__all__
 
 
@@ -82,9 +85,7 @@ class TestCliPluginList:
         """When entry points exist, they are listed."""
         from movie_narrator.plugin_loader import list_available_plugins
 
-        with patch(
-            "movie_narrator.plugin_loader.entry_points"
-        ) as mock_ep:
+        with patch("movie_narrator.plugin_loader.entry_points") as mock_ep:
             mock_ep.return_value = []
             result = runner.invoke(app, ["plugin", "list"])
             assert result.exit_code == 0
@@ -146,10 +147,7 @@ class TestCliPluginInvalidAction:
 class TestPluginTemplate:
     """The plugin template in examples/plugins/template/ is valid."""
 
-    TEMPLATE_DIR = (
-        Path(__file__).resolve().parent.parent
-        / "examples" / "plugins" / "template"
-    )
+    TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "examples" / "plugins" / "template"
 
     def test_template_directory_exists(self):
         assert self.TEMPLATE_DIR.is_dir()

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -84,7 +84,11 @@ def test_match_clips_embedding_disabled_keeps_heuristic(tmp_path, monkeypatch):
     monkeypatch.setattr(
         match_module,
         "probe",
-        lambda name: (False, "pip install movie-narrator[ml]") if name == "sentence_transformers" else (True, ""),
+        lambda name: (
+            (False, "pip install movie-narrator[ml]")
+            if name == "sentence_transformers"
+            else (True, "")
+        ),
     )
     match_clips(ctx)
     assert ctx.status.match == "success"
@@ -113,9 +117,7 @@ def test_match_summary_full_schema_when_embedding_path_runs(tmp_path, monkeypatc
         {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
         {"start": 4.0, "end": 9.0, "text": "beta scene one"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     class FakeST:
         def __init__(self, *a, **kw):
@@ -139,14 +141,32 @@ def test_match_summary_full_schema_when_embedding_path_runs(tmp_path, monkeypatc
 
     # All required fields present
     required_fields = [
-        "version", "status", "segments", "scenes_in", "scenes_after_merge",
-        "scenes_after_drop", "merge_min_duration", "drop_min_duration",
-        "min_score", "speed_clamp", "source_counts", "heuristic_ratio",
-        "embedding_ratio", "score", "raw_score", "speed_factor",
-        "low_score_fallback_count", "captioning", "embedding_model",
-        "degraded_reason", "diversity",
+        "version",
+        "status",
+        "segments",
+        "scenes_in",
+        "scenes_after_merge",
+        "scenes_after_drop",
+        "merge_min_duration",
+        "drop_min_duration",
+        "min_score",
+        "speed_clamp",
+        "source_counts",
+        "heuristic_ratio",
+        "embedding_ratio",
+        "score",
+        "raw_score",
+        "speed_factor",
+        "low_score_fallback_count",
+        "captioning",
+        "embedding_model",
+        "degraded_reason",
+        "diversity",
         # back-compat
-        "total", "embedding", "heuristic", "captions_fake",
+        "total",
+        "embedding",
+        "heuristic",
+        "captions_fake",
     ]
     for field in required_fields:
         assert field in summary, f"match_summary: missing field '{field}' in match_summary"
@@ -179,7 +199,9 @@ def test_match_summary_degraded_reason_all_heuristic(tmp_path, monkeypatch):
     ]
     # sentence_transformers NOT available → all heuristic
     monkeypatch.setattr(
-        match_module, "probe", lambda name: (False, "") if name == "sentence_transformers" else (False, ""),
+        match_module,
+        "probe",
+        lambda name: (False, "") if name == "sentence_transformers" else (False, ""),
     )
 
     match_clips(ctx)
@@ -209,9 +231,7 @@ def test_match_summary_low_score_fallback_count(tmp_path, monkeypatch):
         {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
         {"start": 4.0, "end": 9.0, "text": "beta scene one"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     # Embeddings: alpha matches scene 0 strongly, gamma is orthogonal to both.
     # NOTE: _embed_texts L2-normalizes vectors, so we must use vectors that
@@ -306,9 +326,9 @@ def test_build_scene_captions_mixed_real_and_fake():
     from movie_narrator.pipeline.match import _build_scene_captions
 
     scenes = [
-        Scene(index=0, start=0.0, end=5.0),   # has speech
+        Scene(index=0, start=0.0, end=5.0),  # has speech
         Scene(index=1, start=5.0, end=10.0),  # no speech (gap)
-        Scene(index=2, start=10.0, end=15.0), # has speech
+        Scene(index=2, start=10.0, end=15.0),  # has speech
     ]
     transcript = [
         {"start": 0.0, "end": 4.0, "text": "speech in scene 0"},
@@ -318,7 +338,7 @@ def test_build_scene_captions_mixed_real_and_fake():
     result = _build_scene_captions(scenes, transcript)
     assert len(result) == 3
     assert result[0][1] is False  # scene 0 has speech
-    assert result[1][1] is True   # scene 1 no speech → fake
+    assert result[1][1] is True  # scene 1 no speech → fake
     assert result[2][1] is False  # scene 2 has speech
 
 
@@ -347,9 +367,7 @@ def test_match_summary_keys_compatible_with_old_metadata_export(tmp_path, monkey
         {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
         {"start": 4.0, "end": 9.0, "text": "beta scene one"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     class FakeST:
         def __init__(self, *a, **kw):
@@ -397,7 +415,9 @@ def test_match_summary_legacy_fields_when_all_heuristic(tmp_path, monkeypatch):
 
     # sentence_transformers NOT available → all heuristic
     monkeypatch.setattr(
-        match_module, "probe", lambda name: (False, ""),
+        match_module,
+        "probe",
+        lambda name: (False, ""),
     )
 
     match_clips(ctx)
@@ -483,7 +503,9 @@ def test_match_captions_real_when_transcript_available(tmp_path, monkeypatch):
 
     # Both available
     monkeypatch.setattr(
-        match_module, "probe", lambda name: (True, ""),
+        match_module,
+        "probe",
+        lambda name: (True, ""),
     )
 
     # Real transcript covering both scenes
@@ -491,9 +513,7 @@ def test_match_captions_real_when_transcript_available(tmp_path, monkeypatch):
         {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
         {"start": 4.0, "end": 9.0, "text": "beta scene one"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     class FakeST:
         def __init__(self, *a, **kw):
@@ -547,8 +567,8 @@ def test_match_drops_tiny_scenes(tmp_path):
             TimedSegment(text="B", start=2.5, end=5.0),
         ],
         scenes=[
-            Scene(index=0, start=0.0, end=0.2),   # tiny (< 0.4s)
-            Scene(index=1, start=0.2, end=8.0),   # long
+            Scene(index=0, start=0.0, end=0.2),  # tiny (< 0.4s)
+            Scene(index=1, start=0.2, end=8.0),  # long
         ],
     )
     ctx.status.scene = "success"
@@ -586,8 +606,8 @@ def test_match_default_merge_merges_short_scenes(tmp_path):
         source_video_path=str(tmp_path / "video.mp4"),
         timed_segments=[TimedSegment(text="A", start=0.0, end=5.0)],
         scenes=[
-            Scene(index=0, start=0.0, end=1.0),   # short (< 2.0 default)
-            Scene(index=1, start=1.0, end=8.0),   # long
+            Scene(index=0, start=0.0, end=1.0),  # short (< 2.0 default)
+            Scene(index=1, start=1.0, end=8.0),  # long
         ],
     )
     ctx.status.scene = "success"
@@ -680,8 +700,11 @@ def test_match_clips_cache_write_and_hit(tmp_path, monkeypatch):
         call_count[0] += 1
         # Simulate cache write (real function does this)
         from movie_narrator.pipeline.match import _cache_key
-        cache_name = _cache_key(video_path, kw.get("model_name", "medium"), kw.get("language", "zh"))
-        (output_dir / cache_name).write_text('[]', encoding="utf-8")
+
+        cache_name = _cache_key(
+            video_path, kw.get("model_name", "medium"), kw.get("language", "zh")
+        )
+        (output_dir / cache_name).write_text("[]", encoding="utf-8")
         return [{"start": 0.0, "end": 5.0, "text": "hello"}]
 
     monkeypatch.setattr(match_module, "_transcribe_video_audio", fake_transcribe)
@@ -725,6 +748,7 @@ def test_match_clips_cache_corrupt_recovers(tmp_path, monkeypatch):
 
     # Write corrupt cache file
     from movie_narrator.pipeline.match import _cache_key
+
     cache_name = _cache_key(str(tmp_path / "video.mp4"), "medium", "zh")
     (tmp_path / cache_name).write_text("NOT VALID JSON {{{", encoding="utf-8")
 
@@ -959,9 +983,7 @@ def test_match_clips_embedding_reranks_when_available(tmp_path, monkeypatch):
         {"start": 0.0, "end": 3.5, "text": "alpha scene zero"},
         {"start": 4.0, "end": 9.0, "text": "beta scene one"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     class FakeST:
         def __init__(self, *a, **kw):
@@ -1041,6 +1063,7 @@ def test_transcribe_video_audio_faster_whisper_fallback(tmp_path, monkeypatch):
 
     # Make WhisperX import raise to simulate Windows CPU k2-fsa failure
     import builtins
+
     real_import = builtins.__import__
 
     def fail_whisperx(name, *args, **kwargs):
@@ -1061,9 +1084,7 @@ def test_transcribe_video_audio_faster_whisper_fallback(tmp_path, monkeypatch):
     fake_seg2.end = 10.0
     fake_seg2.text = " 场景二对话 "
     fake_model = MagicMock()
-    fake_model.transcribe = MagicMock(
-        return_value=([fake_seg1, fake_seg2], MagicMock())
-    )
+    fake_model.transcribe = MagicMock(return_value=([fake_seg1, fake_seg2], MagicMock()))
     fake_fw.WhisperModel = MagicMock(return_value=fake_model)
     monkeypatch.setitem(sys.modules, "faster_whisper", fake_fw)
 
@@ -1089,6 +1110,7 @@ def test_transcribe_video_audio_both_backends_fail_returns_none(tmp_path, monkey
 
     # Make WhisperX import fail
     import builtins
+
     real_import = builtins.__import__
 
     def fail_whisperx(name, *args, **kwargs):
@@ -1137,6 +1159,7 @@ def test_transcribe_video_audio_cache_hit_skips_transcription(tmp_path, monkeypa
     # Read cache directly (simulating what _transcribe_video_audio does)
     cache_path = tmp_path / cache_key
     import json
+
     result = json.loads(cache_path.read_text(encoding="utf-8"))
 
     assert result == cached_segments
@@ -1151,14 +1174,41 @@ def test_apply_diversity_no_swaps_needed():
     from movie_narrator.models import MatchedClip
 
     clips = [
-        MatchedClip(segment_index=0, text="a", narr_start=0, narr_end=2,
-                    src_start=0, src_end=2, score=1.0, scene_index=0, source="heuristic"),
-        MatchedClip(segment_index=1, text="b", narr_start=2, narr_end=4,
-                    src_start=2, src_end=4, score=1.0, scene_index=1, source="heuristic"),
-        MatchedClip(segment_index=2, text="c", narr_start=4, narr_end=6,
-                    src_start=4, src_end=6, score=1.0, scene_index=2, source="heuristic"),
+        MatchedClip(
+            segment_index=0,
+            text="a",
+            narr_start=0,
+            narr_end=2,
+            src_start=0,
+            src_end=2,
+            score=1.0,
+            scene_index=0,
+            source="heuristic",
+        ),
+        MatchedClip(
+            segment_index=1,
+            text="b",
+            narr_start=2,
+            narr_end=4,
+            src_start=2,
+            src_end=4,
+            score=1.0,
+            scene_index=1,
+            source="heuristic",
+        ),
+        MatchedClip(
+            segment_index=2,
+            text="c",
+            narr_start=4,
+            narr_end=6,
+            src_start=4,
+            src_end=6,
+            score=1.0,
+            scene_index=2,
+            source="heuristic",
+        ),
     ]
-    scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(5)]
+    scenes = [SimpleNamespace(index=i, start=i * 2, end=i * 2 + 2) for i in range(5)]
     swaps, swaps_log = _apply_diversity(clips, scenes, window=3, max_reuse=2)
     assert swaps == 0
     assert swaps_log == []
@@ -1173,14 +1223,41 @@ def test_apply_diversity_swaps_consecutive_reuse():
     from movie_narrator.models import MatchedClip
 
     clips = [
-        MatchedClip(segment_index=0, text="a", narr_start=0, narr_end=2,
-                    src_start=0, src_end=2, score=1.0, scene_index=1, source="embedding"),
-        MatchedClip(segment_index=1, text="b", narr_start=2, narr_end=4,
-                    src_start=2, src_end=4, score=1.0, scene_index=1, source="embedding"),
-        MatchedClip(segment_index=2, text="c", narr_start=4, narr_end=6,
-                    src_start=4, src_end=6, score=1.0, scene_index=1, source="embedding"),
+        MatchedClip(
+            segment_index=0,
+            text="a",
+            narr_start=0,
+            narr_end=2,
+            src_start=0,
+            src_end=2,
+            score=1.0,
+            scene_index=1,
+            source="embedding",
+        ),
+        MatchedClip(
+            segment_index=1,
+            text="b",
+            narr_start=2,
+            narr_end=4,
+            src_start=2,
+            src_end=4,
+            score=1.0,
+            scene_index=1,
+            source="embedding",
+        ),
+        MatchedClip(
+            segment_index=2,
+            text="c",
+            narr_start=4,
+            narr_end=6,
+            src_start=4,
+            src_end=6,
+            score=1.0,
+            scene_index=1,
+            source="embedding",
+        ),
     ]
-    scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(5)]
+    scenes = [SimpleNamespace(index=i, start=i * 2, end=i * 2 + 2) for i in range(5)]
     swaps, swaps_log = _apply_diversity(clips, scenes, window=3, max_reuse=2)
     assert swaps == 1
     assert len(swaps_log) == 1
@@ -1197,15 +1274,42 @@ def test_apply_diversity_no_swap_when_all_scenes_used():
     from movie_narrator.models import MatchedClip
 
     clips = [
-        MatchedClip(segment_index=0, text="a", narr_start=0, narr_end=2,
-                    src_start=0, src_end=2, score=1.0, scene_index=0, source="heuristic"),
-        MatchedClip(segment_index=1, text="b", narr_start=2, narr_end=4,
-                    src_start=2, src_end=4, score=1.0, scene_index=1, source="heuristic"),
-        MatchedClip(segment_index=2, text="c", narr_start=4, narr_end=6,
-                    src_start=4, src_end=6, score=1.0, scene_index=0, source="heuristic"),
+        MatchedClip(
+            segment_index=0,
+            text="a",
+            narr_start=0,
+            narr_end=2,
+            src_start=0,
+            src_end=2,
+            score=1.0,
+            scene_index=0,
+            source="heuristic",
+        ),
+        MatchedClip(
+            segment_index=1,
+            text="b",
+            narr_start=2,
+            narr_end=4,
+            src_start=2,
+            src_end=4,
+            score=1.0,
+            scene_index=1,
+            source="heuristic",
+        ),
+        MatchedClip(
+            segment_index=2,
+            text="c",
+            narr_start=4,
+            narr_end=6,
+            src_start=4,
+            src_end=6,
+            score=1.0,
+            scene_index=0,
+            source="heuristic",
+        ),
     ]
     # Only 2 scenes available — both used in window, can't swap
-    scenes = [SimpleNamespace(index=i, start=i*2, end=i*2+2) for i in range(2)]
+    scenes = [SimpleNamespace(index=i, start=i * 2, end=i * 2 + 2) for i in range(2)]
     swaps, swaps_log = _apply_diversity(clips, scenes, window=3, max_reuse=1)
     # Scene 0 appears 2 times in window of 3, max_reuse=1, but no unused scene available
     assert swaps == 0
@@ -1265,9 +1369,7 @@ def _setup_ep3_ctx(tmp_path, monkeypatch, topk=None, reuse_penalty=None):
         {"start": 0.0, "end": 3.5, "text": "scene zero speech"},
         {"start": 4.0, "end": 9.0, "text": "scene one speech"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     fake_mod = ModuleType("sentence_transformers")
     fake_mod.SentenceTransformer = _EP3FakeST
@@ -1356,12 +1458,14 @@ def test_ep3_cosine_topk_returns_sorted_descending():
     from movie_narrator.pipeline.match import _cosine_topk
 
     target = np.array([1.0, 0.0, 0.0])
-    candidates = np.array([
-        [0.5, 0.866, 0.0],   # cosine = 0.5
-        [1.0, 0.0, 0.0],     # cosine = 1.0
-        [0.0, 1.0, 0.0],     # cosine = 0.0
-        [0.8, 0.6, 0.0],     # cosine = 0.8
-    ])
+    candidates = np.array(
+        [
+            [0.5, 0.866, 0.0],  # cosine = 0.5
+            [1.0, 0.0, 0.0],  # cosine = 1.0
+            [0.0, 1.0, 0.0],  # cosine = 0.0
+            [0.8, 0.6, 0.0],  # cosine = 0.8
+        ]
+    )
     result = _cosine_topk(target, candidates, k=3)
     assert len(result) == 3
     # Sorted descending: 1.0, 0.8, 0.5
@@ -1375,10 +1479,12 @@ def test_ep3_cosine_topk_k_exceeds_candidates():
     from movie_narrator.pipeline.match import _cosine_topk
 
     target = np.array([1.0, 0.0])
-    candidates = np.array([
-        [0.6, 0.8],   # cosine = 0.6
-        [1.0, 0.0],   # cosine = 1.0
-    ])
+    candidates = np.array(
+        [
+            [0.6, 0.8],  # cosine = 0.6
+            [1.0, 0.0],  # cosine = 1.0
+        ]
+    )
     result = _cosine_topk(target, candidates, k=10)
     assert len(result) == 2  # capped at available candidates
     assert result[0] == (1, 1.0)
@@ -1402,15 +1508,19 @@ def test_ep3_greedy_topk_assign_unit():
     # 3 scenes, 2 narration segments
     # narration_0 = [1,0,0], narration_1 = [1,0,0]  (both match scene_0 best)
     # scene_0 = [1,0,0], scene_1 = [0.96,0.28,0], scene_2 = [0,1,0]
-    narration_vecs = np.array([
-        [1.0, 0.0, 0.0],
-        [1.0, 0.0, 0.0],
-    ])
-    scene_vecs = np.array([
-        [1.0, 0.0, 0.0],
-        [0.96, 0.28, 0.0],
-        [0.0, 1.0, 0.0],
-    ])
+    narration_vecs = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+        ]
+    )
+    scene_vecs = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.96, 0.28, 0.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
     scenes = [SimpleNamespace(index=i, start=i * 2, end=i * 2 + 2) for i in range(3)]
 
     results = _greedy_topk_assign(

--- a/tests/test_pipeline_pause.py
+++ b/tests/test_pipeline_pause.py
@@ -109,18 +109,14 @@ class TestSavePipelineState:
         """State JSON contains the completed_step field."""
         ctx = _make_ctx(tmp_path)
         _save_pipeline_state(ctx, "generate_script")
-        data = json.loads(
-            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / "pipeline_state.json").read_text(encoding="utf-8"))
         assert data["completed_step"] == "generate_script"
 
     def test_state_file_contains_context(self, tmp_path: Path):
         """State JSON contains a context field with movie_name."""
         ctx = _make_ctx(tmp_path)
         _save_pipeline_state(ctx, "match_clips")
-        data = json.loads(
-            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / "pipeline_state.json").read_text(encoding="utf-8"))
         assert "context" in data
         assert data["context"]["movie_name"] == "test-movie"
 
@@ -128,9 +124,7 @@ class TestSavePipelineState:
         """Services field is excluded from serialization (non-serializable)."""
         ctx = _make_ctx(tmp_path)
         _save_pipeline_state(ctx, "match_clips")
-        data = json.loads(
-            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / "pipeline_state.json").read_text(encoding="utf-8"))
         # services should not be in the serialized context
         assert "services" not in data["context"]
 
@@ -140,9 +134,7 @@ class TestSavePipelineState:
         ctx.metadata["pause_at"] = "render_video"
         ctx.metadata["custom_key"] = "custom_value"
         _save_pipeline_state(ctx, "match_clips")
-        data = json.loads(
-            (tmp_path / "pipeline_state.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / "pipeline_state.json").read_text(encoding="utf-8"))
         assert data["context"]["metadata"]["pause_at"] == "render_video"
         assert data["context"]["metadata"]["custom_key"] == "custom_value"
 
@@ -206,10 +198,12 @@ class TestRunPipelineStartStep:
 
         # Patch each step to record execution and return ctx
         for step in original_steps:
+
             def make_wrapper(s):
                 def wrapper(c):
                     executed.append(s.__name__)
                     return c
+
                 wrapper.__name__ = s.__name__
                 return wrapper
 
@@ -219,12 +213,15 @@ class TestRunPipelineStartStep:
         patched_steps = []
         for step in original_steps:
             name = step.__name__
+
             def make_mock(n):
                 def mock_step(c):
                     executed.append(n)
                     return c
+
                 mock_step.__name__ = n
                 return mock_step
+
             patched_steps.append(make_mock(name))
 
         monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
@@ -255,12 +252,15 @@ class TestRunPipelineStartStep:
         patched_steps = []
         for step in original_steps:
             name = step.__name__
+
             def make_mock(n):
                 def mock_step(c):
                     executed.append(n)
                     return c
+
                 mock_step.__name__ = n
                 return mock_step
+
             patched_steps.append(make_mock(name))
 
         monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
@@ -287,11 +287,14 @@ class TestRunPipelinePauseAt:
         patched_steps = []
         for step in original_steps:
             name = step.__name__
+
             def make_mock(n):
                 def mock_step(c):
                     return c
+
                 mock_step.__name__ = n
                 return mock_step
+
             patched_steps.append(make_mock(name))
 
         monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
@@ -313,11 +316,14 @@ class TestRunPipelinePauseAt:
         patched_steps = []
         for step in original_steps:
             name = step.__name__
+
             def make_mock(n):
                 def mock_step(c):
                     return c
+
                 mock_step.__name__ = n
                 return mock_step
+
             patched_steps.append(make_mock(name))
 
         monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
@@ -341,11 +347,14 @@ class TestRunPipelinePauseAt:
         patched_steps = []
         for step in original_steps:
             name = step.__name__
+
             def make_mock(n):
                 def mock_step(c):
                     return c
+
                 mock_step.__name__ = n
                 return mock_step
+
             patched_steps.append(make_mock(name))
 
         monkeypatch.setattr(runner_mod, "STEPS", patched_steps)
@@ -366,11 +375,14 @@ class TestRunPipelinePauseAt:
         patched_steps = []
         for step in original_steps:
             name = step.__name__
+
             def make_mock(n):
                 def mock_step(c):
                     return c
+
                 mock_step.__name__ = n
                 return mock_step
+
             patched_steps.append(make_mock(name))
 
         monkeypatch.setattr(runner_mod, "STEPS", patched_steps)

--- a/tests/test_plugin_discovery.py
+++ b/tests/test_plugin_discovery.py
@@ -80,6 +80,7 @@ class FakePlugin:
 
     def register(self, ctx: PluginContext) -> None:
         self.registered = True
+
         # Register a dummy step to verify registry integration
         def my_step(ctx):
             return ctx
@@ -298,15 +299,18 @@ class TestSDKExports:
 
     def test_discover_plugins_exported(self):
         from movie_narrator import discover_plugins
+
         assert callable(discover_plugins)
 
     def test_list_available_plugins_exported(self):
         from movie_narrator import list_available_plugins
+
         assert callable(list_available_plugins)
 
     def test_services_exported(self):
         from movie_narrator import Services as ExportedServices
         from movie_narrator.models import Services
+
         assert ExportedServices is Services
 
     def test_entry_point_group_constant(self):
@@ -314,6 +318,7 @@ class TestSDKExports:
 
     def test_discover_plugins_in_contract_all(self):
         from movie_narrator import contract
+
         assert "discover_plugins" in contract.__all__
         assert "list_available_plugins" in contract.__all__
         assert "Services" in contract.__all__

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -210,8 +210,9 @@ class TestStepRegistry:
         def hard_step(ctx):
             return ctx
 
-        reg.register("soft", soft_step, soft=True, status_field="soft_field",
-                     consequence="soft step failed")
+        reg.register(
+            "soft", soft_step, soft=True, status_field="soft_field", consequence="soft step failed"
+        )
         reg.register("hard", hard_step)
 
         assert reg.soft_step_names() == {"soft"}
@@ -256,6 +257,7 @@ class TestStepRegistryDecorator:
         def local_register(name, **kwargs):
             def decorator(func):
                 return reg.register(name, func, **kwargs)
+
             return decorator
 
         @local_register("decorated", soft=True)
@@ -284,6 +286,7 @@ class TestGlobalStepRegistry:
 
     def test_ordered_names_match_pipeline(self):
         from movie_narrator.pipeline.runner import STEPS
+
         assert len(step_registry.ordered_steps()) == len(STEPS)
 
     def test_first_step_is_resolve_video(self):
@@ -296,8 +299,13 @@ class TestGlobalStepRegistry:
 
     def test_soft_steps_correct(self):
         expected = {
-            "research_plot", "align_audio", "detect_scenes",
-            "match_clips", "mix_bgm", "export_clips", "translate_subtitles",
+            "research_plot",
+            "align_audio",
+            "detect_scenes",
+            "match_clips",
+            "mix_bgm",
+            "export_clips",
+            "translate_subtitles",
             "run_qa_gate",
         }
         assert step_registry.soft_step_names() == expected
@@ -411,8 +419,10 @@ class TestGlobalTtsRegistry:
 
     def test_factory_returns_provider(self):
         from movie_narrator.config import Settings, TTSProviderType
+
         settings = Settings(tts_provider=TTSProviderType.EDGE)
         from movie_narrator.tts.factory import get_tts_provider
+
         provider = get_tts_provider(settings)
         assert provider is not None
 
@@ -434,11 +444,13 @@ class TestGlobalVisionRegistry:
     def test_stub_registered_after_import(self):
         # Import the factory to trigger registration
         import movie_narrator.vision.factory  # noqa: F401
+
         assert "stub" in vision_registry.names()
 
     def test_create_stub(self):
         import movie_narrator.vision.factory  # noqa: F401
         from movie_narrator.vision.protocol import VisionCaptioner
+
         provider = vision_registry.create("stub")
         assert isinstance(provider, VisionCaptioner)
 
@@ -449,6 +461,7 @@ class TestGlobalLlmRegistry:
     def test_openai_registered_after_import(self):
         # Import the module to trigger registration
         import movie_narrator.utils.llm  # noqa: F401
+
         assert "openai" in llm_registry.names()
 
     def test_registry_category(self):
@@ -465,6 +478,7 @@ class TestGlobalResearchRegistry:
     def test_llm_registered_after_import(self):
         # Import the module to trigger registration
         import movie_narrator.pipeline.research  # noqa: F401
+
         assert "llm" in research_registry.names()
 
     def test_registry_category(self):
@@ -607,21 +621,25 @@ class TestUnifiedParamSchema:
 
     def test_param_whitelist_is_frozenset(self):
         from movie_narrator.pipeline.runner import PARAM_WHITELIST
+
         assert isinstance(PARAM_WHITELIST, frozenset)
 
     def test_param_whitelist_has_vision_captioner(self):
         """vision_captioner was missing from JobParams before v0.5."""
         from movie_narrator.pipeline.runner import PARAM_WHITELIST
+
         assert "vision_captioner" in PARAM_WHITELIST
 
     def test_job_params_has_vision_captioner(self):
         from movie_narrator.workflow.schema import JobParams
+
         assert "vision_captioner" in JobParams.model_fields
 
     def test_allowed_param_keys_subset_of_whitelist(self):
         """ALLOWED_PARAM_KEYS must be a subset of PARAM_WHITELIST."""
         from movie_narrator.pipeline.runner import PARAM_WHITELIST
         from movie_narrator.presets.base import ALLOWED_PARAM_KEYS
+
         assert ALLOWED_PARAM_KEYS <= PARAM_WHITELIST
 
 
@@ -633,66 +651,80 @@ class TestSDKSurface:
 
     def test_register_step_exported(self):
         from movie_narrator import register_step
+
         assert callable(register_step)
 
     def test_register_tts_exported(self):
         from movie_narrator import register_tts
+
         assert callable(register_tts)
 
     def test_register_vision_exported(self):
         from movie_narrator import register_vision
+
         assert callable(register_vision)
 
     def test_register_llm_exported(self):
         from movie_narrator import register_llm
+
         assert callable(register_llm)
 
     def test_register_research_exported(self):
         from movie_narrator import register_research
+
         assert callable(register_research)
 
     def test_llm_registry_exported(self):
         from movie_narrator import llm_registry as exported
         from movie_narrator.providers import llm_registry
+
         assert exported is llm_registry
 
     def test_research_registry_exported(self):
         from movie_narrator import research_registry as exported
         from movie_narrator.providers import research_registry
+
         assert exported is research_registry
 
     def test_context_exported(self):
         from movie_narrator import Context as ExportedContext
         from movie_narrator.models import Context
+
         assert ExportedContext is Context
 
     def test_step_registry_exported(self):
         from movie_narrator import step_registry as exported
         from movie_narrator.pipeline.registry import step_registry
+
         assert exported is step_registry
 
     def test_tts_registry_exported(self):
         from movie_narrator import tts_registry as exported
         from movie_narrator.providers import tts_registry
+
         assert exported is tts_registry
 
     def test_vision_registry_exported(self):
         from movie_narrator import vision_registry as exported
         from movie_narrator.providers import vision_registry
+
         assert exported is vision_registry
 
     def test_plugin_types_exported(self):
         from movie_narrator import Plugin, PluginContext, load_plugin
+
         assert Plugin is not None
         assert PluginContext is not None
         assert callable(load_plugin)
 
     def test_step_type_alias_exported(self):
         from movie_narrator import Step
+
         assert Step is not None
 
     def test_build_context_and_run_pipeline_exported(self):
         from movie_narrator import build_context, run_pipeline
+
         assert callable(build_context)
         assert callable(run_pipeline)
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -50,7 +50,9 @@ def test_preset_tags_within_allowed_vocab(preset_name):
     preset = get_preset(preset_name)
     for tag_key, tag_val in preset.tag_dict.items():
         assert tag_key in ALLOWED_PROMPT_TAGS, f"Unknown tag key: {tag_key}"
-        assert tag_val in ALLOWED_PROMPT_TAGS[tag_key], f"Tag '{tag_key}' value '{tag_val}' not allowed"
+        assert tag_val in ALLOWED_PROMPT_TAGS[tag_key], (
+            f"Tag '{tag_key}' value '{tag_val}' not allowed"
+        )
 
 
 # ── Preset differentiation ──────────────────────────────────
@@ -133,10 +135,13 @@ def test_validate_rejects_bad_param_key():
 
     class BadPreset:
         name = "bad"
+
         def params(self):
             return {"nonexistent_key": 42}
+
         def prompt_tags(self):
             return {}
+
         def description(self):
             return "bad"
 
@@ -149,10 +154,13 @@ def test_validate_rejects_bad_tag_value():
 
     class BadTagPreset:
         name = "bad-tag"
+
         def params(self):
             return {}
+
         def prompt_tags(self):
             return {"prompt_cadence": "supersonic"}  # not in allowed set
+
         def description(self):
             return "bad tag"
 
@@ -177,6 +185,7 @@ def test_builtin_presets_proxy_is_iterable():
 def test_allowed_param_keys_subset_of_param_whitelist():
     """ALLOWED_PARAM_KEYS must be a subset of PARAM_WHITELIST."""
     from movie_narrator.pipeline.runner import PARAM_WHITELIST
+
     assert ALLOWED_PARAM_KEYS <= PARAM_WHITELIST, (
         f"Keys in ALLOWED_PARAM_KEYS but not PARAM_WHITELIST: "
         f"{ALLOWED_PARAM_KEYS - PARAM_WHITELIST}"
@@ -202,5 +211,6 @@ def test_yaml_narration_preset_field_accepted(tmp_path):
 def test_yaml_narration_preset_defaults_none():
     """JobConfig.narration_preset defaults to None when not specified."""
     from movie_narrator.workflow.schema import JobConfig
+
     config = JobConfig(movie="test")
     assert config.narration_preset is None

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -189,41 +189,50 @@ class TestGetPreviewDuration:
 class TestShouldSkipStepForPreview:
     """should_skip_step_for_preview only skips soft steps when preview is on."""
 
-    @pytest.mark.parametrize("step", [
-        "research_plot",
-        "translate_subtitles",
-        "run_qa_gate",
-        "export_clips",
-    ])
+    @pytest.mark.parametrize(
+        "step",
+        [
+            "research_plot",
+            "translate_subtitles",
+            "run_qa_gate",
+            "export_clips",
+        ],
+    )
     def test_soft_steps_skipped_in_preview(self, step):
         assert should_skip_step_for_preview(step, True) is True
 
-    @pytest.mark.parametrize("step", [
-        "resolve_video",
-        "prepare_assets",
-        "generate_script",
-        "export_script_md",
-        "generate_voice",
-        "align_audio",
-        "detect_scenes",
-        "match_clips",
-        "mix_bgm",
-        "generate_subtitle",
-        "render_video",
-        "validate_deliverable",
-    ])
+    @pytest.mark.parametrize(
+        "step",
+        [
+            "resolve_video",
+            "prepare_assets",
+            "generate_script",
+            "export_script_md",
+            "generate_voice",
+            "align_audio",
+            "detect_scenes",
+            "match_clips",
+            "mix_bgm",
+            "generate_subtitle",
+            "render_video",
+            "validate_deliverable",
+        ],
+    )
     def test_hard_steps_never_skipped(self, step):
         """Hard steps run even in preview mode."""
         assert should_skip_step_for_preview(step, True) is False
 
-    @pytest.mark.parametrize("step", [
-        "research_plot",
-        "translate_subtitles",
-        "run_qa_gate",
-        "export_clips",
-        "generate_script",
-        "render_video",
-    ])
+    @pytest.mark.parametrize(
+        "step",
+        [
+            "research_plot",
+            "translate_subtitles",
+            "run_qa_gate",
+            "export_clips",
+            "generate_script",
+            "render_video",
+        ],
+    )
     def test_nothing_skipped_when_preview_off(self, step):
         """Preview off = nothing skipped (backward compatible)."""
         assert should_skip_step_for_preview(step, False) is False

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -29,8 +29,10 @@ def test_qa_runs_in_ci_when_explicitly_enabled(tmp_path):
     """qa_enabled=True forces QA even in CI."""
     ctx = _ctx(tmp_path, qa_enabled=True)
     report = QAReport(ok=True, issues=[], metrics={"duration": 10.0, "mean_volume": -14.0})
-    with patch("movie_narrator.pipeline.qa.is_ci", return_value=True), \
-         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+    with (
+        patch("movie_narrator.pipeline.qa.is_ci", return_value=True),
+        patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report),
+    ):
         validate_deliverable(ctx)
     assert ctx.metadata["qa_report"]["ok"] is True
 
@@ -48,8 +50,10 @@ def test_qa_runs_locally_by_default(tmp_path):
     """Outside CI with qa_enabled unset, QA runs."""
     ctx = _ctx(tmp_path)
     report = QAReport(ok=True, issues=[], metrics={"duration": 10.0, "mean_volume": -14.0})
-    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False), \
-         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+    with (
+        patch("movie_narrator.pipeline.qa.is_ci", return_value=False),
+        patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report),
+    ):
         validate_deliverable(ctx)
     assert ctx.metadata["qa_report"]["ok"] is True
 
@@ -62,8 +66,10 @@ def test_qa_raises_on_failure(tmp_path):
         issues=[QAIssue("silent_audio", "mean volume -60dB too low")],
         metrics={"duration": 10.0, "mean_volume": -60.0},
     )
-    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False), \
-         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+    with (
+        patch("movie_narrator.pipeline.qa.is_ci", return_value=False),
+        patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report),
+    ):
         with pytest.raises(RuntimeError, match="silent_audio"):
             validate_deliverable(ctx)
 
@@ -85,8 +91,10 @@ def test_qa_stores_report_in_metadata(tmp_path):
         issues=[QAIssue("too_short", "5s < 85% of 10s")],
         metrics={"duration": 5.0, "mean_volume": -14.0},
     )
-    with patch("movie_narrator.pipeline.qa.is_ci", return_value=False), \
-         patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report):
+    with (
+        patch("movie_narrator.pipeline.qa.is_ci", return_value=False),
+        patch("movie_narrator.pipeline.qa.evaluate_deliverable", return_value=report),
+    ):
         with pytest.raises(RuntimeError):
             validate_deliverable(ctx)
     stored = ctx.metadata["qa_report"]

--- a/tests/test_race.py
+++ b/tests/test_race.py
@@ -73,8 +73,7 @@ class TestGenerateCandidates:
         """Each default candidate has a unique parameter combination."""
         cands = generate_candidates()
         combos = [
-            (c.match_topk, c.match_topk_reuse_penalty, c.match_diversity_window)
-            for c in cands
+            (c.match_topk, c.match_topk_reuse_penalty, c.match_diversity_window) for c in cands
         ]
         assert len(set(combos)) == len(combos)
 
@@ -610,13 +609,15 @@ class TestRunRace:
         fake_video.parent.mkdir(parents=True, exist_ok=True)
         fake_video.write_bytes(b"fake video content")
 
-        candidates = [CandidateConfig(
-            label="test",
-            narration_preset="douyin-fast",
-            match_topk=5,
-            match_topk_reuse_penalty=0.15,
-            match_diversity_window=3,
-        )]
+        candidates = [
+            CandidateConfig(
+                label="test",
+                narration_preset="douyin-fast",
+                match_topk=5,
+                match_topk_reuse_penalty=0.15,
+                match_diversity_window=3,
+            )
+        ]
 
         def mock_build_context(**kwargs):
             ctx = Context(
@@ -672,18 +673,24 @@ class TestRunRace:
             preset = kwargs.get("narration_preset", "")
             if preset == "douyin-fast":
                 ctx.metadata["match_summary"] = {
-                    "segments": 10, "embedding_ratio": 0.9,
-                    "score": {"avg": 0.8}, "diversity": {"swaps": 2},
+                    "segments": 10,
+                    "embedding_ratio": 0.9,
+                    "score": {"avg": 0.8},
+                    "diversity": {"swaps": 2},
                 }
             elif preset == "mainstream-dry":
                 ctx.metadata["match_summary"] = {
-                    "segments": 10, "embedding_ratio": 0.7,
-                    "score": {"avg": 0.5}, "diversity": {"swaps": 2},
+                    "segments": 10,
+                    "embedding_ratio": 0.7,
+                    "score": {"avg": 0.5},
+                    "diversity": {"swaps": 2},
                 }
             else:
                 ctx.metadata["match_summary"] = {
-                    "segments": 10, "embedding_ratio": 0.5,
-                    "score": {"avg": 0.3}, "diversity": {"swaps": 2},
+                    "segments": 10,
+                    "embedding_ratio": 0.5,
+                    "score": {"avg": 0.3},
+                    "diversity": {"swaps": 2},
                 }
             ctx.metadata["duration_metrics"] = {"ratio": 1.0}
             ctx.video_path = None

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -51,6 +51,7 @@ def test_render_videofileclip_failure_warns(tmp_path, monkeypatch):
 
     # Patch at the moviepy module level
     import movie_narrator.pipeline.render as render_mod
+
     monkeypatch.setattr(render_mod, "VideoFileClip", mock_videofileclip)
 
     # Mock CompositeVideoClip to avoid actual rendering

--- a/tests/test_render_template.py
+++ b/tests/test_render_template.py
@@ -141,7 +141,7 @@ class TestSubstituteMovie:
     def test_special_chars_in_movie_name(self):
         """Special characters (quotes, parentheses) are inserted literally."""
         movie = '"战狼2"（特别版）'
-        assert _substitute_movie("{movie}解说", movie) == f'{movie}解说'
+        assert _substitute_movie("{movie}解说", movie) == f"{movie}解说"
 
 
 # ── 2. render_template field parsing ──────────────────────

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -42,8 +42,10 @@ def test_research_llm_success(tmp_path):
         ' "genres": ["Sci-Fi"], "cast": ["DiCaprio"], "keywords": ["dreams"]}'
     )
 
-    with patch("movie_narrator.pipeline.research.get_settings") as gs, \
-         patch("movie_narrator.pipeline.research.get_llm_client") as gl:
+    with (
+        patch("movie_narrator.pipeline.research.get_settings") as gs,
+        patch("movie_narrator.pipeline.research.get_llm_client") as gl,
+    ):
         gs.return_value.research_provider = "llm"
         gs.return_value.research_retries = 3
         gs.return_value.research_retry_delay = 0

--- a/tests/test_rhythm_scoring.py
+++ b/tests/test_rhythm_scoring.py
@@ -82,8 +82,8 @@ class TestComputeRhythmAdjustment:
         """Closer scenes get higher bonuses than farther ones."""
         scene_start = 0.0
         scene_span = 100.0
-        near = Scene(index=0, start=10.0, end=20.0)   # pos ≈ 0.15 (hook center)
-        far = Scene(index=1, start=50.0, end=60.0)    # pos ≈ 0.55 (far from hook)
+        near = Scene(index=0, start=10.0, end=20.0)  # pos ≈ 0.15 (hook center)
+        far = Scene(index=1, start=50.0, end=60.0)  # pos ≈ 0.55 (far from hook)
         near_adj = _compute_rhythm_adjustment("hook", near, scene_start, scene_span)
         far_adj = _compute_rhythm_adjustment("hook", far, scene_start, scene_span)
         assert near_adj > far_adj
@@ -118,8 +118,8 @@ class TestGreedyTopkAssignRhythm:
         scene_vecs = np.array([[1.0, 0.0], [1.0, 0.0]])
         narration_vecs = np.array([[1.0, 0.0]])
         scenes = [
-            Scene(index=0, start=0.0, end=10.0),    # pos=0.05 (early)
-            Scene(index=1, start=80.0, end=90.0),   # pos=0.85 (late)
+            Scene(index=0, start=0.0, end=10.0),  # pos=0.05 (early)
+            Scene(index=1, start=80.0, end=90.0),  # pos=0.85 (late)
         ]
         # "hook" prefers early scenes → scene 0 should win
         beats_meta = [{"rhythm_zone": "hook"}]
@@ -139,8 +139,8 @@ class TestGreedyTopkAssignRhythm:
         scene_vecs = np.array([[1.0, 0.0], [1.0, 0.0]])
         narration_vecs = np.array([[1.0, 0.0]])
         scenes = [
-            Scene(index=0, start=0.0, end=10.0),    # pos=0.05 (early)
-            Scene(index=1, start=80.0, end=90.0),   # pos=0.85 (late)
+            Scene(index=0, start=0.0, end=10.0),  # pos=0.05 (early)
+            Scene(index=1, start=80.0, end=90.0),  # pos=0.85 (late)
         ]
         beats_meta = [{"rhythm_zone": "settle"}]
         results = _greedy_topk_assign(
@@ -179,8 +179,8 @@ class TestGreedyTopkAssignRhythm:
         scene_vecs = np.array([[0.1, 0.0], [1.0, 0.0]])
         narration_vecs = np.array([[1.0, 0.0]])
         scenes = [
-            Scene(index=0, start=10.0, end=20.0),   # pos=0.15 (hook center)
-            Scene(index=1, start=80.0, end=90.0),   # pos=0.85 (far from hook)
+            Scene(index=0, start=10.0, end=20.0),  # pos=0.15 (hook center)
+            Scene(index=1, start=80.0, end=90.0),  # pos=0.85 (far from hook)
         ]
         beats_meta = [{"rhythm_zone": "hook"}]
         results = _greedy_topk_assign(
@@ -210,9 +210,7 @@ def _setup_embedding_mock(monkeypatch):
         {"start": 50.0, "end": 75.0, "text": "gamma scene two"},
         {"start": 75.0, "end": 100.0, "text": "delta scene three"},
     ]
-    monkeypatch.setattr(
-        match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript
-    )
+    monkeypatch.setattr(match_module, "_transcribe_video_audio", lambda *a, **k: mock_transcript)
 
     class FakeST:
         def __init__(self, *a, **kw):
@@ -347,8 +345,8 @@ def test_match_clips_rhythm_hook_prefers_early_scene(tmp_path, monkeypatch):
     (tmp_path / "video.mp4").write_bytes(b"00")
     ctx.status.scene = "success"
     ctx.scenes = [
-        Scene(index=0, start=0.0, end=25.0),     # early
-        Scene(index=1, start=75.0, end=100.0),   # late
+        Scene(index=0, start=0.0, end=25.0),  # early
+        Scene(index=1, start=75.0, end=100.0),  # late
     ]
     # Both segments use the same text → equal semantic similarity to both scenes
     # (since both scene captions contain "alpha")

--- a/tests/test_runner_workflow_metadata.py
+++ b/tests/test_runner_workflow_metadata.py
@@ -68,6 +68,7 @@ def test_run_pipeline_accumulates_degraded_steps_for_internal_fallback(tmp_path)
     runner's outer except block never fired, so _degraded_steps stayed
     empty and the degradation was invisible in the runner's summary.
     """
+
     def _passthrough(ctx: Context) -> Context:
         return ctx
 
@@ -109,6 +110,7 @@ def test_run_pipeline_accumulates_degraded_steps_for_internal_fallback(tmp_path)
 def test_run_pipeline_does_not_duplicate_degraded_steps(tmp_path):
     """Soft-step degradation: if a soft step both raises AND sets status='failed', the runner
     should not add it to _degraded_steps twice (idempotent)."""
+
     def _passthrough(ctx: Context) -> Context:
         return ctx
 
@@ -147,6 +149,7 @@ def test_run_pipeline_does_not_duplicate_degraded_steps(tmp_path):
 def test_run_pipeline_no_degraded_when_step_succeeds(tmp_path):
     """Soft-step degradation: a step that returns normally with status='success' should NOT
     be added to _degraded_steps."""
+
     def _passthrough(ctx: Context) -> Context:
         return ctx
 

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -19,9 +19,7 @@ def test_detect_scenes_disabled_without_dep(tmp_path):
 
 def test_detect_scenes_skipped_no_source(tmp_path):
     ctx = Context(movie_name="m", output_dir=str(tmp_path))
-    with patch(
-        "movie_narrator.pipeline.scenes.probe", return_value=(True, "")
-    ):
+    with patch("movie_narrator.pipeline.scenes.probe", return_value=(True, "")):
         detect_scenes(ctx)
     assert ctx.status.scene == "skipped"
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -67,14 +67,15 @@ def _mock_settings(**overrides):
 
 def _beats_json(n: int) -> str:
     """Build a valid Phase 1 response with n beats."""
-    beats = [f"剧情关键点{i+1}" for i in range(n)]
-    return '{"beats": ' + str(beats).replace("'", '"') + '}'
+    beats = [f"剧情关键点{i + 1}" for i in range(n)]
+    return '{"beats": ' + str(beats).replace("'", '"') + "}"
 
 
 def _segments_json(texts: list) -> str:
     """Build a valid Phase 2 response with segments."""
     segs = [{"text": t} for t in texts]
     import json
+
     return json.dumps({"segments": segs}, ensure_ascii=False)
 
 
@@ -147,8 +148,9 @@ def test_trim_segments_trims_to_exact_target():
 
 def test_trim_preserves_first_three_hooks():
     """First 3 segments (hooks) must be preserved during trim."""
-    segs = [ScriptSegment(text=f"hook{i}") for i in range(3)] + \
-           [ScriptSegment(text=f"body{i}") for i in range(7)]
+    segs = [ScriptSegment(text=f"hook{i}") for i in range(3)] + [
+        ScriptSegment(text=f"body{i}") for i in range(7)
+    ]
     result = _trim_segments(segs, 5)
     assert len(result) == 5
     # First 3 must be the hooks
@@ -214,8 +216,12 @@ def test_phase1_includes_research_context(tmp_path):
     """Research summary should appear in Phase 1 prompt."""
     ctx = _make_ctx(tmp_path)
     ctx.research = ResearchInfo(
-        title="测试电影", year="2024", summary="一部关于勇气的电影",
-        genres=["动作"], cast=["演员A"], keywords=["勇气"],
+        title="测试电影",
+        year="2024",
+        summary="一部关于勇气的电影",
+        genres=["动作"],
+        cast=["演员A"],
+        keywords=["勇气"],
     )
     beats_resp = _mock_llm_response(_beats_json(3))
     mock_cm = _mock_llm_cm(response=beats_resp)
@@ -348,11 +354,13 @@ def test_generate_script_hard_fails_on_all_retries(tmp_path, monkeypatch):
     ctx = _make_ctx(tmp_path)
     ctx.metadata["prompt_target_sentences"] = 3
 
-    mock_cm = _mock_llm_cm(side_effect=[
-        ConnectionError("unreachable"),  # attempt 1 Phase 1
-        ConnectionError("unreachable"),  # attempt 2 Phase 1
-        ConnectionError("unreachable"),  # attempt 3 Phase 1
-    ])
+    mock_cm = _mock_llm_cm(
+        side_effect=[
+            ConnectionError("unreachable"),  # attempt 1 Phase 1
+            ConnectionError("unreachable"),  # attempt 2 Phase 1
+            ConnectionError("unreachable"),  # attempt 3 Phase 1
+        ]
+    )
 
     with patch("movie_narrator.pipeline.script.is_ci", return_value=False):
         with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
@@ -368,11 +376,13 @@ def test_generate_script_retry_succeeds(tmp_path):
 
     beats_resp = _mock_llm_response(_beats_json(3))
     seg_resp = _mock_llm_response(_segments_json(["s1", "s2", "s3"]))
-    mock_cm = _mock_llm_cm(side_effect=[
-        ConnectionError("timeout"),  # attempt 1 Phase 1 fails
-        beats_resp,                   # attempt 2 Phase 1
-        seg_resp,                     # attempt 2 Phase 2
-    ])
+    mock_cm = _mock_llm_cm(
+        side_effect=[
+            ConnectionError("timeout"),  # attempt 1 Phase 1 fails
+            beats_resp,  # attempt 2 Phase 1
+            seg_resp,  # attempt 2 Phase 2
+        ]
+    )
 
     with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
         with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
@@ -441,8 +451,12 @@ def test_generate_script_research_in_phase1(tmp_path):
     ctx = _make_ctx(tmp_path)
     ctx.metadata["prompt_target_sentences"] = 3
     ctx.research = ResearchInfo(
-        title="测试电影", year="2024", summary="一部关于勇气的电影",
-        genres=["动作"], cast=["演员A"], keywords=["勇气"],
+        title="测试电影",
+        year="2024",
+        summary="一部关于勇气的电影",
+        genres=["动作"],
+        cast=["演员A"],
+        keywords=["勇气"],
     )
 
     beats_resp = _mock_llm_response(_beats_json(3))
@@ -477,12 +491,14 @@ def test_generate_script_phase1_ok_phase2_fail_then_retry(tmp_path):
     seg_resp = _mock_llm_response(_segments_json(["s1", "s2", "s3"]))
     # Attempt 1: Phase 1 OK, Phase 2 fails
     # Attempt 2: Phase 1 OK, Phase 2 OK
-    mock_cm = _mock_llm_cm(side_effect=[
-        beats_resp,               # attempt 1 Phase 1
-        ConnectionError("phase2 fail"),  # attempt 1 Phase 2
-        beats_resp,               # attempt 2 Phase 1
-        seg_resp,                 # attempt 2 Phase 2
-    ])
+    mock_cm = _mock_llm_cm(
+        side_effect=[
+            beats_resp,  # attempt 1 Phase 1
+            ConnectionError("phase2 fail"),  # attempt 1 Phase 2
+            beats_resp,  # attempt 2 Phase 1
+            seg_resp,  # attempt 2 Phase 2
+        ]
+    )
 
     with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
         with patch("movie_narrator.pipeline.script.get_llm_client", return_value=mock_cm):
@@ -503,11 +519,16 @@ def test_generate_script_phase1_ok_phase2_fail_all_retries(tmp_path, monkeypatch
 
     beats_resp = _mock_llm_response(_beats_json(3))
     # 3 attempts: each Phase 1 OK, Phase 2 fails
-    mock_cm = _mock_llm_cm(side_effect=[
-        beats_resp, ConnectionError("p2 fail"),
-        beats_resp, ConnectionError("p2 fail"),
-        beats_resp, ConnectionError("p2 fail"),
-    ])
+    mock_cm = _mock_llm_cm(
+        side_effect=[
+            beats_resp,
+            ConnectionError("p2 fail"),
+            beats_resp,
+            ConnectionError("p2 fail"),
+            beats_resp,
+            ConnectionError("p2 fail"),
+        ]
+    )
 
     with patch("movie_narrator.pipeline.script.is_ci", return_value=False):
         with patch("movie_narrator.pipeline.script.get_settings", return_value=_mock_settings()):
@@ -524,6 +545,7 @@ def test_phase1_filters_none_beats(tmp_path):
     ctx = _make_ctx(tmp_path)
     # LLM returns [None, "point1", "point2"] — None should be dropped
     import json
+
     bad_resp = _mock_llm_response(json.dumps({"beats": [None, "point1", "point2"]}))
     mock_cm = _mock_llm_cm(response=bad_resp)
     mock_llm = mock_cm.__enter__.return_value
@@ -537,6 +559,7 @@ def test_phase1_filters_string_none_beats(tmp_path):
     """The string "None" should also be filtered (case-insensitive)."""
     ctx = _make_ctx(tmp_path)
     import json
+
     bad_resp = _mock_llm_response(json.dumps({"beats": ["none", "point1", "point2"]}))
     mock_cm = _mock_llm_cm(response=bad_resp)
     mock_llm = mock_cm.__enter__.return_value
@@ -550,6 +573,7 @@ def test_phase1_accepts_integer_beats(tmp_path):
     """Integer beats should be converted to strings (not dropped)."""
     ctx = _make_ctx(tmp_path)
     import json
+
     resp = _mock_llm_response(json.dumps({"beats": [1, 2, 3]}))
     mock_cm = _mock_llm_cm(response=resp)
     mock_llm = mock_cm.__enter__.return_value
@@ -567,9 +591,7 @@ def test_phase2_filters_empty_text_segments(tmp_path):
     ctx = _make_ctx(tmp_path)
     beats = ["b1", "b2", "b3"]
     # Mix of valid, empty string, whitespace-only, and None text
-    seg_resp = _mock_llm_response(
-        _segments_json(["valid", "", "   "])
-    )
+    seg_resp = _mock_llm_response(_segments_json(["valid", "", "   "]))
     mock_cm = _mock_llm_cm(response=seg_resp)
     mock_llm = mock_cm.__enter__.return_value
 
@@ -627,8 +649,7 @@ def test_preset_sentence_count_enforced(preset_name, expected_count, tmp_path):
     preset = get_preset(preset_name)
     target = preset.param_dict.get("prompt_target_sentences")
     assert target == expected_count, (
-        f"{preset_name} preset has prompt_target_sentences={target}, "
-        f"expected {expected_count}"
+        f"{preset_name} preset has prompt_target_sentences={target}, expected {expected_count}"
     )
 
     # Build context with preset params applied
@@ -772,18 +793,18 @@ def test_script_target_count_in_metadata(tmp_path):
 _DYNAMIC_CASES = [
     # (preset_name, duration, expected_count)
     # 60s baseline — matches preset's prompt_target_sentences
-    ("douyin-fast", 60, 18),      # 60 / 3.3 = 18.2 → 18
-    ("mainstream-dry", 60, 12),   # 60 / 5.0 = 12.0 → 12
-    ("bilibili-long", 60, 8),     # 60 / 7.5 = 8.0 → 8
+    ("douyin-fast", 60, 18),  # 60 / 3.3 = 18.2 → 18
+    ("mainstream-dry", 60, 12),  # 60 / 5.0 = 12.0 → 12
+    ("bilibili-long", 60, 8),  # 60 / 7.5 = 8.0 → 8
     # 120s — double the sentences, same per-sentence length
-    ("douyin-fast", 120, 36),     # 120 / 3.3 = 36.4 → 36
+    ("douyin-fast", 120, 36),  # 120 / 3.3 = 36.4 → 36
     ("mainstream-dry", 120, 24),  # 120 / 5.0 = 24.0 → 24
-    ("bilibili-long", 120, 16),   # 120 / 7.5 = 16.0 → 16
+    ("bilibili-long", 120, 16),  # 120 / 7.5 = 16.0 → 16
     # 90s — 1.5x sentences
-    ("bilibili-long", 90, 12),    # 90 / 7.5 = 12.0 → 12
+    ("bilibili-long", 90, 12),  # 90 / 7.5 = 12.0 → 12
     # 30s — half sentences
-    ("douyin-fast", 30, 9),       # 30 / 3.3 = 9.1 → 9
-    ("bilibili-long", 30, 4),     # 30 / 7.5 = 4.0 → 4
+    ("douyin-fast", 30, 9),  # 30 / 3.3 = 9.1 → 9
+    ("bilibili-long", 30, 4),  # 30 / 7.5 = 4.0 → 4
 ]
 
 
@@ -843,8 +864,7 @@ def test_dynamic_count_60s_matches_preset_baseline(tmp_path):
         seg_dur = preset.param_dict.get("prompt_target_segment_duration")
         dynamic_count = round(60 / seg_dur)
         assert dynamic_count == base_count, (
-            f"{name}: 60s dynamic count {dynamic_count} != "
-            f"preset baseline {base_count}"
+            f"{name}: 60s dynamic count {dynamic_count} != preset baseline {base_count}"
         )
 
 
@@ -854,12 +874,14 @@ def test_dynamic_count_60s_matches_preset_baseline(tmp_path):
 def test_truncate_to_max_chars_no_truncation_needed():
     """Text within limit is unchanged."""
     from movie_narrator.pipeline.script import _truncate_to_max_chars
+
     assert _truncate_to_max_chars("短句", 10) == "短句"
 
 
 def test_truncate_to_max_chars_hard_cut():
     """Text exceeding limit with no punctuation is hard-cut."""
     from movie_narrator.pipeline.script import _truncate_to_max_chars
+
     result = _truncate_to_max_chars("abcdefghij", 5)
     assert result == "abcde"
 
@@ -867,6 +889,7 @@ def test_truncate_to_max_chars_hard_cut():
 def test_truncate_to_max_chars_cut_at_punctuation():
     """Text exceeding limit is cut at last punctuation before limit."""
     from movie_narrator.pipeline.script import _truncate_to_max_chars
+
     # "这是一句，很长的中文测试句子" with max_chars=8
     # Comma at position 4, within the first 8 chars
     text = "这是一句，很长的中文测试句子"
@@ -878,5 +901,6 @@ def test_truncate_to_max_chars_cut_at_punctuation():
 def test_truncate_to_max_chars_empty_after_truncation():
     """Edge case: punctuation-only text truncates to empty."""
     from movie_narrator.pipeline.script import _truncate_to_max_chars
+
     # Single punctuation char within limit
     assert _truncate_to_max_chars("，", 1) == "，"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,8 +40,10 @@ def test_ensure_user_config_creates_file(tmp_path):
     """ensure_user_config creates ~/.movie-narrator/.env when missing."""
     fake_home = tmp_path / "fakehome"
     fake_env = fake_home / ".movie-narrator" / ".env"
-    with patch("movie_narrator.config._USER_DIR", fake_home / ".movie-narrator"), \
-         patch("movie_narrator.config._USER_ENV", fake_env):
+    with (
+        patch("movie_narrator.config._USER_DIR", fake_home / ".movie-narrator"),
+        patch("movie_narrator.config._USER_ENV", fake_env),
+    ):
         result = ensure_user_config()
     assert result == fake_env
     assert fake_env.exists()
@@ -58,7 +60,9 @@ def test_ensure_user_config_no_overwrite(tmp_path):
     fake_env = fake_dir / ".env"
     original = "MN_LLM_MODEL=my-custom-model\n"
     fake_env.write_text(original, encoding="utf-8")
-    with patch("movie_narrator.config._USER_DIR", fake_dir), \
-         patch("movie_narrator.config._USER_ENV", fake_env):
+    with (
+        patch("movie_narrator.config._USER_DIR", fake_dir),
+        patch("movie_narrator.config._USER_ENV", fake_env),
+    ):
         ensure_user_config()
     assert fake_env.read_text(encoding="utf-8") == original

--- a/tests/test_step_retry.py
+++ b/tests/test_step_retry.py
@@ -24,7 +24,9 @@ def _make_ctx(tmp_path):
 def test_handle_step_error_no_controller(tmp_path):
     """No controller → ABORT (existing fail-fast behavior)."""
     ctx = _make_ctx(tmp_path)
-    action = _handle_step_error(None, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    action = _handle_step_error(
+        None, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console
+    )
     assert action is StepAction.ABORT
 
 
@@ -33,7 +35,9 @@ def test_handle_step_error_no_handler_method(tmp_path):
     ctx = _make_ctx(tmp_path)
     controller = MagicMock()
     del controller.on_step_error  # ensure attribute doesn't exist
-    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    action = _handle_step_error(
+        controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console
+    )
     assert action is StepAction.ABORT
 
 
@@ -42,9 +46,13 @@ def test_handle_step_error_retry(tmp_path):
     ctx = _make_ctx(tmp_path)
     controller = MagicMock()
     controller.on_step_error.return_value = StepAction.RETRY
-    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    action = _handle_step_error(
+        controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console
+    )
     assert action is StepAction.RETRY
-    controller.on_step_error.assert_called_once_with("generate_voice", controller.on_step_error.call_args[0][1], 1)
+    controller.on_step_error.assert_called_once_with(
+        "generate_voice", controller.on_step_error.call_args[0][1], 1
+    )
 
 
 def test_handle_step_error_skip(tmp_path):
@@ -52,7 +60,9 @@ def test_handle_step_error_skip(tmp_path):
     ctx = _make_ctx(tmp_path)
     controller = MagicMock()
     controller.on_step_error.return_value = StepAction.SKIP
-    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    action = _handle_step_error(
+        controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console
+    )
     assert action is StepAction.SKIP
 
 
@@ -61,7 +71,9 @@ def test_handle_step_error_abort(tmp_path):
     ctx = _make_ctx(tmp_path)
     controller = MagicMock()
     controller.on_step_error.return_value = StepAction.ABORT
-    action = _handle_step_error(controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console)
+    action = _handle_step_error(
+        controller, "generate_voice", RuntimeError("timeout"), 1, ctx.services.console
+    )
     assert action is StepAction.ABORT
 
 
@@ -111,6 +123,7 @@ def test_interactive_controller_abort_default(tmp_path, monkeypatch):
 
 def test_interactive_controller_eof_aborts(tmp_path, monkeypatch):
     """InteractiveCLIController aborts on EOFError (no stdin)."""
+
     def raise_eof(_):
         raise EOFError()
 

--- a/tests/test_text_image.py
+++ b/tests/test_text_image.py
@@ -48,10 +48,15 @@ def test_bottom_layout_has_semi_transparent_backdrop_bar():
     width) to avoid false failures while still proving the backdrop bar
     exists and spans a wide horizontal stretch.
     """
-    arr = create_text_image("long bottom subtitle text for backdrop", (1280, 720),
-                            fontsize=40, position="bottom",
-                            max_width_ratio=0.9, bottom_margin_ratio=0.06,
-                            max_lines=2)
+    arr = create_text_image(
+        "long bottom subtitle text for backdrop",
+        (1280, 720),
+        fontsize=40,
+        position="bottom",
+        max_width_ratio=0.9,
+        bottom_margin_ratio=0.06,
+        max_lines=2,
+    )
     alpha = arr[..., 3]
     rgb = arr[..., :3]
     # Stroke/text + backdrop all produce dark pixels behind/around text:
@@ -60,10 +65,10 @@ def test_bottom_layout_has_semi_transparent_backdrop_bar():
     # Backdrop bar lives in the bottom ~12% of the canvas.
     band_rows = np.where((dark_mask.sum(axis=1) > 200))[0]
     assert band_rows.size > 0
-    assert band_rows.max() > h * 0.78   # below 78% of canvas height
+    assert band_rows.max() > h * 0.78  # below 78% of canvas height
     # Backdrop spans a wide horizontal stretch (>= 50% of canvas width).
     # 50% (not 60%) because Linux font metrics render text narrower than Windows.
-    band_cols = np.where(dark_mask[band_rows.min():band_rows.max()+1].sum(axis=0) > 5)[0]
+    band_cols = np.where(dark_mask[band_rows.min() : band_rows.max() + 1].sum(axis=0) > 5)[0]
     assert band_cols.max() - band_cols.min() > w * 0.5
 
 
@@ -71,8 +76,9 @@ def test_bottom_layout_full_canvas_outside_textband_is_transparent():
     """Outside the bottom subtitle band, alpha must be 0 — so source
     footage shown above the subtitle remains untouched when ImageClip is
     composited via ``with_position((center, bottom))``."""
-    arr = create_text_image("subtitle", (1280, 720), fontsize=40, position="bottom",
-                            bottom_margin_ratio=0.06)
+    arr = create_text_image(
+        "subtitle", (1280, 720), fontsize=40, position="bottom", bottom_margin_ratio=0.06
+    )
     alpha = arr[..., 3]
     # Pick a row at the middle of the canvas — should be fully transparent.
     mid_row = 360
@@ -95,8 +101,12 @@ def test_bottom_wraps_long_text():
     """Long text is wrapped and capped at max_lines."""
     long_text = " ".join(["word"] * 50)
     arr = create_text_image(
-        long_text, (640, 360), fontsize=30, position="bottom",
-        max_width_ratio=0.9, max_lines=2,
+        long_text,
+        (640, 360),
+        fontsize=30,
+        position="bottom",
+        max_width_ratio=0.9,
+        max_lines=2,
     )
     assert arr.shape == (360, 640, 4)
 
@@ -105,7 +115,11 @@ def test_bottom_ellipsis_on_overflow():
     """When text exceeds max_lines, the last kept line is truncated with ellipsis."""
     long_text = "line one is very long\nline two is also long\nline three"
     arr = create_text_image(
-        long_text, (800, 400), fontsize=30, position="bottom", max_lines=1,
+        long_text,
+        (800, 400),
+        fontsize=30,
+        position="bottom",
+        max_lines=1,
     )
     assert arr.shape == (400, 800, 4)
 

--- a/tests/test_tmdb_provider.py
+++ b/tests/test_tmdb_provider.py
@@ -47,9 +47,7 @@ def _make_response(status: int, body: str, headers=None):
 def _make_http_error(code: int, headers=None):
     """Build an HTTPError instance for testing error paths."""
     hdrs = headers if headers is not None else http.client.HTTPMessage()
-    return urllib.error.HTTPError(
-        "http://test", code, "Error", hdrs, BytesIO(b"")
-    )
+    return urllib.error.HTTPError("http://test", code, "Error", hdrs, BytesIO(b""))
 
 
 class TestTmdbProviderRegistration:
@@ -297,14 +295,17 @@ class TestTmdbRetry:
 
     def test_retries_on_429_then_succeeds(self):
         ok_resp = _make_response(200, '{"results": []}')
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=[_make_http_error(429), ok_resp],
-        ) as mock_open, patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=[_make_http_error(429), ok_resp],
+            ) as mock_open,
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result == {"results": []}
@@ -315,14 +316,17 @@ class TestTmdbRetry:
 
     def test_gives_up_after_max_retries(self):
         err = _make_http_error(429)
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=[err, err, err, err],
-        ) as mock_open, patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=[err, err, err, err],
+            ) as mock_open,
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result is None
@@ -333,14 +337,17 @@ class TestTmdbRetry:
 
     def test_non_429_http_error_is_not_retried(self):
         err = _make_http_error(404)
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=err,
-        ) as mock_open, patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=err,
+            ) as mock_open,
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result is None
@@ -361,11 +368,15 @@ class TestTmdbCache:
             return_value=resp,
         ) as mock_open:
             result1 = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
             result2 = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result1 == {"ok": True}
@@ -380,11 +391,15 @@ class TestTmdbCache:
             return_value=resp,
         ) as mock_open:
             _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "a"},
             )
             _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "b"},
             )
         # Different query params produce different URLs — both hit network.
@@ -398,13 +413,17 @@ class TestTmdbCache:
         ):
             # Prime the cache with the first call.
             _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         # Second call: urlopen is not mocked, so any network access would
         # hit the real internet and fail. A cache hit avoids that entirely.
         result = _tmdb_get(
-            "https://api.themoviedb.org/3", "/search/movie", "key",
+            "https://api.themoviedb.org/3",
+            "/search/movie",
+            "key",
             {"query": "test", "api_key": "key"},
         )
         assert result == {"ok": True}
@@ -421,14 +440,17 @@ class TestTmdbRateLimitWithRetryAfter:
         headers.add_header("Retry-After", "5")
         err = _make_http_error(429, headers=headers)
         ok_resp = _make_response(200, '{"ok": true}')
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=[err, ok_resp],
-        ), patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=[err, ok_resp],
+            ),
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result == {"ok": True}
@@ -440,14 +462,17 @@ class TestTmdbRateLimitWithRetryAfter:
         headers.add_header("Retry-After", "3")
         err = _make_http_error(429, headers=headers)
         ok_resp = _make_response(200, '{"ok": true}')
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=[err, err, ok_resp],
-        ), patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=[err, err, ok_resp],
+            ),
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result == {"ok": True}
@@ -457,14 +482,17 @@ class TestTmdbRateLimitWithRetryAfter:
 
     def test_falls_back_to_backoff_without_retry_after(self):
         ok_resp = _make_response(200, '{"ok": true}')
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=[_make_http_error(429), ok_resp],
-        ), patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=[_make_http_error(429), ok_resp],
+            ),
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result == {"ok": True}
@@ -476,14 +504,17 @@ class TestTmdbRateLimitWithRetryAfter:
         headers.add_header("Retry-After", "0.5")
         err = _make_http_error(429, headers=headers)
         ok_resp = _make_response(200, '{"ok": true}')
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=[err, ok_resp],
-        ), patch(
-            "movie_narrator.providers.tmdb.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=[err, ok_resp],
+            ),
+            patch("movie_narrator.providers.tmdb.time.sleep") as mock_sleep,
+        ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result == {"ok": True}
@@ -504,7 +535,9 @@ class TestTmdbNetworkErrorHandling:
         ):
             try:
                 _tmdb_get(
-                    "https://api.themoviedb.org/3", "/search/movie", "key",
+                    "https://api.themoviedb.org/3",
+                    "/search/movie",
+                    "key",
                     {"query": "test"},
                 )
                 assert False, "Should have raised URLError"
@@ -538,12 +571,13 @@ class TestTmdbNetworkErrorHandling:
         settings.tmdb_base_url = "https://api.themoviedb.org/3"
         settings.tmdb_language = "zh-CN"
         err = urllib.error.URLError("connection refused")
-        with patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen",
-            side_effect=err,
-        ), patch(
-            "movie_narrator.providers.tmdb.logger"
-        ) as mock_logger:
+        with (
+            patch(
+                "movie_narrator.providers.tmdb.urllib.request.urlopen",
+                side_effect=err,
+            ),
+            patch("movie_narrator.providers.tmdb.logger") as mock_logger,
+        ):
             enrich_movie_card_with_tmdb(card, ctx, settings)
         # A network error during enrichment should be logged at warning.
         assert mock_logger.warning.called
@@ -580,9 +614,7 @@ class TestTmdbSearchEmptyResults:
             "movie_narrator.providers.tmdb.urllib.request.urlopen",
             return_value=resp,
         ):
-            result = _search_movie(
-                "https://api.themoviedb.org/3", "key", "Test", "zh-CN"
-            )
+            result = _search_movie("https://api.themoviedb.org/3", "key", "Test", "zh-CN")
         assert result is None
 
     def test_search_returns_none_for_missing_results_key(self):
@@ -591,9 +623,7 @@ class TestTmdbSearchEmptyResults:
             "movie_narrator.providers.tmdb.urllib.request.urlopen",
             return_value=resp,
         ):
-            result = _search_movie(
-                "https://api.themoviedb.org/3", "key", "Test", "zh-CN"
-            )
+            result = _search_movie("https://api.themoviedb.org/3", "key", "Test", "zh-CN")
         assert result is None
 
     def test_enrichment_returns_original_card_for_empty_results(self):
@@ -627,7 +657,9 @@ class TestTmdbMalformedResponse:
             return_value=resp,
         ):
             result = _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
         assert result is None
@@ -639,11 +671,15 @@ class TestTmdbMalformedResponse:
             return_value=resp,
         ) as mock_open:
             _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test"},
             )
             _tmdb_get(
-                "https://api.themoviedb.org/3", "/search/movie", "key",
+                "https://api.themoviedb.org/3",
+                "/search/movie",
+                "key",
                 {"query": "test", "api_key": "key"},
             )
         # Malformed JSON should not be cached, so both calls hit network.

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -16,10 +16,18 @@ from unittest.mock import patch
 import pytest
 
 from movie_narrator.models import (
-    Context, StepResult, SubtitlePaths, TimedSegment,
+    Context,
+    StepResult,
+    SubtitlePaths,
+    TimedSegment,
 )
 from movie_narrator.pipeline.translate import (
-    SUPPORTED_PROVIDERS, _call_llm_chunk, _chunk_texts, _is_blank, _translate_via_llm, translate_subtitles,
+    SUPPORTED_PROVIDERS,
+    _call_llm_chunk,
+    _chunk_texts,
+    _is_blank,
+    _translate_via_llm,
+    translate_subtitles,
 )
 from movie_narrator.pipeline.subtitle import generate_subtitle
 from movie_narrator.workflow.errors import JobConfigError
@@ -98,8 +106,10 @@ def test_translate_provider_records_metadata(tmp_path, monkeypatch):
     )
     # Patch the LLM call to raise so we exercise the failure path.
     from movie_narrator.pipeline import translate as t_mod
+
     monkeypatch.setattr(
-        t_mod, "_call_llm_chunk",
+        t_mod,
+        "_call_llm_chunk",
         lambda **kw: (_ for _ in ()).throw(RuntimeError("net down")),
     )
     translate_subtitles(ctx)
@@ -252,6 +262,7 @@ def test_subtitle_render_subtitle_path_resolves_per_mode(tmp_path):
     # re-run to re-resolve (subtitle_paths already populated; resolve helper
     # is pure, so calling again mutates only render_subtitle_path)
     from movie_narrator.pipeline.subtitle import _resolve_render_subtitle_path
+
     ctx.render_subtitle_path = _resolve_render_subtitle_path(ctx, ctx.subtitle_paths)
     assert ctx.render_subtitle_path == ctx.subtitle_paths.translated
 
@@ -298,6 +309,7 @@ def test_subtitle_skips_misaligned_translations(tmp_path):
 def _empty_settings():
     """Minimal Settings stand-in (we only test merge_job's surface area)."""
     from movie_narrator.config import Settings
+
     return Settings()
 
 

--- a/tests/test_tts_cache.py
+++ b/tests/test_tts_cache.py
@@ -19,12 +19,22 @@ def test_provider_version_change_produces_different_key():
     """
     root = Path("/tmp/cache_test")
     k1 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="edge",
-        provider_version=1, model="", voice="v", text="t", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="edge",
+        provider_version=1,
+        model="",
+        voice="v",
+        text="t",
+        style_prompt="",
     )
     k2 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="edge",
-        provider_version=2, model="", voice="v", text="t", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="edge",
+        provider_version=2,
+        model="",
+        voice="v",
+        text="t",
+        style_prompt="",
     )
     assert cache_path_for(root, k1) != cache_path_for(root, k2)
 
@@ -33,12 +43,22 @@ def test_text_change_produces_different_key():
     """Different text must produce a different cache path."""
     root = Path("/tmp/cache_test")
     k1 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="edge",
-        provider_version=1, model="", voice="v", text="hello", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="edge",
+        provider_version=1,
+        model="",
+        voice="v",
+        text="hello",
+        style_prompt="",
     )
     k2 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="edge",
-        provider_version=1, model="", voice="v", text="world", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="edge",
+        provider_version=1,
+        model="",
+        voice="v",
+        text="world",
+        style_prompt="",
     )
     assert cache_path_for(root, k1) != cache_path_for(root, k2)
 
@@ -47,12 +67,22 @@ def test_provider_change_produces_different_key():
     """Switching providers must produce a different cache path."""
     root = Path("/tmp/cache_test")
     k1 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="edge",
-        provider_version=1, model="", voice="v", text="t", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="edge",
+        provider_version=1,
+        model="",
+        voice="v",
+        text="t",
+        style_prompt="",
     )
     k2 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="openai",
-        provider_version=1, model="tts-1", voice="v", text="t", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="openai",
+        provider_version=1,
+        model="tts-1",
+        voice="v",
+        text="t",
+        style_prompt="",
     )
     assert cache_path_for(root, k1) != cache_path_for(root, k2)
 
@@ -61,12 +91,22 @@ def test_style_prompt_change_produces_different_key():
     """ST-08: Different style_prompt must produce a different cache path."""
     root = Path("/tmp/cache_test")
     k1 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="mimo",
-        provider_version=1, model="mimo-tts", voice="v", text="t", style_prompt="",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="mimo",
+        provider_version=1,
+        model="mimo-tts",
+        voice="v",
+        text="t",
+        style_prompt="",
     )
     k2 = TTSCacheKey(
-        schema_version=CACHE_SCHEMA_VERSION, provider="mimo",
-        provider_version=1, model="mimo-tts", voice="v", text="t", style_prompt="excited",
+        schema_version=CACHE_SCHEMA_VERSION,
+        provider="mimo",
+        provider_version=1,
+        model="mimo-tts",
+        voice="v",
+        text="t",
+        style_prompt="excited",
     )
     assert cache_path_for(root, k1) != cache_path_for(root, k2)
 

--- a/tests/test_tts_cache_flag_order.py
+++ b/tests/test_tts_cache_flag_order.py
@@ -53,15 +53,11 @@ def test_cache_flags_stay_aligned_under_out_of_order_completion():
         await asyncio.sleep(delay)
         return _silent(), 0.3, False
 
-    results, cached_flags = asyncio.run(
-        _gather_aligned(segments, lambda s: _one(s))
-    )
+    results, cached_flags = asyncio.run(_gather_aligned(segments, lambda s: _one(s)))
 
     # Input order preserved in both results and flags.
     assert [r[0] for r in results]  # audios present, ordered by input
-    assert cached_flags == [False, True, False], (
-        f"flags misaligned with segments: {cached_flags}"
-    )
+    assert cached_flags == [False, True, False], f"flags misaligned with segments: {cached_flags}"
     # Sum must equal the true cache-hit count (1).
     assert sum(cached_flags) == 1
 
@@ -69,6 +65,7 @@ def test_cache_flags_stay_aligned_under_out_of_order_completion():
 def test_all_cache_hits_and_all_misses_still_correct():
     """Homogeneous cache states were correct even before the fix; they
     must stay correct (flags are now derived from gather results)."""
+
     async def _run(states: list[bool]):
         async def _one(hit: bool):
             if hit:
@@ -99,8 +96,6 @@ def test_mixed_flags_sum_matches_true_hit_count():
         await asyncio.sleep(0.05 * ((idx % 3) + 1))  # stagger misses
         return _silent(), 0.3, False
 
-    _, flags = asyncio.run(
-        _gather_aligned(states, lambda h, i=0: _one(h, i))
-    )
+    _, flags = asyncio.run(_gather_aligned(states, lambda h, i=0: _one(h, i)))
     assert flags == expected
     assert sum(flags) == sum(expected) == 2

--- a/tests/test_tts_providers.py
+++ b/tests/test_tts_providers.py
@@ -41,6 +41,7 @@ from movie_narrator.utils.errors import ConfigError
 _FFMPEG_OK = shutil.which("ffmpeg") is not None
 try:
     from pydub import AudioSegment as _test_seg
+
     _tmp = Path(os.environ.get("TEMP", "/tmp")) / "_ffmpeg_probe.mp3"
     _test_seg.silent(duration=10).export(_tmp, format="mp3")
     _test_seg.from_mp3(_tmp)
@@ -49,9 +50,7 @@ try:
 except Exception:
     _MP3_OK = False
 
-requires_mp3 = pytest.mark.skipif(
-    not _MP3_OK, reason="ffmpeg lacks mp3/wav codec support"
-)
+requires_mp3 = pytest.mark.skipif(not _MP3_OK, reason="ffmpeg lacks mp3/wav codec support")
 
 
 # ─── TTSCacheKey & cache_path_for ───
@@ -245,6 +244,7 @@ class TestEdgeTTSProvider:
 class TestOpenAITTSProvider:
     def _make_settings(self, **overrides):
         from movie_narrator.config import Settings, TTSProviderType
+
         defaults = dict(
             tts_provider=TTSProviderType.OPENAI,
             openai_tts_model="tts-1",
@@ -258,6 +258,7 @@ class TestOpenAITTSProvider:
 
     def test_constructor_uses_explicit_api_key(self):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         settings = self._make_settings(openai_tts_api_key="sk-explicit")
         with patch("openai.OpenAI") as mock_openai:
             provider = OpenAITTSProvider(settings)
@@ -267,6 +268,7 @@ class TestOpenAITTSProvider:
 
     def test_constructor_falls_back_to_llm_api_key(self):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         settings = self._make_settings(openai_tts_api_key=None, llm_api_key="llm-fallback")
         with patch("openai.OpenAI") as mock_openai:
             provider = OpenAITTSProvider(settings)
@@ -275,6 +277,7 @@ class TestOpenAITTSProvider:
 
     def test_constructor_falls_back_to_llm_base_url(self):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         settings = self._make_settings(
             openai_tts_base_url=None,
             llm_base_url="http://my-llm:8080/v1",
@@ -286,6 +289,7 @@ class TestOpenAITTSProvider:
 
     def test_constructor_raises_on_missing_key(self):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         settings = self._make_settings(openai_tts_api_key=None, llm_api_key="")
         with patch("openai.OpenAI"):
             with pytest.raises(ConfigError, match="requires.*API_KEY"):
@@ -293,6 +297,7 @@ class TestOpenAITTSProvider:
 
     def test_real_synthesize_validates_voice(self, tmp_path):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         settings = self._make_settings()
         with patch("openai.OpenAI"):
             provider = OpenAITTSProvider(settings)
@@ -302,6 +307,7 @@ class TestOpenAITTSProvider:
 
     def test_real_synthesize_accepts_valid_voice(self, tmp_path):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         settings = self._make_settings()
         with patch("openai.OpenAI"):
             provider = OpenAITTSProvider(settings)
@@ -314,6 +320,7 @@ class TestOpenAITTSProvider:
 
     def test_all_whitelist_voices_accepted(self, tmp_path):
         from movie_narrator.tts.openai_provider import OpenAITTSProvider, OPENAI_TTS_VOICES
+
         settings = self._make_settings()
         with patch("openai.OpenAI"):
             provider = OpenAITTSProvider(settings)
@@ -330,6 +337,7 @@ class TestOpenAITTSProvider:
 class TestMimoTTSProvider:
     def _make_settings(self, **overrides):
         from movie_narrator.config import Settings, TTSProviderType
+
         defaults = dict(
             tts_provider=TTSProviderType.MIMO,
             mimo_tts_model="mimo-v2.5-tts",
@@ -352,6 +360,7 @@ class TestMimoTTSProvider:
         if audio_data is None:
             from io import BytesIO
             from pydub import AudioSegment as _seg
+
             seg = _seg.silent(duration=100, frame_rate=8000)
             buf = BytesIO()
             seg.export(buf, format="wav")
@@ -364,6 +373,7 @@ class TestMimoTTSProvider:
 
     def test_constructor_uses_explicit_api_key(self):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         settings = self._make_settings(mimo_api_key="mimo-explicit")
         with patch("openai.OpenAI") as mock_openai:
             MimoTTSProvider(settings)
@@ -372,6 +382,7 @@ class TestMimoTTSProvider:
 
     def test_constructor_falls_back_to_llm_api_key(self):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         settings = self._make_settings(mimo_api_key=None, llm_api_key="llm-fallback")
         with patch("openai.OpenAI") as mock_openai:
             MimoTTSProvider(settings)
@@ -380,6 +391,7 @@ class TestMimoTTSProvider:
 
     def test_constructor_raises_on_missing_key(self):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         settings = self._make_settings(mimo_api_key=None, llm_api_key="")
         with patch("openai.OpenAI"):
             with pytest.raises(ConfigError, match="requires.*API_KEY"):
@@ -387,6 +399,7 @@ class TestMimoTTSProvider:
 
     def test_constructor_uses_custom_base_url(self):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         settings = self._make_settings(mimo_base_url="https://custom.mimo.api/v1")
         with patch("openai.OpenAI") as mock_openai:
             MimoTTSProvider(settings)
@@ -396,6 +409,7 @@ class TestMimoTTSProvider:
     @requires_mp3
     def test_named_voice_mode_calls_api_correctly(self, tmp_path):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider, MIMO_TTS
+
         settings = self._make_settings(
             mimo_tts_model=MIMO_TTS,
             mimo_style_prompt="Bright and bouncy tone.",
@@ -409,7 +423,7 @@ class TestMimoTTSProvider:
 
         assert provider._call_api.call_count == 1
         args = provider._call_api.call_args.args
-        assert args[0] == "Hello world"       # text
+        assert args[0] == "Hello world"  # text
         assert args[1] == "Bright and bouncy tone."  # user_content (style prompt)
         audio_param = args[2]
         assert audio_param["voice"] == "Chloe"
@@ -419,6 +433,7 @@ class TestMimoTTSProvider:
     @requires_mp3
     def test_voiceclone_mode_encodes_audio_file(self, tmp_path):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider, MIMO_VOICECLONE
+
         # Create a fake voice file
         voice_file = tmp_path / "voice.wav"
         voice_file.write_bytes(b"fake wav header + data")
@@ -441,16 +456,20 @@ class TestMimoTTSProvider:
 
     def test_voiceclone_raises_on_missing_file(self, tmp_path):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider, MIMO_VOICECLONE
+
         settings = self._make_settings(mimo_tts_model=MIMO_VOICECLONE)
         with patch("openai.OpenAI"):
             provider = MimoTTSProvider(settings)
 
         with pytest.raises(ConfigError, match="Voice clone file not found"):
-            asyncio.run(provider._real_synthesize("text", "/nonexistent/voice.wav", tmp_path / "out.mp3"))
+            asyncio.run(
+                provider._real_synthesize("text", "/nonexistent/voice.wav", tmp_path / "out.mp3")
+            )
 
     @requires_mp3
     def test_voicedesign_mode_uses_voice_as_description(self, tmp_path):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider, MIMO_VOICEDESIGN
+
         settings = self._make_settings(mimo_tts_model=MIMO_VOICEDESIGN)
         with patch("openai.OpenAI"):
             provider = MimoTTSProvider(settings)
@@ -468,6 +487,7 @@ class TestMimoTTSProvider:
 
     def test_unsupported_model_raises_config_error(self, tmp_path):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         settings = self._make_settings(mimo_tts_model="mimo-unsupported-model")
         with patch("openai.OpenAI"):
             provider = MimoTTSProvider(settings)
@@ -477,6 +497,7 @@ class TestMimoTTSProvider:
 
     def test_voice_b64_cache_avoids_reread(self, tmp_path):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider, MIMO_VOICECLONE
+
         voice_file = tmp_path / "voice.wav"
         voice_file.write_bytes(b"cache test data")
 
@@ -493,6 +514,7 @@ class TestMimoTTSProvider:
 
     def test_is_protocol_subclass(self):
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         assert issubclass(MimoTTSProvider, TTSProvider)
 
 
@@ -502,12 +524,14 @@ class TestMimoTTSProvider:
 class TestFactory:
     def test_returns_edge_provider(self):
         from movie_narrator.config import Settings, TTSProviderType
+
         settings = Settings(tts_provider=TTSProviderType.EDGE)
         provider = get_tts_provider(settings)
         assert isinstance(provider, EdgeTTSProvider)
 
     def test_returns_openai_provider(self):
         from movie_narrator.config import Settings, TTSProviderType
+
         settings = Settings(
             tts_provider=TTSProviderType.OPENAI,
             openai_tts_api_key="sk-test",
@@ -515,10 +539,12 @@ class TestFactory:
         with patch("openai.OpenAI"):
             provider = get_tts_provider(settings)
         from movie_narrator.tts.openai_provider import OpenAITTSProvider
+
         assert isinstance(provider, OpenAITTSProvider)
 
     def test_no_singleton_each_call_new_instance(self):
         from movie_narrator.config import Settings, TTSProviderType
+
         settings = Settings(tts_provider=TTSProviderType.EDGE)
         p1 = get_tts_provider(settings)
         p2 = get_tts_provider(settings)
@@ -526,6 +552,7 @@ class TestFactory:
 
     def test_returns_mimo_provider(self):
         from movie_narrator.config import Settings, TTSProviderType
+
         settings = Settings(
             tts_provider=TTSProviderType.MIMO,
             mimo_api_key="mimo-test",
@@ -533,6 +560,7 @@ class TestFactory:
         with patch("openai.OpenAI"):
             provider = get_tts_provider(settings)
         from movie_narrator.tts.mimo_provider import MimoTTSProvider
+
         assert isinstance(provider, MimoTTSProvider)
 
 
@@ -543,6 +571,7 @@ class TestFactory:
 class TestGenerateVoiceCI:
     def _make_ctx(self, tmp_path):
         from movie_narrator.models import Context, ScriptSegment
+
         ctx = Context(movie_name="Test", output_dir=str(tmp_path))
         ctx.segments = [
             ScriptSegment(text="Hello world this is a test", index=0),
@@ -633,6 +662,7 @@ class TestGenerateVoiceCI:
 class TestGenerateVoiceCache:
     def _make_ctx(self, tmp_path):
         from movie_narrator.models import Context, ScriptSegment
+
         ctx = Context(movie_name="Test", output_dir=str(tmp_path))
         ctx.segments = [ScriptSegment(text="Cached segment", index=0)]
         return ctx
@@ -652,8 +682,10 @@ class TestGenerateVoiceCache:
         # First call to populate cache
         with patch("edge_tts.Communicate") as mock_comm:
             mock_comm.return_value.save = AsyncMock(
-                side_effect=lambda path: Path(path).parent.mkdir(parents=True, exist_ok=True)
-                or _write_silent_mp3(Path(path))
+                side_effect=lambda path: (
+                    Path(path).parent.mkdir(parents=True, exist_ok=True)
+                    or _write_silent_mp3(Path(path))
+                )
             )
             generate_voice(ctx)
 
@@ -672,12 +704,22 @@ class TestGenerateVoiceCache:
         from movie_narrator.tts.cache import TTSCacheKey, cache_path_for
 
         k_edge = TTSCacheKey(
-            schema_version=3, provider="edge", provider_version=1,
-            model="", voice="v", text="t", style_prompt="",
+            schema_version=3,
+            provider="edge",
+            provider_version=1,
+            model="",
+            voice="v",
+            text="t",
+            style_prompt="",
         )
         k_openai = TTSCacheKey(
-            schema_version=3, provider="openai", provider_version=1,
-            model="tts-1", voice="v", text="t", style_prompt="",
+            schema_version=3,
+            provider="openai",
+            provider_version=1,
+            model="tts-1",
+            voice="v",
+            text="t",
+            style_prompt="",
         )
         assert cache_path_for(tmp_path, k_edge) != cache_path_for(tmp_path, k_openai)
 
@@ -688,22 +730,26 @@ class TestGenerateVoiceCache:
 class TestSettingsTTS:
     def test_default_tts_provider_is_edge(self):
         from movie_narrator.config import Settings, TTSProviderType
+
         # Use _env_file=None to prevent .env from overriding defaults
         s = Settings(_env_file=None)
         assert s.tts_provider is TTSProviderType.EDGE
 
     def test_openai_tts_model_default(self):
         from movie_narrator.config import Settings
+
         s = Settings()
         assert s.openai_tts_model == "tts-1"
 
     def test_openai_tts_api_key_default_none(self):
         from movie_narrator.config import Settings
+
         s = Settings()
         assert s.openai_tts_api_key is None
 
     def test_env_prefix_tts_provider(self, monkeypatch):
         from movie_narrator.config import Settings, TTSProviderType
+
         # Clear lru_cache to pick up new env
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "openai")
@@ -714,6 +760,7 @@ class TestSettingsTTS:
     def test_invalid_tts_provider_raises(self, monkeypatch):
         from pydantic import ValidationError
         from movie_narrator.config import Settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "invalid-provider")
         with pytest.raises(ValidationError):
@@ -722,6 +769,7 @@ class TestSettingsTTS:
 
     def test_mimo_defaults(self):
         from movie_narrator.config import Settings
+
         # Use _env_file=None to prevent .env from overriding defaults
         s = Settings(_env_file=None)
         assert s.mimo_tts_model == "mimo-v2.5-tts"
@@ -731,6 +779,7 @@ class TestSettingsTTS:
 
     def test_env_prefix_mimo_provider(self, monkeypatch):
         from movie_narrator.config import Settings, TTSProviderType
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "mimo")
         s = Settings()
@@ -779,5 +828,6 @@ class TestMetadataExportTTS:
 def _write_silent_mp3(path: Path):
     """Write a minimal silent mp3 file for test mocks."""
     from pydub import AudioSegment
+
     path.parent.mkdir(parents=True, exist_ok=True)
     AudioSegment.silent(duration=1000).export(path, format="mp3")

--- a/tests/test_v0510_subtitle.py
+++ b/tests/test_v0510_subtitle.py
@@ -59,11 +59,13 @@ def _make_segments(
     segs = []
     t = 0.0
     for i in range(n):
-        segs.append(TimedSegment(
-            text=f"{prefix}{i}",
-            start=t,
-            end=t + duration,
-        ))
+        segs.append(
+            TimedSegment(
+                text=f"{prefix}{i}",
+                start=t,
+                end=t + duration,
+            )
+        )
         t += duration
     return segs
 
@@ -338,7 +340,7 @@ def test_aggregate_normal():
 
 
 def test_extract_terms_quoted_cjk():
-    text = '电影「流浪地球」非常好看'
+    text = "电影「流浪地球」非常好看"
     terms = extract_terms(text)
     assert "流浪地球" in terms
 
@@ -559,6 +561,7 @@ def test_subtitle_qa_overlaps_detected(tmp_path):
 
 def test_balance_lines_cjk():
     from movie_narrator.utils.text_image import _balance_lines
+
     lines = ["中中中中中中中中中中中", "短"]
     balanced = _balance_lines(lines, 2)
     assert len(balanced) == 2
@@ -568,6 +571,7 @@ def test_balance_lines_cjk():
 
 def test_balance_lines_latin_skipped():
     from movie_narrator.utils.text_image import _balance_lines
+
     lines = ["very long latin text here", "short"]
     balanced = _balance_lines(lines, 2)
     # Latin text should not be rebalanced
@@ -576,16 +580,19 @@ def test_balance_lines_latin_skipped():
 
 def test_balance_lines_single():
     from movie_narrator.utils.text_image import _balance_lines
+
     assert _balance_lines(["only one"], 2) == ["only one"]
 
 
 def test_balance_lines_empty():
     from movie_narrator.utils.text_image import _balance_lines
+
     assert _balance_lines([], 2) == []
 
 
 def test_balance_lines_exceeds_max():
     from movie_narrator.utils.text_image import _balance_lines
+
     # 5 lines but max_lines=2 → don't balance
     lines = ["a", "b", "c", "d", "e"]
     result = _balance_lines(lines, 2)

--- a/tests/test_v0511_match_align.py
+++ b/tests/test_v0511_match_align.py
@@ -54,12 +54,14 @@ def _make_word_segments(n: int = 5, start: float = 0.0, gap: float = 0.5) -> lis
     words = []
     t = start
     for i in range(n):
-        words.append({
-            "word": f"word{i}",
-            "start": t,
-            "end": t + gap * 0.8,
-            "score": 0.8 + 0.03 * i,  # varying scores 0.80–0.92
-        })
+        words.append(
+            {
+                "word": f"word{i}",
+                "start": t,
+                "end": t + gap * 0.8,
+                "score": 0.8 + 0.03 * i,  # varying scores 0.80–0.92
+            }
+        )
         t += gap
     return words
 
@@ -80,17 +82,19 @@ def _make_matched_clips(
 
     clips = []
     for i in range(n):
-        clips.append(MatchedClip(
-            segment_index=i,
-            text=f"segment {i}",
-            narr_start=float(i * 2.0),
-            narr_end=float(i * 2.0 + 1.5),
-            src_start=float(i * 3.0),
-            src_end=float(i * 3.0 + 2.5),
-            score=scores[i],
-            scene_index=scene_indices[i],
-            source=sources[i],
-        ))
+        clips.append(
+            MatchedClip(
+                segment_index=i,
+                text=f"segment {i}",
+                narr_start=float(i * 2.0),
+                narr_end=float(i * 2.0 + 1.5),
+                src_start=float(i * 3.0),
+                src_end=float(i * 3.0 + 2.5),
+                score=scores[i],
+                scene_index=scene_indices[i],
+                source=sources[i],
+            )
+        )
     return clips
 
 
@@ -573,8 +577,13 @@ def test_timed_segment_with_words():
 
 def test_matched_clip_default_fields():
     mc = MatchedClip(
-        segment_index=0, text="test", narr_start=0.0, narr_end=1.0,
-        src_start=0.0, src_end=1.0, score=0.8,
+        segment_index=0,
+        text="test",
+        narr_start=0.0,
+        narr_end=1.0,
+        src_start=0.0,
+        src_end=1.0,
+        score=0.8,
     )
     assert mc.embedding_score is None
     assert mc.rhythm_score is None
@@ -584,9 +593,15 @@ def test_matched_clip_default_fields():
 
 def test_matched_clip_model_dump_includes_new_fields():
     mc = MatchedClip(
-        segment_index=0, text="test", narr_start=0.0, narr_end=1.0,
-        src_start=0.0, src_end=1.0, score=0.8,
-        embedding_score=0.7, composite_score=0.65,
+        segment_index=0,
+        text="test",
+        narr_start=0.0,
+        narr_end=1.0,
+        src_start=0.0,
+        src_end=1.0,
+        score=0.8,
+        embedding_score=0.7,
+        composite_score=0.65,
     )
     d = mc.model_dump()
     assert "embedding_score" in d

--- a/tests/test_v0512_holistic_qa.py
+++ b/tests/test_v0512_holistic_qa.py
@@ -339,14 +339,16 @@ class TestProbeVideoEncoding:
         video_file.write_bytes(b"\x00" * 10)
 
         mock_data = {
-            "streams": [{
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1920,
-                "height": 1080,
-                "r_frame_rate": "30000/1001",
-                "pix_fmt": "yuv420p",
-            }],
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "r_frame_rate": "30000/1001",
+                    "pix_fmt": "yuv420p",
+                }
+            ],
             "format": {},
         }
 
@@ -361,14 +363,16 @@ class TestProbeVideoEncoding:
         video_file.write_bytes(b"\x00" * 10)
 
         mock_data = {
-            "streams": [{
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1920,
-                "height": 1080,
-                "r_frame_rate": "30/1",
-                "pix_fmt": "yuv420p",
-            }],
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "r_frame_rate": "30/1",
+                    "pix_fmt": "yuv420p",
+                }
+            ],
             "format": {"bit_rate": "4000000"},
         }
 
@@ -394,14 +398,16 @@ class TestProbeVideoEncoding:
         video_file.write_bytes(b"\x00" * 10)
 
         mock_data = {
-            "streams": [{
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1920,
-                "height": 1080,
-                "r_frame_rate": "invalid",
-                "pix_fmt": "yuv420p",
-            }],
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "r_frame_rate": "invalid",
+                    "pix_fmt": "yuv420p",
+                }
+            ],
             "format": {},
         }
 
@@ -416,14 +422,16 @@ class TestProbeVideoEncoding:
         video_file.write_bytes(b"\x00" * 10)
 
         mock_data = {
-            "streams": [{
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1920,
-                "height": 1080,
-                "r_frame_rate": "30/0",
-                "pix_fmt": "yuv420p",
-            }],
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "r_frame_rate": "30/0",
+                    "pix_fmt": "yuv420p",
+                }
+            ],
             "format": {},
         }
 
@@ -446,20 +454,23 @@ class TestEvaluateVideoQuality:
         video_file.write_bytes(b"\x00" * 10)
 
         mock_data = {
-            "streams": [{
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1920,
-                "height": 1080,
-                "r_frame_rate": "30/1",
-                "pix_fmt": "yuv420p",
-                "bit_rate": "5000000",
-            }, {
-                "codec_type": "audio",
-                "codec_name": "aac",
-                "channels": 2,
-                "sample_rate": "48000",
-            }],
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "r_frame_rate": "30/1",
+                    "pix_fmt": "yuv420p",
+                    "bit_rate": "5000000",
+                },
+                {
+                    "codec_type": "audio",
+                    "codec_name": "aac",
+                    "channels": 2,
+                    "sample_rate": "48000",
+                },
+            ],
             "format": {},
         }
 
@@ -474,15 +485,17 @@ class TestEvaluateVideoQuality:
         video_file.write_bytes(b"\x00" * 10)
 
         mock_data = {
-            "streams": [{
-                "codec_type": "video",
-                "codec_name": "h264",
-                "width": 1280,
-                "height": 720,
-                "r_frame_rate": "30/1",
-                "pix_fmt": "yuv420p",
-                "bit_rate": "1500000",
-            }],
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1280,
+                    "height": 720,
+                    "r_frame_rate": "30/1",
+                    "pix_fmt": "yuv420p",
+                    "bit_rate": "1500000",
+                }
+            ],
             "format": {},
         }
 
@@ -603,7 +616,9 @@ class TestDimensionExtractors:
     def test_extract_script_score_many_issues(self):
         meta = {"script_qa": {"total_issues": 15}}
         score, _, _ = _extract_script_score(meta)
-        assert score == 0.0  # max(0, 1.0 - 15*0.1) = 0.0... wait: 1.0 - 1.5 = -0.5, max(0, -0.5) = 0.0
+        assert (
+            score == 0.0
+        )  # max(0, 1.0 - 15*0.1) = 0.0... wait: 1.0 - 1.5 = -0.5, max(0, -0.5) = 0.0
 
     def test_extract_audio_score(self):
         meta = {
@@ -701,7 +716,13 @@ class TestDimensionExtractors:
         assert score == 0.6  # 1.0 - 2 * 0.2
 
     def test_extract_video_encoding_score_ok(self):
-        meta = {"video_qa": {"ok": True, "issues": [], "metrics": {"codec": "h264", "width": 1920, "height": 1080}}}
+        meta = {
+            "video_qa": {
+                "ok": True,
+                "issues": [],
+                "metrics": {"codec": "h264", "width": 1920, "height": 1080},
+            }
+        }
         result = _extract_video_encoding_score(meta)
         assert result is not None
         score, _, details = result
@@ -1183,64 +1204,84 @@ class TestRunQaGate:
         assert ctx.step_state.result == StepResult.WARNING
 
     def test_audio_qa_clipping(self, tmp_path):
-        ctx = _make_ctx(tmp_path, audio_quality={
-            "segments": [
-                {"clipping_ratio": 0.005},  # ok
-                {"clipping_ratio": 0.02},   # critical
-            ],
-        })
+        ctx = _make_ctx(
+            tmp_path,
+            audio_quality={
+                "segments": [
+                    {"clipping_ratio": 0.005},  # ok
+                    {"clipping_ratio": 0.02},  # critical
+                ],
+            },
+        )
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
         assert ctx.metadata["qa_gate"]["passed"] is False
         assert any("Audio QA" in i for i in ctx.metadata["qa_gate"]["issues"])
 
     def test_audio_qa_ok(self, tmp_path):
-        ctx = _make_ctx(tmp_path, audio_quality={
-            "segments": [{"clipping_ratio": 0.001}],
-        })
+        ctx = _make_ctx(
+            tmp_path,
+            audio_quality={
+                "segments": [{"clipping_ratio": 0.001}],
+            },
+        )
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
         assert ctx.metadata["qa_gate"]["passed"] is True
 
     def test_subtitle_qa_too_many_issues(self, tmp_path):
-        ctx = _make_ctx(tmp_path, subtitle_qa={
-            "original": {"total_cues": 10, "issues_count": 6},  # 60% > 50%
-        })
+        ctx = _make_ctx(
+            tmp_path,
+            subtitle_qa={
+                "original": {"total_cues": 10, "issues_count": 6},  # 60% > 50%
+            },
+        )
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
         assert ctx.metadata["qa_gate"]["passed"] is False
         assert any("Subtitle QA" in i for i in ctx.metadata["qa_gate"]["issues"])
 
     def test_subtitle_qa_ok(self, tmp_path):
-        ctx = _make_ctx(tmp_path, subtitle_qa={
-            "original": {"total_cues": 10, "issues_count": 3},  # 30% < 50%
-        })
+        ctx = _make_ctx(
+            tmp_path,
+            subtitle_qa={
+                "original": {"total_cues": 10, "issues_count": 3},  # 30% < 50%
+            },
+        )
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
         assert ctx.metadata["qa_gate"]["passed"] is True
 
     def test_alignment_qa_low_confidence(self, tmp_path):
-        ctx = _make_ctx(tmp_path, alignment_qa={
-            "total_segments": 10,
-            "low_confidence_count": 6,  # 60% > 50%
-        })
+        ctx = _make_ctx(
+            tmp_path,
+            alignment_qa={
+                "total_segments": 10,
+                "low_confidence_count": 6,  # 60% > 50%
+            },
+        )
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
         assert ctx.metadata["qa_gate"]["passed"] is False
         assert any("Alignment QA" in i for i in ctx.metadata["qa_gate"]["issues"])
 
     def test_alignment_qa_ok(self, tmp_path):
-        ctx = _make_ctx(tmp_path, alignment_qa={
-            "total_segments": 10,
-            "low_confidence_count": 3,  # 30% < 50%
-        })
+        ctx = _make_ctx(
+            tmp_path,
+            alignment_qa={
+                "total_segments": 10,
+                "low_confidence_count": 3,  # 30% < 50%
+            },
+        )
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
         assert ctx.metadata["qa_gate"]["passed"] is True
 
     def test_translation_too_many_untranslated(self, tmp_path):
         ctx = _make_ctx(tmp_path)
-        ctx.timed_segments = [TimedSegment(text=f"seg{i}", start=float(i), end=float(i + 1)) for i in range(10)]
+        ctx.timed_segments = [
+            TimedSegment(text=f"seg{i}", start=float(i), end=float(i + 1)) for i in range(10)
+        ]
         ctx.metadata["untranslated_indices"] = [1, 2, 3, 4]  # 40% > 30%
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)
@@ -1249,7 +1290,9 @@ class TestRunQaGate:
 
     def test_translation_ok(self, tmp_path):
         ctx = _make_ctx(tmp_path)
-        ctx.timed_segments = [TimedSegment(text=f"seg{i}", start=float(i), end=float(i + 1)) for i in range(10)]
+        ctx.timed_segments = [
+            TimedSegment(text=f"seg{i}", start=float(i), end=float(i + 1)) for i in range(10)
+        ]
         ctx.metadata["untranslated_indices"] = [1, 2]  # 20% < 30%
         with patch("movie_narrator.pipeline.qa_gate.is_ci", return_value=False):
             run_qa_gate(ctx)

--- a/tests/test_v058_quality.py
+++ b/tests/test_v058_quality.py
@@ -172,6 +172,7 @@ class TestJudgeFiveDimensions:
     def test_judge_script_ci_mode_returns_five_dimensions(self):
         """CI mode should return default pass score with all 5 dimensions."""
         from movie_narrator.pipeline.script import judge_script
+
         with patch("movie_narrator.pipeline.script.is_ci", return_value=True):
             scores = judge_script([], "test", None)
         assert "anti_ai_compliance" in scores

--- a/tests/test_v059_audio.py
+++ b/tests/test_v059_audio.py
@@ -50,9 +50,7 @@ try:
 except Exception:
     _MP3_OK = False
 
-requires_mp3 = pytest.mark.skipif(
-    not _MP3_OK, reason="ffmpeg lacks mp3/wav codec support"
-)
+requires_mp3 = pytest.mark.skipif(not _MP3_OK, reason="ffmpeg lacks mp3/wav codec support")
 
 
 # ── Helpers ────────────────────────────────────────────────
@@ -420,8 +418,10 @@ def test_detect_emotion_zones_empty():
 
 def test_detect_emotion_zones_single_emotion():
     """All same emotion should produce one zone."""
-    segments = [TimedSegment(text="s1", start=0.0, end=1.0),
-                TimedSegment(text="s2", start=1.0, end=2.0)]
+    segments = [
+        TimedSegment(text="s1", start=0.0, end=1.0),
+        TimedSegment(text="s2", start=1.0, end=2.0),
+    ]
     emotions = ["intense", "intense"]
     zones = _detect_emotion_zones(segments, emotions)
     assert len(zones) == 1
@@ -432,9 +432,11 @@ def test_detect_emotion_zones_single_emotion():
 
 def test_detect_emotion_zones_two_zones():
     """Emotion change should produce two zones."""
-    segments = [TimedSegment(text="s1", start=0.0, end=1.0),
-                TimedSegment(text="s2", start=1.0, end=2.0),
-                TimedSegment(text="s3", start=2.0, end=3.0)]
+    segments = [
+        TimedSegment(text="s1", start=0.0, end=1.0),
+        TimedSegment(text="s2", start=1.0, end=2.0),
+        TimedSegment(text="s3", start=2.0, end=3.0),
+    ]
     emotions = ["intense", "intense", "calm"]
     zones = _detect_emotion_zones(segments, emotions)
     assert len(zones) == 2
@@ -534,17 +536,21 @@ class TestTTSPipelineIntegration:
     def test_tts_emotion_prosody_applied(self, tmp_path, monkeypatch):
         """TTS step should apply emotion-based prosody and log it."""
         from movie_narrator.config import get_settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
         monkeypatch.setenv("CI", "1")
         ctx = self._make_tts_ctx(tmp_path)
         ctx.metadata["beats_meta"] = [
-            {"emotion": "intense"}, {"emotion": "calm"},
-            {"emotion": "suspense"}, {"emotion": "intense"},
+            {"emotion": "intense"},
+            {"emotion": "calm"},
+            {"emotion": "suspense"},
+            {"emotion": "intense"},
             {"emotion": "laughter"},
         ]
 
         from movie_narrator.pipeline.tts import generate_voice
+
         result = generate_voice(ctx)
 
         aq = result.metadata.get("audio_quality", {})
@@ -559,12 +565,14 @@ class TestTTSPipelineIntegration:
     def test_tts_prosody_no_beats_meta(self, tmp_path, monkeypatch):
         """Without beats_meta, all prosody speeds should be 1.0."""
         from movie_narrator.config import get_settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
         monkeypatch.setenv("CI", "1")
         ctx = self._make_tts_ctx(tmp_path)
 
         from movie_narrator.pipeline.tts import generate_voice
+
         result = generate_voice(ctx)
 
         aq = result.metadata.get("audio_quality", {})
@@ -577,12 +585,14 @@ class TestTTSPipelineIntegration:
     def test_tts_audio_quality_metrics(self, tmp_path, monkeypatch):
         """TTS step should produce per-segment audio quality metrics."""
         from movie_narrator.config import get_settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
         monkeypatch.setenv("CI", "1")
         ctx = self._make_tts_ctx(tmp_path)
 
         from movie_narrator.pipeline.tts import generate_voice
+
         result = generate_voice(ctx)
 
         aq = result.metadata.get("audio_quality", {})
@@ -595,12 +605,14 @@ class TestTTSPipelineIntegration:
     def test_tts_v2_speed_not_triggered_when_ok(self, tmp_path, monkeypatch):
         """V2 speed should not trigger when duration is within range."""
         from movie_narrator.config import get_settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
         monkeypatch.setenv("CI", "1")
         ctx = self._make_tts_ctx(tmp_path, duration=10)
 
         from movie_narrator.pipeline.tts import generate_voice
+
         result = generate_voice(ctx)
 
         aq = result.metadata.get("audio_quality", {})
@@ -609,6 +621,7 @@ class TestTTSPipelineIntegration:
     def test_tts_v2_speed_triggered_on_overflow(self, tmp_path, monkeypatch):
         """V2 speed should trigger when narration overflows target."""
         from movie_narrator.config import get_settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
         monkeypatch.setenv("CI", "1")
@@ -617,6 +630,7 @@ class TestTTSPipelineIntegration:
         ctx.segments = [ScriptSegment(text=long_text) for _ in range(5)]
 
         from movie_narrator.pipeline.tts import generate_voice
+
         result = generate_voice(ctx)
 
         dm = result.metadata.get("duration_metrics", {})
@@ -625,12 +639,14 @@ class TestTTSPipelineIntegration:
     def test_tts_duration_metrics_always_present(self, tmp_path, monkeypatch):
         """Duration metrics should always be populated."""
         from movie_narrator.config import get_settings
+
         get_settings.cache_clear()
         monkeypatch.setenv("MN_TTS_PROVIDER", "edge")
         monkeypatch.setenv("CI", "1")
         ctx = self._make_tts_ctx(tmp_path, duration=60)
 
         from movie_narrator.pipeline.tts import generate_voice
+
         result = generate_voice(ctx)
 
         dm = result.metadata.get("duration_metrics", {})
@@ -676,8 +692,10 @@ def test_bgm_transitions_stored_in_metadata(tmp_path):
         TimedSegment(text="s5", start=4.0, end=5.0),
     ]
     ctx.metadata["beats_meta"] = [
-        {"emotion": "intense"}, {"emotion": "intense"},
-        {"emotion": "calm"}, {"emotion": "calm"},
+        {"emotion": "intense"},
+        {"emotion": "intense"},
+        {"emotion": "calm"},
+        {"emotion": "calm"},
         {"emotion": "suspense"},
     ]
 
@@ -687,7 +705,9 @@ def test_bgm_transitions_stored_in_metadata(tmp_path):
     assert transitions is not None
     assert len(transitions) >= 1
     # Check transition from intense to calm
-    intense_to_calm = [t for t in transitions if t["from_emotion"] == "intense" and t["to_emotion"] == "calm"]
+    intense_to_calm = [
+        t for t in transitions if t["from_emotion"] == "intense" and t["to_emotion"] == "calm"
+    ]
     assert len(intense_to_calm) >= 1
 
 

--- a/tests/test_v060_task_queue.py
+++ b/tests/test_v060_task_queue.py
@@ -399,6 +399,7 @@ class TestCancelController:
     def test_implements_run_controller(self):
         """CancelController satisfies the RunController protocol."""
         from movie_narrator.pipeline.errors import RunController
+
         ctrl = CancelController()
         # RunController is a Protocol with is_cancelled() method
         assert hasattr(ctrl, "is_cancelled")
@@ -539,7 +540,12 @@ class TestLocalTaskQueue:
             task_id = queue.submit(req)
             status = queue.get_status(task_id)
             assert status is not None
-            assert status in [TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.COMPLETED, TaskStatus.FAILED]
+            assert status in [
+                TaskStatus.PENDING,
+                TaskStatus.RUNNING,
+                TaskStatus.COMPLETED,
+                TaskStatus.FAILED,
+            ]
         finally:
             queue.shutdown(wait=False)
 
@@ -663,6 +669,7 @@ class TestExecuteTask:
         """Test that _execute_task runs the pipeline and captures results."""
         # Mock run_pipeline to return a fake context
         from movie_narrator.models import Context, Assets, Services
+
         fake_ctx = Context(
             movie_name="TestMovie",
             output_dir=str(tmp_path),
@@ -711,6 +718,7 @@ class TestExecuteTask:
     def test_pipeline_cancelled(self, tmp_path, monkeypatch):
         """Test that _execute_task handles cancellation."""
         from movie_narrator.pipeline.errors import PipelineCancelled
+
         monkeypatch.setenv("CI", "1")
         monkeypatch.setattr(
             "movie_narrator.cloud.worker.run_pipeline",
@@ -767,6 +775,7 @@ class TestRunTask:
     def test_successful_first_try(self, tmp_path, monkeypatch):
         """Task succeeds on first attempt — no retries needed."""
         from movie_narrator.models import Context, Assets, Services
+
         fake_ctx = Context(
             movie_name="Test",
             output_dir=str(tmp_path),
@@ -829,6 +838,7 @@ class TestRunTask:
                 raise exc
             # Succeed on second try
             from movie_narrator.models import Context, Assets, Services
+
             ctx.video_path = str(tmp_path / "out.mp4")
             return ctx
 
@@ -903,6 +913,7 @@ class TestRunTask:
 
         # Cancel after a short delay (during the retry sleep)
         import threading
+
         timer = threading.Timer(0.1, controller.cancel)
         timer.start()
 
@@ -921,6 +932,7 @@ class TestContractExports:
 
     def test_contract_version_bumped(self):
         from movie_narrator.contract import CONTRACT_VERSION
+
         assert CONTRACT_VERSION == (1, 0, 0)
 
     def test_contract_exports_cloud_types(self):
@@ -937,6 +949,7 @@ class TestContractExports:
             TaskStorage,
             run_task,
         )
+
         # All should be importable
         assert CancelController is not None
         assert LocalTaskQueue is not None
@@ -952,6 +965,7 @@ class TestContractExports:
             TaskResult,
             TaskStatus,
         )
+
         assert CancelController is not None
         assert LocalTaskQueue is not None
         assert Task is not None
@@ -973,11 +987,26 @@ class TestContractExports:
             TaskStorage,
             run_task,
         )
-        assert all(x is not None for x in [
-            ACTIVE_STATES, TERMINAL_STATES, CancelController, LocalTaskQueue,
-            ProgressConsole, Task, TaskPriority, TaskProgress, TaskQueue,
-            TaskRequest, TaskResult, TaskStatus, TaskStorage, run_task,
-        ])
+
+        assert all(
+            x is not None
+            for x in [
+                ACTIVE_STATES,
+                TERMINAL_STATES,
+                CancelController,
+                LocalTaskQueue,
+                ProgressConsole,
+                Task,
+                TaskPriority,
+                TaskProgress,
+                TaskQueue,
+                TaskRequest,
+                TaskResult,
+                TaskStatus,
+                TaskStorage,
+                run_task,
+            ]
+        )
 
 
 # ════════════════════════════════════════════════════════════

--- a/tests/test_v061_remote.py
+++ b/tests/test_v061_remote.py
@@ -189,7 +189,12 @@ class TestTaskAPIServer:
 
         status = remote_queue.get_status(task_id)
         assert status is not None
-        assert status in [TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.COMPLETED, TaskStatus.FAILED]
+        assert status in [
+            TaskStatus.PENDING,
+            TaskStatus.RUNNING,
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+        ]
 
     def test_get_result_not_completed(self, api_server, remote_queue):
         """get_result returns None for non-terminal tasks."""
@@ -346,7 +351,8 @@ class TestWorkerDaemon:
     def test_double_start_raises(self, tmp_path):
         """Starting an already-running daemon raises RuntimeError."""
         daemon = WorkerDaemon(
-            host="127.0.0.1", port=0,
+            host="127.0.0.1",
+            port=0,
             storage_dir=tmp_path / "daemon_err",
             max_workers=1,
         )
@@ -529,9 +535,7 @@ class TestRemoteIntegration:
         """Multiple tasks can be submitted concurrently."""
         task_ids = []
         for i in range(5):
-            tid = remote_queue.submit(
-                TaskRequest(movie_name=f"Concurrent{i}", max_retries=0)
-            )
+            tid = remote_queue.submit(TaskRequest(movie_name=f"Concurrent{i}", max_retries=0))
             task_ids.append(tid)
 
         # All should have unique IDs
@@ -552,11 +556,13 @@ class TestContractExports:
     def test_contract_version_bumped(self):
         """CONTRACT_VERSION is (1, 0, 0)."""
         from movie_narrator.contract import CONTRACT_VERSION
+
         assert CONTRACT_VERSION == (1, 0, 0)
 
     def test_remote_types_in_contract_all(self):
         """Remote inference types are in contract __all__."""
         from movie_narrator import contract
+
         for name in [
             "RemoteTaskQueue",
             "RemoteQueueError",
@@ -580,6 +586,7 @@ class TestContractExports:
             run_daemon,
             download_artifact,
         )
+
         assert RemoteTaskQueue is not None
         assert TaskAPIServer is not None
         assert WorkerDaemon is not None

--- a/tests/test_v062_gap6_concurrency.py
+++ b/tests/test_v062_gap6_concurrency.py
@@ -148,15 +148,9 @@ class TestActiveCountOptimization:
     def test_active_count_not_started_falls_back_to_storage(self, tmp_path):
         """When not started, active_count scans storage for compatibility."""
         queue = LocalTaskQueue(storage_dir=tmp_path, auto_start=False)
-        queue.storage.save(
-            Task(request=TaskRequest(movie_name="A"), status=TaskStatus.PENDING)
-        )
-        queue.storage.save(
-            Task(request=TaskRequest(movie_name="B"), status=TaskStatus.RUNNING)
-        )
-        queue.storage.save(
-            Task(request=TaskRequest(movie_name="C"), status=TaskStatus.COMPLETED)
-        )
+        queue.storage.save(Task(request=TaskRequest(movie_name="A"), status=TaskStatus.PENDING))
+        queue.storage.save(Task(request=TaskRequest(movie_name="B"), status=TaskStatus.RUNNING))
+        queue.storage.save(Task(request=TaskRequest(movie_name="C"), status=TaskStatus.COMPLETED))
         assert queue.active_count == 2
 
 

--- a/tests/test_v080_api_auth.py
+++ b/tests/test_v080_api_auth.py
@@ -140,12 +140,8 @@ class TestApiAuthMiddleware:
 
     def test_correct_key_returns_200(self, secure_server):
         """api_key set: correct X-API-Key allows access to protected endpoints."""
-        assert _request_code(
-            f"{secure_server.base_url}/info", api_key="secret-key-123"
-        ) == 200
-        assert _request_code(
-            f"{secure_server.base_url}/tasks", api_key="secret-key-123"
-        ) == 200
+        assert _request_code(f"{secure_server.base_url}/info", api_key="secret-key-123") == 200
+        assert _request_code(f"{secure_server.base_url}/tasks", api_key="secret-key-123") == 200
 
     def test_correct_key_post_task(self, secure_server):
         """api_key set: correct key allows POST /tasks (201 created)."""
@@ -174,9 +170,7 @@ class TestApiAuthMiddleware:
         # No key at all
         assert _request_code(f"{secure_server.base_url}/health") == 200
         # Even a wrong key is fine for /health (exempt from auth)
-        assert _request_code(
-            f"{secure_server.base_url}/health", api_key="wrong"
-        ) == 200
+        assert _request_code(f"{secure_server.base_url}/health", api_key="wrong") == 200
 
     def test_unauthorized_body(self, secure_server):
         """401 response body is exactly {"error": "unauthorized"}."""
@@ -189,8 +183,10 @@ class TestApiAuthMiddleware:
     def test_api_key_stored_on_server(self, tmp_path):
         """TaskAPIServer stores api_key on the instance."""
         server = TaskAPIServer(
-            host="127.0.0.1", port=0,
-            storage_dir=tmp_path / "tasks", max_workers=1,
+            host="127.0.0.1",
+            port=0,
+            storage_dir=tmp_path / "tasks",
+            max_workers=1,
             api_key="stored-key",
         )
         assert server.api_key == "stored-key"
@@ -216,8 +212,10 @@ class TestDaemonGuard:
         """run_daemon refuses a non-loopback host without api_key (SystemExit)."""
         with pytest.raises(SystemExit) as exc_info:
             run_daemon(
-                host="0.0.0.0", port=0,
-                storage_dir=tmp_path, blocking=False,
+                host="0.0.0.0",
+                port=0,
+                storage_dir=tmp_path,
+                blocking=False,
             )
         assert exc_info.value.code == 1
 
@@ -225,15 +223,19 @@ class TestDaemonGuard:
         """run_daemon refuses an external host without api_key."""
         with pytest.raises(SystemExit):
             run_daemon(
-                host="10.0.0.5", port=0,
-                storage_dir=tmp_path, blocking=False,
+                host="10.0.0.5",
+                port=0,
+                storage_dir=tmp_path,
+                blocking=False,
             )
 
     def test_guard_allows_loopback_without_key(self, tmp_path):
         """run_daemon allows loopback host without api_key (backwards compatible)."""
         server = run_daemon(
-            host="127.0.0.1", port=0,
-            storage_dir=tmp_path, blocking=False,
+            host="127.0.0.1",
+            port=0,
+            storage_dir=tmp_path,
+            blocking=False,
         )
         assert server is not None
         assert server.api_key is None
@@ -247,8 +249,10 @@ class TestDaemonGuard:
             lambda self, blocking=False: None,
         )
         server = run_daemon(
-            host="0.0.0.0", port=0,
-            storage_dir=tmp_path, blocking=False,
+            host="0.0.0.0",
+            port=0,
+            storage_dir=tmp_path,
+            blocking=False,
             allow_insecure=True,
         )
         assert server is not None
@@ -262,8 +266,10 @@ class TestDaemonGuard:
             lambda self, blocking=False: None,
         )
         server = run_daemon(
-            host="0.0.0.0", port=0,
-            storage_dir=tmp_path, blocking=False,
+            host="0.0.0.0",
+            port=0,
+            storage_dir=tmp_path,
+            blocking=False,
             api_key="my-key",
         )
         assert server is not None
@@ -299,8 +305,7 @@ class TestSettingsApiKey:
         """MN_API_KEY is documented in .env.example."""
         from movie_narrator.config import _EXAMPLE_ENV
 
-        content = _EXAMPLE_ENV.read_text(encoding="utf-8") \
-            if _EXAMPLE_ENV.is_file() else ""
+        content = _EXAMPLE_ENV.read_text(encoding="utf-8") if _EXAMPLE_ENV.is_file() else ""
         # Either the file documents it, or the fallback template omits it;
         # the example file is the source of truth, so assert it's there.
         assert "MN_API_KEY" in content

--- a/tests/test_v080_real_scenedetect.py
+++ b/tests/test_v080_real_scenedetect.py
@@ -12,6 +12,7 @@ This module fills that gap. It is skipped automatically when PySceneDetect or
 OpenCV is unavailable (i.e. on CI); run it locally after
 ``pip install "movie-narrator[media]"``.
 """
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_v080_render_template.py
+++ b/tests/test_v080_render_template.py
@@ -25,14 +25,16 @@ from movie_narrator.presets.mainstream_dry import MainstreamDryPreset
 from movie_narrator.utils.metadata_export import build_metadata_json
 
 # ── 已识别的 render_template 顶层键 ────────────────────────
-_RECOGNISED_KEYS = frozenset({
-    "title_card_text",
-    "end_card_text",
-    "watermark_text",
-    "disclaimer_text",
-    "slogan_text",
-    "aspect_safe_area",
-})
+_RECOGNISED_KEYS = frozenset(
+    {
+        "title_card_text",
+        "end_card_text",
+        "watermark_text",
+        "disclaimer_text",
+        "slogan_text",
+        "aspect_safe_area",
+    }
+)
 
 _TEST_MOVIE = "飞驰人生"
 

--- a/tests/test_v081_logging.py
+++ b/tests/test_v081_logging.py
@@ -176,6 +176,7 @@ def test_correlation_not_auto_propagated_to_thread():
     captured: Dict[str, Any] = {}
 
     with correlation_scope("parent-cid"):
+
         def worker() -> None:
             captured["auto"] = get_correlation_id()
 

--- a/tests/test_v081_metrics.py
+++ b/tests/test_v081_metrics.py
@@ -63,9 +63,7 @@ def test_content_type_latest():
 
 def test_counter_render():
     reg = MetricsRegistry()
-    reg.counter("my_counter", "A counter", ("code",)).inc(
-        2, labels={"code": "200"}
-    )
+    reg.counter("my_counter", "A counter", ("code",)).inc(2, labels={"code": "200"})
     out = reg.render()
     assert "# HELP my_counter A counter" in out
     assert "# TYPE my_counter counter" in out
@@ -120,7 +118,7 @@ def test_render_prometheus_text_all_families():
     ):
         assert f"# TYPE {name} " in text
     # Build info carries the version label.
-    assert 'mn_build_info{version=' in text
+    assert "mn_build_info{version=" in text
 
 
 def test_record_task_submitted_and_terminal():
@@ -169,9 +167,7 @@ def test_record_error_defaults_unknown():
 def test_record_http_request_uses_path_template():
     metrics.record_http_request("GET", "/tasks/{id}", 200)
     metrics.record_http_request("GET", "/tasks/{id}", 200)
-    c = get_registry().counter(
-        HTTP_REQUESTS_TOTAL, label_names=("method", "path", "code")
-    )
+    c = get_registry().counter(HTTP_REQUESTS_TOTAL, label_names=("method", "path", "code"))
     assert c.value({"method": "GET", "path": "/tasks/{id}", "code": "200"}) == 2
 
 
@@ -203,13 +199,8 @@ def test_route_template_folds_task_paths():
 
     assert _route_template("/tasks/abc123") == "/tasks/{id}"
     assert _route_template("/tasks/abc123/result") == "/tasks/{id}/result"
-    assert (
-        _route_template("/tasks/abc123/artifacts") == "/tasks/{id}/artifacts"
-    )
-    assert (
-        _route_template("/tasks/abc123/download/video.mp4")
-        == "/tasks/{id}/download/{filename}"
-    )
+    assert _route_template("/tasks/abc123/artifacts") == "/tasks/{id}/artifacts"
+    assert _route_template("/tasks/abc123/download/video.mp4") == "/tasks/{id}/download/{filename}"
 
 
 def test_metrics_public_env(monkeypatch):

--- a/tests/test_v082_health.py
+++ b/tests/test_v082_health.py
@@ -229,9 +229,7 @@ class TestDeepHealth:
 
     def test_failed_core_check_is_503(self, open_server):
         """A failing core check makes the deep check report 503 / error."""
-        payload, code = build_health_payload(
-            open_server.queue, shutting_down=True, deep=True
-        )
+        payload, code = build_health_payload(open_server.queue, shutting_down=True, deep=True)
         assert code == 503
         assert payload["status"] == "error"
         assert payload["ready"] is False
@@ -243,9 +241,7 @@ class TestDeepHealth:
             "movie_narrator.cloud.health.dependency_report",
             lambda: {"llm": {"status": STATUS_FAIL, "detail": "down", "duration_ms": 1.0}},
         )
-        payload, code = build_health_payload(
-            open_server.queue, shutting_down=True, deep=True
-        )
+        payload, code = build_health_payload(open_server.queue, shutting_down=True, deep=True)
         assert code == 503
         assert payload["status"] == "error"
 
@@ -299,8 +295,10 @@ class TestReadinessEndpoint:
     def test_shutdown_flag_tracks_stop(self, tmp_path):
         """TaskAPIServer.is_shutting_down flips on stop()."""
         server = TaskAPIServer(
-            host="127.0.0.1", port=0,
-            storage_dir=tmp_path / "tasks", max_workers=1,
+            host="127.0.0.1",
+            port=0,
+            storage_dir=tmp_path / "tasks",
+            max_workers=1,
         )
         server.start(blocking=False)
         assert server.is_shutting_down is False
@@ -433,9 +431,7 @@ class TestDependencyProbes:
 
     def test_edge_tts_has_no_http_target(self, monkeypatch):
         """The default offline TTS backend exposes no URL to probe."""
-        monkeypatch.setattr(
-            "movie_narrator.config.get_settings", lambda: _FakeSettings("edge")
-        )
+        monkeypatch.setattr("movie_narrator.config.get_settings", lambda: _FakeSettings("edge"))
         monkeypatch.delenv(REMOTE_STORAGE_ENV, raising=False)
         targets = _dependency_targets()
         assert set(targets) == {"llm"}
@@ -446,17 +442,13 @@ class TestDependencyProbes:
     )
     def test_http_tts_providers_are_probed(self, monkeypatch, provider, expected):
         """HTTP-based TTS providers contribute their base URL."""
-        monkeypatch.setattr(
-            "movie_narrator.config.get_settings", lambda: _FakeSettings(provider)
-        )
+        monkeypatch.setattr("movie_narrator.config.get_settings", lambda: _FakeSettings(provider))
         targets = _dependency_targets()
         assert targets["tts"] == expected
 
     def test_remote_storage_from_env(self, monkeypatch):
         """MN_REMOTE_STORAGE_URL adds a remote storage target."""
-        monkeypatch.setattr(
-            "movie_narrator.config.get_settings", lambda: _FakeSettings("edge")
-        )
+        monkeypatch.setattr("movie_narrator.config.get_settings", lambda: _FakeSettings("edge"))
         monkeypatch.setenv(REMOTE_STORAGE_ENV, "http://storage.invalid")
         assert _dependency_targets()["remote_storage"] == "http://storage.invalid"
 
@@ -509,7 +501,11 @@ class TestDependencyProbes:
 
         def _raise(request, timeout=None):
             raise urllib.error.HTTPError(
-                "http://llm.invalid/v1", 404, "Not Found", None, None  # type: ignore[arg-type]
+                "http://llm.invalid/v1",
+                404,
+                "Not Found",
+                None,
+                None,  # type: ignore[arg-type]
             )
 
         monkeypatch.setattr(urllib.request, "urlopen", _raise)
@@ -538,8 +534,6 @@ class TestDependencyProbes:
             called["n"] += 1
             return {}
 
-        monkeypatch.setattr(
-            "movie_narrator.cloud.health.run_dependency_checks", _fake
-        )
+        monkeypatch.setattr("movie_narrator.cloud.health.run_dependency_checks", _fake)
         assert dependency_report() == {}
         assert called["n"] == 1

--- a/tests/test_v082_openapi.py
+++ b/tests/test_v082_openapi.py
@@ -180,11 +180,7 @@ class TestSpecPaths:
                 for segment in path.split("/")
                 if segment.startswith("{") and segment.endswith("}")
             )
-            declared = {
-                p["name"]
-                for p in op.get("parameters", [])
-                if p.get("in") == "path"
-            }
+            declared = {p["name"] for p in op.get("parameters", []) if p.get("in") == "path"}
             assert declared == expected, f"{method.upper()} {path}"
             for param in op.get("parameters", []):
                 if param.get("in") == "path":
@@ -192,10 +188,7 @@ class TestSpecPaths:
 
     def test_task_list_query_parameters(self, spec):
         """GET /tasks documents ?status= and ?limit=."""
-        params = {
-            p["name"]: p
-            for p in spec["paths"]["/tasks"]["get"]["parameters"]
-        }
+        params = {p["name"]: p for p in spec["paths"]["/tasks"]["get"]["parameters"]}
         assert set(params) == {"status", "limit"}
         assert params["status"]["in"] == "query"
         assert params["status"]["required"] is False
@@ -203,10 +196,7 @@ class TestSpecPaths:
 
     def test_health_deep_query_parameter(self, spec):
         """GET /health documents the ?deep= opt-in flag."""
-        params = {
-            p["name"]: p
-            for p in spec["paths"]["/health"]["get"]["parameters"]
-        }
+        params = {p["name"]: p for p in spec["paths"]["/health"]["get"]["parameters"]}
         assert "deep" in params
         assert params["deep"]["in"] == "query"
         assert params["deep"]["required"] is False
@@ -220,11 +210,7 @@ class TestSpecPaths:
 
     def test_response_codes_cover_the_contract(self, spec):
         """The documented status codes match what the handler can return."""
-        codes = {
-            code
-            for _, _, op in _operations(spec)
-            for code in op["responses"]
-        }
+        codes = {code for _, _, op in _operations(spec) for code in op["responses"]}
         assert {"200", "201", "400", "401", "403", "404", "503"} <= codes
 
     def test_probe_endpoints_document_503(self, spec):
@@ -279,18 +265,14 @@ class TestSpecComponents:
     def test_every_schema_is_referenced_or_top_level(self, spec):
         """No orphan component schema (dead weight in generated clients)."""
         schemas = spec["components"]["schemas"]
-        referenced = {
-            value.rsplit("/", 1)[-1] for key, value in _walk(spec) if key == "$ref"
-        }
+        referenced = {value.rsplit("/", 1)[-1] for key, value in _walk(spec) if key == "$ref"}
         assert set(schemas) == referenced
 
     def test_task_request_matches_model(self, spec):
         """The TaskRequest component tracks the pydantic model fields."""
         from movie_narrator.cloud.models import TaskRequest
 
-        model_schema = TaskRequest.model_json_schema(
-            ref_template="#/components/schemas/{model}"
-        )
+        model_schema = TaskRequest.model_json_schema(ref_template="#/components/schemas/{model}")
         model_schema.pop("$defs", None)
         assert spec["components"]["schemas"]["TaskRequest"] == model_schema
 
@@ -351,9 +333,7 @@ class TestOpenApiEndpoint:
 
     def test_served_without_api_key(self, server):
         """The spec route is exempt from authentication."""
-        with urllib.request.urlopen(
-            f"{server.base_url}/openapi.json", timeout=5
-        ) as resp:
+        with urllib.request.urlopen(f"{server.base_url}/openapi.json", timeout=5) as resp:
             assert resp.getcode() == 200
             assert resp.headers.get("Content-Type", "").startswith("application/json")
             body = json.loads(resp.read())
@@ -362,9 +342,7 @@ class TestOpenApiEndpoint:
 
     def test_server_url_reflects_host_header(self, server):
         """The served document advertises the host the client used."""
-        with urllib.request.urlopen(
-            f"{server.base_url}/openapi.json", timeout=5
-        ) as resp:
+        with urllib.request.urlopen(f"{server.base_url}/openapi.json", timeout=5) as resp:
             body = json.loads(resp.read())
         assert body["servers"][0]["url"] == server.base_url
 

--- a/tests/test_v083_artifact_store.py
+++ b/tests/test_v083_artifact_store.py
@@ -307,9 +307,7 @@ class TestLocalArtifactStore:
         store.put("final.mp4", source_file)
         assert store.url("final.mp4") is None
 
-    @pytest.mark.parametrize(
-        "key", ["../escape.txt", "/etc/passwd", "clips/../../escape.txt"]
-    )
+    @pytest.mark.parametrize("key", ["../escape.txt", "/etc/passwd", "clips/../../escape.txt"])
     def test_traversal_rejected(self, store, source_file, key):
         """Every mutating/reading entry point refuses traversal keys."""
         with pytest.raises(UnsafeKeyError):
@@ -471,9 +469,7 @@ class TestS3ArtifactStore:
                         "NextContinuationToken": "tok",
                     }
                 return {
-                    "Contents": [
-                        {"Key": "b.mp4", "Size": 2, "LastModified": None, "ETag": '"y"'}
-                    ],
+                    "Contents": [{"Key": "b.mp4", "Size": 2, "LastModified": None, "ETag": '"y"'}],
                     "IsTruncated": False,
                 }
 
@@ -717,8 +713,7 @@ class TestApiArtifactEndpoints:
     def test_download_traversal_forbidden(self, api_server, task_with_files):
         """Encoded traversal attempts are rejected with 403."""
         url = (
-            f"{api_server.base_url}/tasks/{task_with_files.id}"
-            f"/download/..%2f..%2f..%2fetc%2fpasswd"
+            f"{api_server.base_url}/tasks/{task_with_files.id}/download/..%2f..%2f..%2fetc%2fpasswd"
         )
         assert _status(url) == 403
 

--- a/tests/test_v083_lifecycle.py
+++ b/tests/test_v083_lifecycle.py
@@ -366,9 +366,7 @@ class TestProtection:
         store.seed("running.mp4", 10, age_seconds=99 * DAY)
         store.seed("done.mp4", 10, age_seconds=99 * DAY)
         policy = ArtifactLifecyclePolicy(ttl_seconds=1)
-        report = cleanup_artifacts(
-            store, policy, now=NOW, protected_keys=["running.mp4"]
-        )
+        report = cleanup_artifacts(store, policy, now=NOW, protected_keys=["running.mp4"])
         assert report.deleted == ["done.mp4"]
         assert report.skipped == ["running.mp4"]
         assert "running.mp4" in store.keys
@@ -378,9 +376,7 @@ class TestProtection:
         store.seed("running.mp4", 100, age_seconds=9 * DAY)
         store.seed("done.mp4", 100, age_seconds=1 * DAY)
         policy = ArtifactLifecyclePolicy(max_total_bytes=50)
-        report = cleanup_artifacts(
-            store, policy, now=NOW, protected_keys={"running.mp4"}
-        )
+        report = cleanup_artifacts(store, policy, now=NOW, protected_keys={"running.mp4"})
         assert report.deleted == ["done.mp4"]
         assert "running.mp4" in store.keys
 
@@ -473,9 +469,7 @@ class TestErrorHandling:
             def list(self, prefix: str = "") -> Iterator[ArtifactInfo]:
                 raise ArtifactStoreError("bucket unreachable")
 
-        report = cleanup_artifacts(
-            BrokenStore(), ArtifactLifecyclePolicy(ttl_seconds=1), now=NOW
-        )
+        report = cleanup_artifacts(BrokenStore(), ArtifactLifecyclePolicy(ttl_seconds=1), now=NOW)
         assert report.deleted == []
         assert report.errors and "bucket unreachable" in report.errors[0][1]
 
@@ -572,9 +566,7 @@ class TestArtifactSweeper:
     def test_thread_lifecycle(self, store):
         """start()/stop() manage a daemon thread cleanly."""
         store.seed("old.mp4", 10, age_seconds=99 * DAY, now=time.time())
-        sweeper = ArtifactSweeper(
-            store, ArtifactLifecyclePolicy(ttl_seconds=1), interval=1.0
-        )
+        sweeper = ArtifactSweeper(store, ArtifactLifecyclePolicy(ttl_seconds=1), interval=1.0)
         assert sweeper.is_running is False
         sweeper.start()
         try:
@@ -647,9 +639,7 @@ class TestArtifactsCli:
 
     def test_list_empty_store(self, tmp_path):
         """An empty store says so instead of printing a bare total."""
-        result = CliRunner().invoke(
-            app, ["artifacts", "list", "--root", str(tmp_path / "empty")]
-        )
+        result = CliRunner().invoke(app, ["artifacts", "list", "--root", str(tmp_path / "empty")])
         assert result.exit_code == 0
         assert "No artifacts found." in result.output
 
@@ -658,9 +648,12 @@ class TestArtifactsCli:
         result = CliRunner().invoke(
             app,
             [
-                "artifacts", "cleanup",
-                "--root", str(cli_root),
-                "--ttl", str(int(7 * DAY)),
+                "artifacts",
+                "cleanup",
+                "--root",
+                str(cli_root),
+                "--ttl",
+                str(int(7 * DAY)),
                 "--dry-run",
             ],
         )
@@ -686,10 +679,14 @@ class TestArtifactsCli:
         result = CliRunner().invoke(
             app,
             [
-                "artifacts", "cleanup",
-                "--root", str(cli_root),
-                "--ttl", "1",
-                "--keep-last", "2",
+                "artifacts",
+                "cleanup",
+                "--root",
+                str(cli_root),
+                "--ttl",
+                "1",
+                "--keep-last",
+                "2",
             ],
         )
         assert result.exit_code == 0

--- a/tests/test_v084_container.py
+++ b/tests/test_v084_container.py
@@ -70,13 +70,11 @@ def _dockerfile_stages(text: str) -> List[str]:
 
 def _stage_body(text: str, stage: str) -> str:
     """Return the Dockerfile text belonging to a single build stage."""
-    stages = list(
-        re.finditer(r"^FROM\s+\S+\s+AS\s+(\S+)", text, re.MULTILINE | re.IGNORECASE)
-    )
+    stages = list(re.finditer(r"^FROM\s+\S+\s+AS\s+(\S+)", text, re.MULTILINE | re.IGNORECASE))
     for i, match in enumerate(stages):
         if match.group(1) == stage:
             end = stages[i + 1].start() if i + 1 < len(stages) else len(text)
-            return text[match.start():end]
+            return text[match.start() : end]
     raise AssertionError(f"stage {stage!r} not found in Dockerfile")
 
 
@@ -101,11 +99,7 @@ def _service_command(service: Dict[str, Any]) -> List[str]:
 
 def _mn_services(compose: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     """Services built from this repo's Dockerfile (i.e. running ``mn``)."""
-    return {
-        name: svc
-        for name, svc in compose["services"].items()
-        if "build" in svc
-    }
+    return {name: svc for name, svc in compose["services"].items() if "build" in svc}
 
 
 # ── Dockerfile ───────────────────────────────────────────────
@@ -182,7 +176,7 @@ class TestDockerfile:
     ) -> None:
         body = _stage_body(dockerfile_text, stage)
         assert "HEALTHCHECK" in body, f"{stage}: must define a HEALTHCHECK"
-        healthcheck = body[body.index("HEALTHCHECK"):]
+        healthcheck = body[body.index("HEALTHCHECK") :]
         assert "/health" in healthcheck, f"{stage}: probe the /health endpoint"
 
     @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
@@ -204,7 +198,7 @@ class TestDockerfile:
         body = _stage_body(dockerfile_text, stage)
         entrypoints = _json_arrays_for("ENTRYPOINT", body)
         assert entrypoints == [["mn"]], (
-            f"{stage}: ENTRYPOINT must be the exec-form [\"mn\"], got {entrypoints}"
+            f'{stage}: ENTRYPOINT must be the exec-form ["mn"], got {entrypoints}'
         )
 
     @pytest.mark.parametrize("stage", ["runtime", "runtime-gpu"])
@@ -216,9 +210,7 @@ class TestDockerfile:
 
     def test_no_build_toolchain_in_runtime(self, dockerfile_text: str) -> None:
         body = _stage_body(dockerfile_text, "runtime")
-        assert "build-essential" not in body, (
-            "the build toolchain must stay in the builder stage"
-        )
+        assert "build-essential" not in body, "the build toolchain must stay in the builder stage"
         assert "gcc" not in body
 
     def test_builder_installs_dependencies_before_source(self, dockerfile_text: str) -> None:
@@ -338,10 +330,9 @@ class TestComposeFile:
         assert compose["services"]["worker-gpu"]["profiles"] == ["gpu"]
 
     def test_gpu_service_reserves_nvidia_devices(self, compose: Dict[str, Any]) -> None:
-        devices = (
-            compose["services"]["worker-gpu"]["deploy"]["resources"]
-            ["reservations"]["devices"]
-        )
+        devices = compose["services"]["worker-gpu"]["deploy"]["resources"]["reservations"][
+            "devices"
+        ]
         assert devices, "declare the NVIDIA device reservation stanza"
         device = devices[0]
         assert device["driver"] == "nvidia"
@@ -401,9 +392,7 @@ class TestComposeFile:
                     f"{name}: named volume {source!r} is not declared under top-level volumes"
                 )
 
-    def test_task_state_is_not_shared_between_replicas(
-        self, compose: Dict[str, Any]
-    ) -> None:
+    def test_task_state_is_not_shared_between_replicas(self, compose: Dict[str, Any]) -> None:
         # TaskStorage caches the whole index in memory and rewrites the file
         # on save, so two processes sharing --storage-dir corrupt each other.
         for name in ("worker", "worker-gpu"):
@@ -434,19 +423,14 @@ class TestComposeFile:
         for name, svc in _mn_services(compose).items():
             env_file = svc.get("env_file")
             assert env_file, f"{name}: wire configuration from .env"
-            paths = [
-                entry["path"] if isinstance(entry, dict) else entry
-                for entry in env_file
-            ]
+            paths = [entry["path"] if isinstance(entry, dict) else entry for entry in env_file]
             assert ".env" in paths, f"{name}: expected .env in env_file, got {paths}"
 
     def test_referenced_env_keys_documented_in_env_example(self, compose_text: str) -> None:
         referenced = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", compose_text))
         assert referenced, "expected the compose file to use env substitution"
         env_example = ENV_EXAMPLE.read_text(encoding="utf-8")
-        documented = set(
-            re.findall(r"^#?\s*([A-Z][A-Z0-9_]*)=", env_example, re.MULTILINE)
-        )
+        documented = set(re.findall(r"^#?\s*([A-Z][A-Z0-9_]*)=", env_example, re.MULTILINE))
         missing = sorted(referenced - documented)
         assert not missing, f"undocumented env keys in .env.example: {missing}"
 
@@ -471,9 +455,7 @@ class TestComposeMatchesCLI:
             "mn serve is the command the containers run; it must exist"
         )
 
-    def test_every_compose_command_exists_in_the_cli(
-        self, compose: Dict[str, Any]
-    ) -> None:
+    def test_every_compose_command_exists_in_the_cli(self, compose: Dict[str, Any]) -> None:
         group = self._cli_group()
         available = set(group.commands)
         checked = 0
@@ -488,9 +470,7 @@ class TestComposeMatchesCLI:
             checked += 1
         assert checked >= 3, "expected api + worker + worker-gpu to be checked"
 
-    def test_every_compose_flag_exists_on_its_command(
-        self, compose: Dict[str, Any]
-    ) -> None:
+    def test_every_compose_flag_exists_on_its_command(self, compose: Dict[str, Any]) -> None:
         group = self._cli_group()
         for name, svc in _mn_services(compose).items():
             tokens = _service_command(svc)

--- a/tests/test_v091_reliability.py
+++ b/tests/test_v091_reliability.py
@@ -101,9 +101,7 @@ class TestCircuitBreakerStateMachine:
         assert excinfo.value.service == "svc"
 
     def test_recovery_opens_to_half_open_after_timeout(self):
-        b = CircuitBreaker(
-            "svc", failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=1
-        )
+        b = CircuitBreaker("svc", failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=1)
         with pytest.raises(ConnectionError):
             with b.guard():
                 raise ConnectionError("boom")
@@ -121,9 +119,7 @@ class TestCircuitBreakerStateMachine:
         assert b.state is CircuitState.CLOSED
 
     def test_half_open_probe_failure_reopens(self):
-        b = CircuitBreaker(
-            "svc", failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=1
-        )
+        b = CircuitBreaker("svc", failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=1)
         with pytest.raises(ConnectionError):
             with b.guard():
                 raise ConnectionError("boom")
@@ -141,9 +137,7 @@ class TestCircuitBreakerStateMachine:
                 pass
 
     def test_guard_rejects_when_probe_slot_busy(self):
-        b = CircuitBreaker(
-            "svc", failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=1
-        )
+        b = CircuitBreaker("svc", failure_threshold=1, recovery_timeout=0.05, half_open_max_calls=1)
         with pytest.raises(ConnectionError):
             with b.guard():
                 raise ConnectionError("boom")
@@ -236,9 +230,7 @@ class TestCircuitBreakerConcurrency:
         assert b.failure_count == 0
 
     def test_concurrent_failures_open_at_threshold(self):
-        b = CircuitBreaker(
-            "svc", failure_threshold=5, recovery_timeout=30.0, half_open_max_calls=1
-        )
+        b = CircuitBreaker("svc", failure_threshold=5, recovery_timeout=30.0, half_open_max_calls=1)
 
         def worker():
             for _ in range(5):
@@ -318,7 +310,9 @@ class TestRetryPolicy:
             calls["n"] += 1
             raise ConnectionError("x")
 
-        with mock.patch("movie_narrator.reliability.retry.time.sleep", side_effect=lambda d: sleeps.append(d)):
+        with mock.patch(
+            "movie_narrator.reliability.retry.time.sleep", side_effect=lambda d: sleeps.append(d)
+        ):
             with pytest.raises(ConnectionError):
                 flaky()
 
@@ -429,7 +423,9 @@ class TestRetryPolicy:
         calls = {"n": 0}
 
         @with_retry(
-            RetryPolicy(max_attempts=3, base_delay=0.001, jitter=0.0, should_retry=lambda exc: False)
+            RetryPolicy(
+                max_attempts=3, base_delay=0.001, jitter=0.0, should_retry=lambda exc: False
+            )
         )
         def flaky():
             calls["n"] += 1
@@ -466,9 +462,7 @@ class TestRetryPolicy:
             calls["n"] += 1
             raise ConnectionError("x")
 
-        with mock.patch(
-            "movie_narrator.reliability.retry.asyncio.sleep", side_effect=fake_sleep
-        ):
+        with mock.patch("movie_narrator.reliability.retry.asyncio.sleep", side_effect=fake_sleep):
             with pytest.raises(ConnectionError):
                 asyncio.run(flaky())
 
@@ -515,9 +509,7 @@ class TestRetryPolicy:
 class TestTmdbIntegration:
     def _fresh_registry(self):
         registry = CircuitBreakerRegistry()
-        registry.get(
-            "tmdb", failure_threshold=2, recovery_timeout=0.05, half_open_max_calls=1
-        )
+        registry.get("tmdb", failure_threshold=2, recovery_timeout=0.05, half_open_max_calls=1)
         return registry
 
     def test_tmdb_network_error_counts_toward_breaker(self):
@@ -528,8 +520,9 @@ class TestTmdbIntegration:
         breaker = registry["tmdb"]
 
         err = OSError("connection refused")
-        with mock.patch.object(tmdb_module, "CIRCUIT_REGISTRY", registry), mock.patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen", side_effect=err
+        with (
+            mock.patch.object(tmdb_module, "CIRCUIT_REGISTRY", registry),
+            mock.patch("movie_narrator.providers.tmdb.urllib.request.urlopen", side_effect=err),
         ):
             with pytest.raises(OSError):
                 tmdb_module._tmdb_get(
@@ -545,9 +538,10 @@ class TestTmdbIntegration:
         breaker = registry["tmdb"]
         breaker.force_open()
 
-        with mock.patch.object(tmdb_module, "CIRCUIT_REGISTRY", registry), mock.patch(
-            "movie_narrator.providers.tmdb.urllib.request.urlopen"
-        ) as mock_open:
+        with (
+            mock.patch.object(tmdb_module, "CIRCUIT_REGISTRY", registry),
+            mock.patch("movie_narrator.providers.tmdb.urllib.request.urlopen") as mock_open,
+        ):
             with pytest.raises(CircuitOpenError):
                 tmdb_module._tmdb_get(
                     "https://api.themoviedb.org/3", "/search/movie", "key", {"query": "t"}
@@ -558,9 +552,7 @@ class TestTmdbIntegration:
 class TestVlmIntegration:
     def _fresh_registry(self):
         registry = CircuitBreakerRegistry()
-        registry.get(
-            "vlm", failure_threshold=2, recovery_timeout=0.05, half_open_max_calls=1
-        )
+        registry.get("vlm", failure_threshold=2, recovery_timeout=0.05, half_open_max_calls=1)
         return registry
 
     def _captioner(self):
@@ -583,9 +575,10 @@ class TestVlmIntegration:
         captioner = self._captioner()
         scene = models.Scene(index=0, start=0.0, end=10.0)
 
-        with mock.patch.object(vlm_module, "CIRCUIT_REGISTRY", registry), mock.patch(
-            "movie_narrator.vision.vlm.urllib.request.urlopen"
-        ) as mock_open:
+        with (
+            mock.patch.object(vlm_module, "CIRCUIT_REGISTRY", registry),
+            mock.patch("movie_narrator.vision.vlm.urllib.request.urlopen") as mock_open,
+        ):
             with pytest.raises(CircuitOpenError):
                 captioner._caption_frame("ZmFrZQ==", scene)
             mock_open.assert_not_called()
@@ -603,11 +596,11 @@ class TestVlmIntegration:
         captioner = self._captioner()
         scene = models.Scene(index=0, start=0.0, end=10.0)
 
-        with mock.patch.object(vlm_module, "CIRCUIT_REGISTRY", registry), mock.patch.object(
-            captioner, "_extract_keyframe_b64", return_value="ZmFrZQ=="
-        ), mock.patch(
-            "movie_narrator.vision.vlm.urllib.request.urlopen"
-        ) as mock_open:
+        with (
+            mock.patch.object(vlm_module, "CIRCUIT_REGISTRY", registry),
+            mock.patch.object(captioner, "_extract_keyframe_b64", return_value="ZmFrZQ=="),
+            mock.patch("movie_narrator.vision.vlm.urllib.request.urlopen") as mock_open,
+        ):
             result = captioner.caption_scenes([scene], video_path=str(video))
             mock_open.assert_not_called()
         # Circuit open → per-scene failure → fallback label, not a crash.
@@ -624,9 +617,10 @@ class TestLlmIntegration:
         )
         breaker.force_open()
 
-        with mock.patch.object(llm_module, "CIRCUIT_REGISTRY", registry), mock.patch(
-            "movie_narrator.utils.llm.llm_registry"
-        ) as mock_registry:
+        with (
+            mock.patch.object(llm_module, "CIRCUIT_REGISTRY", registry),
+            mock.patch("movie_narrator.utils.llm.llm_registry") as mock_registry,
+        ):
             with pytest.raises(CircuitOpenError):
                 with llm_module.get_llm_client():
                     pass  # pragma: no cover — must not be reached
@@ -637,9 +631,7 @@ class TestLlmIntegration:
 class TestTtsIntegration:
     def _fresh_registry(self):
         registry = CircuitBreakerRegistry()
-        registry.get(
-            "tts", failure_threshold=2, recovery_timeout=0.05, half_open_max_calls=1
-        )
+        registry.get("tts", failure_threshold=2, recovery_timeout=0.05, half_open_max_calls=1)
         return registry
 
     def test_tts_open_circuit_raises_retryable_provider_error(self):
@@ -656,8 +648,9 @@ class TestTtsIntegration:
         registry["tts"].force_open()
         provider = StubProvider()
 
-        with mock.patch.object(tts_base, "CIRCUIT_REGISTRY", registry), mock.patch.object(
-            tts_base, "is_ci", return_value=False
+        with (
+            mock.patch.object(tts_base, "CIRCUIT_REGISTRY", registry),
+            mock.patch.object(tts_base, "is_ci", return_value=False),
         ):
             with pytest.raises(ProviderError) as excinfo:
                 asyncio.run(provider.synthesize("hi", "voice", Path("out.mp3")))
@@ -678,8 +671,9 @@ class TestTtsIntegration:
         breaker = registry["tts"]
         provider = FlakyProvider()
 
-        with mock.patch.object(tts_base, "CIRCUIT_REGISTRY", registry), mock.patch.object(
-            tts_base, "is_ci", return_value=False
+        with (
+            mock.patch.object(tts_base, "CIRCUIT_REGISTRY", registry),
+            mock.patch.object(tts_base, "is_ci", return_value=False),
         ):
             with pytest.raises(ProviderError) as excinfo:
                 asyncio.run(provider.synthesize("hi", "voice", Path("out.mp3")))
@@ -699,8 +693,9 @@ class TestTtsIntegration:
         breaker = registry["tts"]
         provider = BadProvider()
 
-        with mock.patch.object(tts_base, "CIRCUIT_REGISTRY", registry), mock.patch.object(
-            tts_base, "is_ci", return_value=False
+        with (
+            mock.patch.object(tts_base, "CIRCUIT_REGISTRY", registry),
+            mock.patch.object(tts_base, "is_ci", return_value=False),
         ):
             with pytest.raises(ValueError):
                 asyncio.run(provider.synthesize("hi", "voice", Path("out.mp3")))

--- a/tests/test_v092_lifecycle.py
+++ b/tests/test_v092_lifecycle.py
@@ -145,10 +145,13 @@ class TestCheckpointStore:
 
     def test_resolve_resume_returns_next_step(self, tmp_path):
         store = CheckpointStore(tmp_path / "tasks")
-        store.save(TaskCheckpoint(
-            task_id="abc", completed_step="generate_script",
-            context_dump={"movie_name": "X"},
-        ))
+        store.save(
+            TaskCheckpoint(
+                task_id="abc",
+                completed_step="generate_script",
+                context_dump={"movie_name": "X"},
+            )
+        )
         plan = store.resolve_resume("abc")
         assert plan is not None
         assert plan.done is False
@@ -206,9 +209,7 @@ class TestWorkerCheckpointing:
             max_retries=0,
         )
         task = Task(request=req)
-        result = _execute_task(
-            task, CancelController(), checkpoint_store=store, attempt=2
-        )
+        result = _execute_task(task, CancelController(), checkpoint_store=store, attempt=2)
         assert result.status == TaskStatus.COMPLETED
 
         cp = store.load(task.id)
@@ -228,9 +229,7 @@ class TestWorkerCheckpointing:
             return ctx
 
         _patch_pipeline(monkeypatch, fake_pipeline)
-        req = TaskRequest(
-            movie_name="Meta", output_dir=str(tmp_path / "out"), max_retries=0
-        )
+        req = TaskRequest(movie_name="Meta", output_dir=str(tmp_path / "out"), max_retries=0)
         task = Task(request=req)
         result = _execute_task(task, CancelController(), checkpoint_store=store)
         assert result.status == TaskStatus.COMPLETED
@@ -257,12 +256,14 @@ class TestWorkerCheckpointing:
             max_retries=0,
         )
         task = Task(request=req)
-        store.save(TaskCheckpoint(
-            task_id=task.id,
-            completed_step="generate_script",
-            context_dump=_context_dump(tmp_path, "ResumeTest"),
-            attempt=0,
-        ))
+        store.save(
+            TaskCheckpoint(
+                task_id=task.id,
+                completed_step="generate_script",
+                context_dump=_context_dump(tmp_path, "ResumeTest"),
+                attempt=0,
+            )
+        )
 
         result = run_task(task, CancelController(), checkpoint_store=store)
         assert result.status == TaskStatus.COMPLETED
@@ -290,12 +291,14 @@ class TestWorkerCheckpointing:
         task = Task(request=req)
         dump = _context_dump(tmp_path, "DoneTest")
         dump["video_path"] = str(tmp_path / "out" / "final.mp4")
-        store.save(TaskCheckpoint(
-            task_id=task.id,
-            completed_step=STEPS[-1].__name__,
-            context_dump=dump,
-            attempt=0,
-        ))
+        store.save(
+            TaskCheckpoint(
+                task_id=task.id,
+                completed_step=STEPS[-1].__name__,
+                context_dump=dump,
+                attempt=0,
+            )
+        )
 
         result = run_task(task, CancelController(), checkpoint_store=store)
         assert result.status == TaskStatus.COMPLETED
@@ -307,9 +310,7 @@ class TestWorkerCheckpointing:
         monkeypatch.setenv("CI", "1")
         store = CheckpointStore(tmp_path / "tasks")
         _patch_pipeline(monkeypatch, _mock_pipeline)
-        req = TaskRequest(
-            movie_name="Delete", output_dir=str(tmp_path / "out"), max_retries=0
-        )
+        req = TaskRequest(movie_name="Delete", output_dir=str(tmp_path / "out"), max_retries=0)
         task = Task(request=req)
         result = run_task(task, CancelController(), checkpoint_store=store)
         assert result.status == TaskStatus.COMPLETED
@@ -326,9 +327,7 @@ class TestWorkerCheckpointing:
             return ctx
 
         _patch_pipeline(monkeypatch, fake_pipeline)
-        req = TaskRequest(
-            movie_name="Fresh", output_dir=str(tmp_path / "out"), max_retries=0
-        )
+        req = TaskRequest(movie_name="Fresh", output_dir=str(tmp_path / "out"), max_retries=0)
         task = Task(request=req)
         result = run_task(task, CancelController(), checkpoint_store=store)
         assert result.status == TaskStatus.COMPLETED
@@ -347,9 +346,9 @@ class TestQueueGracefulShutdown:
         monkeypatch.setenv("CI", "1")
         _patch_pipeline(monkeypatch, _cancel_aware_slow_pipeline(0.6))
         queue = LocalTaskQueue(storage_dir=tmp_path / "tasks", max_workers=1)
-        task_id = queue.submit(TaskRequest(
-            movie_name="Join", output_dir=str(tmp_path / "out"), max_retries=0
-        ))
+        task_id = queue.submit(
+            TaskRequest(movie_name="Join", output_dir=str(tmp_path / "out"), max_retries=0)
+        )
         start = time.monotonic()
         queue.shutdown(wait=True, timeout=10.0)
         elapsed = time.monotonic() - start
@@ -362,9 +361,9 @@ class TestQueueGracefulShutdown:
         monkeypatch.setenv("CI", "1")
         _patch_pipeline(monkeypatch, _cancel_aware_slow_pipeline(10.0))
         queue = LocalTaskQueue(storage_dir=tmp_path / "tasks", max_workers=1)
-        task_id = queue.submit(TaskRequest(
-            movie_name="Cancel", output_dir=str(tmp_path / "out"), max_retries=0
-        ))
+        task_id = queue.submit(
+            TaskRequest(movie_name="Cancel", output_dir=str(tmp_path / "out"), max_retries=0)
+        )
         start = time.monotonic()
         queue.shutdown(wait=True, timeout=0.5)
         assert time.monotonic() - start < 5.0  # returned despite long task
@@ -383,9 +382,9 @@ class TestQueueGracefulShutdown:
         monkeypatch.setenv("CI", "1")
         _patch_pipeline(monkeypatch, _cancel_aware_slow_pipeline(5.0))
         queue = LocalTaskQueue(storage_dir=tmp_path / "tasks", max_workers=1)
-        queue.submit(TaskRequest(
-            movie_name="Abandon", output_dir=str(tmp_path / "out"), max_retries=0
-        ))
+        queue.submit(
+            TaskRequest(movie_name="Abandon", output_dir=str(tmp_path / "out"), max_retries=0)
+        )
         time.sleep(0.2)  # let the worker start
         start = time.monotonic()
         queue.shutdown(wait=False)
@@ -403,12 +402,12 @@ class TestQueueGracefulShutdown:
         monkeypatch.setenv("CI", "1")
         _patch_pipeline(monkeypatch, _cancel_aware_slow_pipeline(0.3))
         queue = LocalTaskQueue(storage_dir=tmp_path / "tasks", max_workers=1)
-        first_id = queue.submit(TaskRequest(
-            movie_name="Occupier", output_dir=str(tmp_path / "out"), max_retries=0
-        ))
-        queued_id = queue.submit(TaskRequest(
-            movie_name="Queued", output_dir=str(tmp_path / "out2"), max_retries=0
-        ))
+        first_id = queue.submit(
+            TaskRequest(movie_name="Occupier", output_dir=str(tmp_path / "out"), max_retries=0)
+        )
+        queued_id = queue.submit(
+            TaskRequest(movie_name="Queued", output_dir=str(tmp_path / "out2"), max_retries=0)
+        )
         time.sleep(0.1)  # occupier running, the other still queued
 
         start = time.monotonic()
@@ -473,18 +472,18 @@ class TestApiGracefulShutdown:
         )
         server.start(blocking=False)
         try:
-            server.queue.submit(TaskRequest(
-                movie_name="Drain",
-                output_dir=str(tmp_path / "out"),
-                max_retries=0,
-            ))
+            server.queue.submit(
+                TaskRequest(
+                    movie_name="Drain",
+                    output_dir=str(tmp_path / "out"),
+                    max_retries=0,
+                )
+            )
             time.sleep(0.2)  # let the worker start
 
             # stop() drains from another thread; the HTTP loop stays up
             # during the drain so probes can report the draining state.
-            stop_thread = threading.Thread(
-                target=server.stop, kwargs={"drain_timeout": 5.0}
-            )
+            stop_thread = threading.Thread(target=server.stop, kwargs={"drain_timeout": 5.0})
             stop_thread.start()
             time.sleep(0.3)  # drain in progress
 
@@ -582,11 +581,13 @@ class TestQueueCheckpointWiring:
         _patch_pipeline(monkeypatch, fake_pipeline)
         queue = LocalTaskQueue(storage_dir=tmp_path / "tasks", max_workers=1)
         try:
-            task_id = queue.submit(TaskRequest(
-                movie_name="Wired",
-                output_dir=str(tmp_path / "out"),
-                max_retries=0,
-            ))
+            task_id = queue.submit(
+                TaskRequest(
+                    movie_name="Wired",
+                    output_dir=str(tmp_path / "out"),
+                    max_retries=0,
+                )
+            )
             # The checkpoint for the completed step must appear while the
             # worker is paused inside the pipeline.
             deadline = time.monotonic() + 5.0

--- a/tests/test_v093_batch_schedule.py
+++ b/tests/test_v093_batch_schedule.py
@@ -78,9 +78,7 @@ def _slow_pipeline(gate: threading.Event):
 @pytest.fixture
 def fast_pipeline(monkeypatch):
     """Patch run_pipeline so tasks complete without real work."""
-    monkeypatch.setattr(
-        "movie_narrator.cloud.worker.run_pipeline", _fast_pipeline
-    )
+    monkeypatch.setattr("movie_narrator.cloud.worker.run_pipeline", _fast_pipeline)
 
 
 @pytest.fixture
@@ -146,9 +144,7 @@ class TestBatchRequestValidation:
 
     def test_format_alias_supported(self):
         """The legacy ``format`` alias works inside batch requests (v0.9.5)."""
-        batch = BatchRequest(
-            requests=[{"movie_name": "x", "format": "9:16"}]
-        )
+        batch = BatchRequest(requests=[{"movie_name": "x", "format": "9:16"}])
         assert batch.requests[0].video_format == "9:16"
 
 
@@ -200,9 +196,7 @@ class TestSubmitBatch:
         """The batch record survives a queue restart (separate JSON file)."""
         storage = tmp_path / "persist"
         queue = LocalTaskQueue(storage_dir=storage)
-        batch = queue.submit_batch(
-            BatchRequest(requests=[TaskRequest(movie_name=_uniq("p"))])
-        )
+        batch = queue.submit_batch(BatchRequest(requests=[TaskRequest(movie_name=_uniq("p"))]))
         queue.shutdown()
 
         queue2 = LocalTaskQueue(storage_dir=storage)
@@ -244,9 +238,7 @@ class TestSubmitBatch:
 
         queue.submit = failing_submit  # type: ignore[method-assign]
         batch = queue.submit_batch(
-            BatchRequest(
-                requests=[TaskRequest(movie_name=_uniq("x"), max_retries=0)]
-            )
+            BatchRequest(requests=[TaskRequest(movie_name=_uniq("x"), max_retries=0)])
         )
         assert batch.status == BatchStatus.FAILED
         assert batch.task_ids == []
@@ -255,9 +247,7 @@ class TestSubmitBatch:
     def test_cancel_batch(self, tmp_path, monkeypatch):
         """cancel_batch cancels active members and refreshes the aggregate."""
         gate = threading.Event()
-        monkeypatch.setattr(
-            "movie_narrator.cloud.worker.run_pipeline", _slow_pipeline(gate)
-        )
+        monkeypatch.setattr("movie_narrator.cloud.worker.run_pipeline", _slow_pipeline(gate))
         queue = LocalTaskQueue(storage_dir=tmp_path / "q4", max_workers=1)
         batch = queue.submit_batch(
             BatchRequest(
@@ -413,17 +403,17 @@ class TestCronParser:
     @pytest.mark.parametrize(
         "expr",
         [
-            "",               # empty
-            "* * *",          # too few fields
-            "60 * * * *",     # minute out of range
-            "* 24 * * *",     # hour out of range
-            "* * 32 * *",     # day-of-month out of range
-            "* * * 13 *",     # month out of range
-            "* * * * 7",      # day-of-week out of range
-            "a * * * *",      # non-numeric
-            "* */0 * * *",    # zero step
-            "*/x * * * *",    # non-numeric step
-            "10-1 * * * *",   # reversed range
+            "",  # empty
+            "* * *",  # too few fields
+            "60 * * * *",  # minute out of range
+            "* 24 * * *",  # hour out of range
+            "* * 32 * *",  # day-of-month out of range
+            "* * * 13 *",  # month out of range
+            "* * * * 7",  # day-of-week out of range
+            "a * * * *",  # non-numeric
+            "* */0 * * *",  # zero step
+            "*/x * * * *",  # non-numeric step
+            "10-1 * * * *",  # reversed range
         ],
     )
     def test_invalid_expressions(self, expr):
@@ -462,9 +452,7 @@ class TestJobScheduler:
 
     def test_due_trigger_submits_job(self, mock_queue, tmp_path):
         scheduler = JobScheduler(queue=mock_queue, storage_dir=tmp_path)
-        schedule = scheduler.register_schedule(
-            "* * * * *", TaskRequest(movie_name="due_movie")
-        )
+        schedule = scheduler.register_schedule("* * * * *", TaskRequest(movie_name="due_movie"))
         # Force the next run into the past so it is due immediately.
         schedule.next_run_at = "2000-01-01T00:00:00+00:00"
         scheduler._store.save(schedule)
@@ -499,9 +487,7 @@ class TestJobScheduler:
                 raise RuntimeError("boom")
 
         scheduler = JobScheduler(queue=_BoomQueue(), storage_dir=tmp_path)
-        schedule = scheduler.register_schedule(
-            "* * * * *", TaskRequest(movie_name="fails")
-        )
+        schedule = scheduler.register_schedule("* * * * *", TaskRequest(movie_name="fails"))
         schedule.next_run_at = "2000-01-01T00:00:00+00:00"
         scheduler._store.save(schedule)
 
@@ -512,12 +498,8 @@ class TestJobScheduler:
 
     def test_runs_recorded_per_schedule(self, mock_queue, tmp_path):
         scheduler = JobScheduler(queue=mock_queue, storage_dir=tmp_path)
-        s1 = scheduler.register_schedule(
-            "* * * * *", TaskRequest(movie_name="a")
-        )
-        s2 = scheduler.register_schedule(
-            "* * * * *", TaskRequest(movie_name="b")
-        )
+        s1 = scheduler.register_schedule("* * * * *", TaskRequest(movie_name="a"))
+        s2 = scheduler.register_schedule("* * * * *", TaskRequest(movie_name="b"))
         for s in (s1, s2):
             s.next_run_at = "2000-01-01T00:00:00+00:00"
             scheduler._store.save(s)
@@ -531,9 +513,7 @@ class TestJobScheduler:
 
     def test_start_stop_thread(self, mock_queue, tmp_path):
         """The loop thread starts and stops cleanly."""
-        scheduler = JobScheduler(
-            queue=mock_queue, storage_dir=tmp_path, poll_interval=0.05
-        )
+        scheduler = JobScheduler(queue=mock_queue, storage_dir=tmp_path, poll_interval=0.05)
         assert not scheduler.is_running
         scheduler.start()
         assert scheduler.is_running
@@ -544,9 +524,7 @@ class TestJobScheduler:
 
     def test_cancel_schedule(self, mock_queue, tmp_path):
         scheduler = JobScheduler(queue=mock_queue, storage_dir=tmp_path)
-        schedule = scheduler.register_schedule(
-            "* * * * *", TaskRequest(movie_name="gone")
-        )
+        schedule = scheduler.register_schedule("* * * * *", TaskRequest(movie_name="gone"))
         assert scheduler.cancel_schedule(schedule.schedule_id) is True
         assert scheduler.cancel_schedule(schedule.schedule_id) is False
         assert scheduler.get_schedule(schedule.schedule_id) is None
@@ -589,9 +567,7 @@ class TestBatchApi:
             f"{api_server.base_url}/tasks/batch",
             body={"requests": [{"movie_name": _uniq("get"), "max_retries": 0}]},
         )
-        status, body = _http(
-            "GET", f"{api_server.base_url}/batches/{created['batch_id']}"
-        )
+        status, body = _http("GET", f"{api_server.base_url}/batches/{created['batch_id']}")
         assert status == 200
         assert body["batch_id"] == created["batch_id"]
         assert "progress" in body
@@ -645,9 +621,7 @@ class TestScheduleApi:
         status, listing = _http("GET", f"{api_server.base_url}/schedules")
         assert status == 200
         assert listing["count"] >= 1
-        assert created["schedule_id"] in {
-            s["schedule_id"] for s in listing["schedules"]
-        }
+        assert created["schedule_id"] in {s["schedule_id"] for s in listing["schedules"]}
 
         status, runs = _http(
             "GET",

--- a/tests/test_v094_dlq_distributed.py
+++ b/tests/test_v094_dlq_distributed.py
@@ -170,9 +170,7 @@ class TestDeadLetterRouting:
     """Worker integration: retry exhaustion routes to the DLQ."""
 
     def test_retry_exhausted_routes_to_dead(self, monkeypatch, dlq_store, tmp_path):
-        task = _run_with_error(
-            monkeypatch, ConnectionError("network down"), max_retries=1
-        )
+        task = _run_with_error(monkeypatch, ConnectionError("network down"), max_retries=1)
         assert task.status == TaskStatus.DEAD
         assert task.retries == 1
 
@@ -185,15 +183,11 @@ class TestDeadLetterRouting:
 
     def test_dead_is_terminal(self, monkeypatch, dlq_store, tmp_path):
         assert TaskStatus.DEAD in TERMINAL_STATES
-        task = _run_with_error(
-            monkeypatch, ConnectionError("down"), max_retries=1
-        )
+        task = _run_with_error(monkeypatch, ConnectionError("down"), max_retries=1)
         assert task.is_terminal is True
 
     def test_non_retryable_error_stays_failed(self, monkeypatch, dlq_store, tmp_path):
-        task = _run_with_error(
-            monkeypatch, ValueError("config error"), max_retries=3
-        )
+        task = _run_with_error(monkeypatch, ValueError("config error"), max_retries=3)
         assert task.status == TaskStatus.FAILED
         assert dlq_store.get(task.id) is None
 
@@ -205,9 +199,7 @@ class TestDeadLetterRouting:
         assert dlq_store.get(task.id) is None
 
     def test_replay_creates_new_task(self, monkeypatch, dlq_store, tmp_path):
-        task = _run_with_error(
-            monkeypatch, ConnectionError("down"), max_retries=1
-        )
+        task = _run_with_error(monkeypatch, ConnectionError("down"), max_retries=1)
         assert task.status == TaskStatus.DEAD
 
         # Restore the success mock so the replayed task completes.
@@ -361,12 +353,8 @@ class TestNodeRegistry:
     """Node parsing and readiness probing."""
 
     def test_parse_comma_separated_nodes(self, monkeypatch):
-        monkeypatch.setattr(
-            NodeRegistry, "_probe", lambda self, url: True
-        )
-        reg = NodeRegistry(
-            nodes="http://a:1, http://b:2 ,", health_timeout=1.0
-        )
+        monkeypatch.setattr(NodeRegistry, "_probe", lambda self, url: True)
+        reg = NodeRegistry(nodes="http://a:1, http://b:2 ,", health_timeout=1.0)
         assert reg.configured_nodes == ["http://a:1", "http://b:2"]
         assert reg.available_nodes() == ["http://a:1", "http://b:2"]
 
@@ -376,9 +364,7 @@ class TestNodeRegistry:
             "_probe",
             lambda self, url: url == "http://ok:1",
         )
-        reg = NodeRegistry(
-            nodes="http://ok:1,http://bad:2", health_timeout=1.0
-        )
+        reg = NodeRegistry(nodes="http://ok:1,http://bad:2", health_timeout=1.0)
         assert reg.available_nodes() == ["http://ok:1"]
 
     def test_empty_nodes(self):

--- a/tests/test_v095_input_sanitization.py
+++ b/tests/test_v095_input_sanitization.py
@@ -127,10 +127,7 @@ class TestTaskRequestValidation:
             TaskRequest(movie_name="x", video_format="4:3")
 
     def test_subtitle_mode_bounded(self):
-        assert (
-            TaskRequest(movie_name="x", subtitle_mode="bilingual").subtitle_mode
-            == "bilingual"
-        )
+        assert TaskRequest(movie_name="x", subtitle_mode="bilingual").subtitle_mode == "bilingual"
         with pytest.raises(ValidationError):
             TaskRequest(movie_name="x", subtitle_mode="invalid")
 
@@ -169,9 +166,7 @@ class TestTaskRequestValidation:
     def test_batch_upper_bound(self):
         BatchRequest(requests=[TaskRequest(movie_name=f"m{i}") for i in range(50)])
         with pytest.raises(ValidationError):
-            BatchRequest(
-                requests=[TaskRequest(movie_name=f"m{i}") for i in range(51)]
-            )
+            BatchRequest(requests=[TaskRequest(movie_name=f"m{i}") for i in range(51)])
 
 
 # ════════════════════════════════════════════════════════════
@@ -185,61 +180,45 @@ class TestApiInputSanitization:
     def test_invalid_task_payload_returns_400(self, open_server):
         """POST /tasks with an invalid lang is rejected with 400."""
         data = json.dumps({"movie_name": "Bad", "lang": "xx"}).encode("utf-8")
-        assert _request_code(
-            f"{open_server.base_url}/tasks", method="POST", data=data
-        ) == 400
+        assert _request_code(f"{open_server.base_url}/tasks", method="POST", data=data) == 400
 
     def test_invalid_video_format_returns_400(self, open_server):
         data = json.dumps({"movie_name": "Bad", "video_format": "4:3"}).encode("utf-8")
-        assert _request_code(
-            f"{open_server.base_url}/tasks", method="POST", data=data
-        ) == 400
+        assert _request_code(f"{open_server.base_url}/tasks", method="POST", data=data) == 400
 
     def test_empty_movie_name_returns_400(self, open_server):
         data = json.dumps({"movie_name": "   "}).encode("utf-8")
-        assert _request_code(
-            f"{open_server.base_url}/tasks", method="POST", data=data
-        ) == 400
+        assert _request_code(f"{open_server.base_url}/tasks", method="POST", data=data) == 400
 
     def test_valid_task_returns_201(self, open_server):
         data = json.dumps({"movie_name": "Good", "max_retries": 0}).encode("utf-8")
-        assert _request_code(
-            f"{open_server.base_url}/tasks", method="POST", data=data
-        ) == 201
+        assert _request_code(f"{open_server.base_url}/tasks", method="POST", data=data) == 201
 
     def test_oversized_body_returns_413(self, open_server):
         """POST /tasks body larger than _MAX_BODY_BYTES → 413 (not 400)."""
         big = json.dumps({"movie_name": "Big", "params": {"pad": "x" * (2 * 1024 * 1024)}})
         assert len(big.encode("utf-8")) > 1024 * 1024
-        assert _request_code(
-            f"{open_server.base_url}/tasks", method="POST", data=big.encode("utf-8")
-        ) == 413
+        assert (
+            _request_code(f"{open_server.base_url}/tasks", method="POST", data=big.encode("utf-8"))
+            == 413
+        )
 
     def test_oversized_batch_body_returns_413(self, open_server):
         big = json.dumps(
-            {
-                "requests": [
-                    {"movie_name": "m", "params": {"pad": "x" * (2 * 1024 * 1024)}}
-                ]
-            }
+            {"requests": [{"movie_name": "m", "params": {"pad": "x" * (2 * 1024 * 1024)}}]}
         )
-        assert _request_code(
-            f"{open_server.base_url}/tasks/batch", method="POST", data=big.encode("utf-8")
-        ) == 413
+        assert (
+            _request_code(
+                f"{open_server.base_url}/tasks/batch", method="POST", data=big.encode("utf-8")
+            )
+            == 413
+        )
 
     def test_invalid_limit_returns_400(self, open_server):
-        assert _request_code(
-            f"{open_server.base_url}/tasks?limit=abc"
-        ) == 400
-        assert _request_code(
-            f"{open_server.base_url}/tasks?limit=-5"
-        ) == 400
+        assert _request_code(f"{open_server.base_url}/tasks?limit=abc") == 400
+        assert _request_code(f"{open_server.base_url}/tasks?limit=-5") == 400
 
     def test_limit_clamped(self, open_server):
         """A large limit is clamped to _MAX_LIST_LIMIT instead of erroring."""
-        assert _request_code(
-            f"{open_server.base_url}/tasks?limit=99999"
-        ) == 200
-        assert _request_code(
-            f"{open_server.base_url}/batches?limit=99999"
-        ) == 200
+        assert _request_code(f"{open_server.base_url}/tasks?limit=99999") == 200
+        assert _request_code(f"{open_server.base_url}/batches?limit=99999") == 200

--- a/tests/test_v096_i18n_pipeline.py
+++ b/tests/test_v096_i18n_pipeline.py
@@ -20,7 +20,10 @@ import json
 from unittest.mock import MagicMock, patch
 
 from movie_narrator.models import (
-    Context, Scene, Services, TimedSegment,
+    Context,
+    Scene,
+    Services,
+    TimedSegment,
 )
 from movie_narrator.pipeline.script import generate_script
 from movie_narrator.pipeline.translate import translate_subtitles
@@ -75,8 +78,8 @@ def _mock_settings(**overrides):
 
 
 def _beats_json(n: int) -> str:
-    beats = [f"剧情关键点{i+1}" for i in range(n)]
-    return '{"beats": ' + str(beats).replace("'", '"') + '}'
+    beats = [f"剧情关键点{i + 1}" for i in range(n)]
+    return '{"beats": ' + str(beats).replace("'", '"') + "}"
 
 
 def _segments_json(texts: list) -> str:
@@ -125,7 +128,9 @@ def test_script_lang_defaults_to_zh(tmp_path):
             result = generate_script(ctx)
 
     mock_llm = mock_cm.__enter__.return_value
-    phase1_prompt = mock_llm.client.chat.completions.create.call_args_list[0].kwargs["messages"][0]["content"]
+    phase1_prompt = mock_llm.client.chat.completions.create.call_args_list[0].kwargs["messages"][0][
+        "content"
+    ]
     assert "Write ALL narration text" not in phase1_prompt
     assert result.metadata["narration_lang"] == "zh"
     assert result.metadata["script_lang"] == "zh"
@@ -136,8 +141,11 @@ def test_script_lang_defaults_to_zh(tmp_path):
 
 def test_select_script_prompt_is_language_aware():
     from movie_narrator.utils.prompts import (
-        SCRIPT_PROMPT, SCRIPT_PROMPT_ZH, select_script_prompt,
+        SCRIPT_PROMPT,
+        SCRIPT_PROMPT_ZH,
+        select_script_prompt,
     )
+
     assert select_script_prompt("zh") == SCRIPT_PROMPT_ZH
     assert select_script_prompt("en") == SCRIPT_PROMPT
     assert select_script_prompt("") == SCRIPT_PROMPT  # backward-compatible
@@ -158,6 +166,7 @@ def test_translate_records_i18n_metadata(tmp_path, monkeypatch):
     ctx.metadata.update(subtitle_lang="en", lang="zh")
 
     from movie_narrator.pipeline import translate as t_mod
+
     monkeypatch.setattr(t_mod, "_call_llm_chunk", lambda **kw: ["hello", "world"])
 
     translate_subtitles(ctx)

--- a/tests/test_v096_voice_map.py
+++ b/tests/test_v096_voice_map.py
@@ -66,10 +66,7 @@ def test_explicit_voice_overrides_default_map():
 
 def test_explicit_voice_overrides_config_override():
     settings = Settings(voice_zh="zh-CN-QingyangNeural")
-    assert (
-        resolve_voice("zh", "edge", explicit_voice="custom", settings=settings)
-        == "custom"
-    )
+    assert resolve_voice("zh", "edge", explicit_voice="custom", settings=settings) == "custom"
 
 
 # ── Config override ────────────────────────────────────────

--- a/tests/test_video_layout.py
+++ b/tests/test_video_layout.py
@@ -17,8 +17,8 @@ def test_cover_wide_source_crops_width():
     """Source wider than canvas → crop width, keep full height."""
     # 1920x1080 source onto 1080x1080 canvas (square).
     box = compute_fit_box((1920, 1080), (1080, 1080), mode="cover")
-    assert box.crop_h == 1080          # full height retained
-    assert box.crop_w == 1080          # width cropped to match canvas aspect
+    assert box.crop_h == 1080  # full height retained
+    assert box.crop_w == 1080  # width cropped to match canvas aspect
     assert box.crop_x == (1920 - 1080) // 2  # center-cropped
     assert box.out_w == 1080 and box.out_h == 1080
 
@@ -27,8 +27,8 @@ def test_cover_tall_source_crops_height():
     """Source taller than canvas → crop height, keep full width."""
     # 1080x1920 source onto 1080x1080 canvas.
     box = compute_fit_box((1080, 1920), (1080, 1080), mode="cover")
-    assert box.crop_w == 1080          # full width retained
-    assert box.crop_h == 1080          # height cropped
+    assert box.crop_w == 1080  # full width retained
+    assert box.crop_h == 1080  # height cropped
     assert box.crop_y == (1920 - 1080) // 2
     assert box.out_w == 1080 and box.out_h == 1080
 

--- a/tests/test_workflow_merge.py
+++ b/tests/test_workflow_merge.py
@@ -76,7 +76,8 @@ def test_bool_sentinel_keep_cache_false_does_not_override_yaml_true():
 def test_bool_sentinel_cli_true_wins():
     job = JobConfig(movie="M", keep_cache=False, no_clips=False)
     r = merge_job(
-        _cli(keep_cache=True, no_clips=True, config_path="job.yaml"), job,
+        _cli(keep_cache=True, no_clips=True, config_path="job.yaml"),
+        job,
         Settings(),
     )
     assert r.keep_cache is True

--- a/tests/test_workflow_steps.py
+++ b/tests/test_workflow_steps.py
@@ -202,8 +202,7 @@ def _assert_step_skipped_by_runner(ctx: Context, step_name: str, status_field: s
 
     # Replicate runner's skip condition
     should_skip = bool(workflow_steps) and (
-        not workflow_steps.get(step_name, True)
-        or (alias and not workflow_steps.get(alias, True))
+        not workflow_steps.get(step_name, True) or (alias and not workflow_steps.get(alias, True))
     )
 
     assert should_skip, f"Runner should skip {step_name} but skip condition not met"

--- a/tests/test_wp6_scene_filter.py
+++ b/tests/test_wp6_scene_filter.py
@@ -104,7 +104,9 @@ class TestFilterDarkScenes:
         """When PIL is not available, skip filtering."""
         scenes = _scenes()
         with (
-            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch(
+                "movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"
+            ),
             patch.dict(sys.modules, {"PIL": None, "PIL.Image": None}),
         ):
             result, dropped = filter_dark_scenes(scenes, "video.mp4", 20.0)
@@ -142,10 +144,10 @@ class TestFilterDarkScenes:
                 return [self._luma] * (64 * 64)
 
         luma_map = {
-            5.0: 5.0,    # scene 0 mid → dark
+            5.0: 5.0,  # scene 0 mid → dark
             15.0: 50.0,  # scene 1 mid → bright
             25.0: 80.0,  # scene 2 mid → bright
-            35.0: 3.0,   # scene 3 mid → dark
+            35.0: 3.0,  # scene 3 mid → dark
             45.0: 60.0,  # scene 4 mid → bright
             55.0: 70.0,  # scene 5 mid → bright
             65.0: 40.0,  # scene 6 mid → bright
@@ -164,12 +166,18 @@ class TestFilterDarkScenes:
         fake_pil.Image.__name__ = "Image"
 
         with (
-            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
-            patch("movie_narrator.pipeline.scene_filter._extract_mid_frame", side_effect=fake_extract),
+            patch(
+                "movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"
+            ),
+            patch(
+                "movie_narrator.pipeline.scene_filter._extract_mid_frame", side_effect=fake_extract
+            ),
             patch.dict(sys.modules, {"PIL": fake_pil, "PIL.Image": fake_pil.Image}),
         ):
             result, dropped = filter_dark_scenes(
-                scenes, str(video_path), 20.0,
+                scenes,
+                str(video_path),
+                20.0,
                 cache_dir=tmp_path / "cache",
             )
 
@@ -185,11 +193,15 @@ class TestFilterDarkScenes:
         video_path.write_bytes(b"fake_video")
 
         with (
-            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch(
+                "movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"
+            ),
             patch("movie_narrator.pipeline.scene_filter._extract_mid_frame", return_value=False),
         ):
             result, dropped = filter_dark_scenes(
-                scenes, str(video_path), 20.0,
+                scenes,
+                str(video_path),
+                20.0,
                 cache_dir=tmp_path / "cache",
             )
 
@@ -203,12 +215,16 @@ class TestFilterDarkScenes:
         video_path.write_bytes(b"fake_video")
 
         with (
-            patch("movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch(
+                "movie_narrator.pipeline.scene_filter.shutil.which", return_value="/usr/bin/ffmpeg"
+            ),
             patch("movie_narrator.pipeline.scene_filter._extract_mid_frame", return_value=True),
             patch("movie_narrator.pipeline.scene_filter._compute_mean_luma", return_value=5.0),
         ):
             result, dropped = filter_dark_scenes(
-                scenes, str(video_path), 20.0,
+                scenes,
+                str(video_path),
+                20.0,
                 cache_dir=tmp_path / "cache",
             )
 
@@ -331,6 +347,7 @@ class TestMatchWP6Integration:
         # Mock embedding to unavailable so we test heuristic path
         with patch("movie_narrator.pipeline.match.probe", return_value=(False, "no st")):
             from movie_narrator.pipeline.match import match_clips
+
             match_clips(ctx)
 
         assert ctx.status.match == "success"
@@ -346,6 +363,7 @@ class TestMatchWP6Integration:
 
         with patch("movie_narrator.pipeline.match.probe", return_value=(False, "no st")):
             from movie_narrator.pipeline.match import match_clips
+
             match_clips(ctx)
 
         assert ctx.status.match == "success"
@@ -353,7 +371,7 @@ class TestMatchWP6Integration:
         # All matched clips should be within 12-68s range (window of 0-80 span)
         for mc in ctx.matched_clips:
             assert mc.src_start >= 10.0  # first kept scene starts at 10 (clipped to 12)
-            assert mc.src_end <= 70.0    # last kept scene ends at 70 (clipped to 68)
+            assert mc.src_end <= 70.0  # last kept scene ends at 70 (clipped to 68)
 
     def test_no_wp6_params_no_change(self, tmp_path):
         """Without scene filter params, behavior is unchanged."""
@@ -362,6 +380,7 @@ class TestMatchWP6Integration:
 
         with patch("movie_narrator.pipeline.match.probe", return_value=(False, "no st")):
             from movie_narrator.pipeline.match import match_clips
+
             match_clips(ctx)
 
         assert ctx.status.match == "success"


### PR DESCRIPTION
Apply \uff format\ across the codebase (150 files: 80 src + 70 tests).

- Pure formatting changes per pyproject.toml (line-length 100)
- No logic changes; ruff check, mypy, and full test suite (2095 passed) verified locally
- Isolated from v1.0 docstring/stability changes as planned